### PR TITLE
Change ports used by odl-video-service docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,6 @@ USER mitodl
 # Set pip cache folder, as it is breaking pip when it is on a shared volume
 ENV XDG_CACHE_HOME /tmp/.cache
 
-EXPOSE 8079
-ENV PORT 8079
+EXPOSE 8089
+ENV PORT 8089
 CMD uwsgi uwsgi.ini

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,12 +1,12 @@
 # This is the version used in development environments
 server {
-    listen 8079;
+    listen 8089;
     server_name odlvideoservice.herokuapp.com;
     return 301 https://techtv.mit.edu$request_uri;
 }
 
 server {
-    listen 8079 default_server;
+    listen 8089 default_server;
     root /src;
 
     location = /robots.txt {
@@ -19,7 +19,7 @@ server {
 
     location / {
         include uwsgi_params;
-        uwsgi_pass web:8077;
+        uwsgi_pass web:8087;
         uwsgi_pass_request_headers on;
         uwsgi_pass_request_body on;
         client_max_body_size 25M;

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -18,7 +18,7 @@ services:
     environment:
       DEBUG: 'False'
       COVERAGE_DIR: htmlcov
-      PORT: 8079
+      PORT: 8089
       NODE_ENV: 'production'
       DATABASE_URL: postgres://postgres@db:5432/postgres
       BOOTCAMP_SECURE_SSL_REDIRECT: 'False'
@@ -35,9 +35,9 @@ services:
       /bin/bash -c '
       sleep 3 &&
       python3 manage.py migrate &&
-      ./with_host.sh python3 manage.py runserver 0.0.0.0:8079'
+      ./with_host.sh python3 manage.py runserver 0.0.0.0:8089'
     ports:
-      - "8079:8079"
+      - "8089:8089"
     links:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./config/nginx.conf:/etc/nginx/conf.d/web.conf
       - ./:/src
     ports:
-      - "8079:8079"
+      - "8089:8089"
     links:
       - web
 
@@ -38,14 +38,14 @@ services:
       python3 manage.py migrate &&
       uwsgi uwsgi.ini'
     ports:
-      - "8077:8077"
+      - "8087:8087"
     links:
       - db
       - redis
     env_file: .env
     environment:
       DEV_ENV: 'True'
-      PORT: 8077
+      PORT: 8087
       DATABASE_URL: postgres://postgres@db:5432/postgres
       REDIS_URL: redis://redis:6379/0
       COVERAGE_DIR: htmlcov


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/odl-video-service/issues/29

#### What's this PR do?
Changes the ports used by the nginx and web containers from 8077-8079 to 8087-8089.

#### How should this be manually tested?
```
docker-compose build
docker-compose up
```
The website should be available on port 8089 instead of 8079.

```docker ps``` should not show any odl-video-service containers using ports 8077-8079.
