### PR TITLE
Add 'ODL_VIDEO_DB_DISABLE_SSL' to celery in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,9 @@ services:
       - redis
     env_file: .env
     environment:
+      DEV_ENV: 'True'
+      ODL_VIDEO_SECURE_SSL_REDIRECT: 'False'
+      ODL_VIDEO_DB_DISABLE_SSL: 'True'
       DATABASE_URL: postgres://postgres@db:5432/postgres
       REDIS_URL: redis://redis:6379/0
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/odl-video-service/issues/36

#### What's this PR do?
Adds 'ODL_VIDEO_DB_DISABLE_SSL' to the celery configuration in docker-compose.yml

#### How should this be manually tested?
- Make sure 'ODL_VIDEO_DB_DISABLE_SSL' is not in your .env file
- ```docker-compose build```
- ```docker-compose run celery python manage.py shell```
- ```import os; os.environ.get('ODL_VIDEO_DB_DISABLE_SSL')```
