### PR TITLE
Stop using uploaded filenames for S3 keys, just use UUID instead.

### DIFF
--- a/ui/models.py
+++ b/ui/models.py
@@ -67,9 +67,9 @@ class Video(models.Model):
         Returns:
             str: A unique S3 key including the user id as a virtual subfolder
         """
-        basename, extension = os.path.splitext(self.source_url.split('/')[-1])
-        newkey = '{user}/{uuid}/{base}{ext}'.format(
-            user=self.creator.id, uuid=str(self.s3_subkey), base=basename, ext=extension)
+        _, extension = os.path.splitext(self.source_url.split('/')[-1])
+        newkey = '{user}/{uuid}/video{ext}'.format(
+            user=self.creator.id, uuid=str(self.s3_subkey), ext=extension)
         return newkey
 
     def transcode_key(self, preset=None):

--- a/ui/models_test.py
+++ b/ui/models_test.py
@@ -43,7 +43,7 @@ def test_video_model_s3keys(user):
     assert isinstance(new_video.s3_subkey, uuid.UUID)
     s3key = new_video.s3_key()
     assert s3key is not None
-    assert s3key == '{}/{}/fake.mp4'.format(user.id, new_video.s3_subkey)
+    assert s3key == '{user}/{uuid}/video.mp4'.format(user=user.id, uuid=new_video.s3_subkey)
 
 
 def test_video_aws_integration(videofile):
@@ -83,5 +83,5 @@ def test_video_transcode_key(user, video, videofile):  # pylint: disable=unused-
     Test that the Video.transcode_key method returns expected results
     """
     preset = 'pre01'
-    assert video.transcode_key(preset) == 'transcoded/{}/{}/BigBuckBunny_pre01'.format(
-        user.id, str(video.s3_subkey))
+    assert video.transcode_key(preset) == 'transcoded/{user}/{uuid}/video_{preset}'.format(
+        user=user.id, uuid=str(video.s3_subkey), preset=preset)

--- a/ui/templates/ui/upload.html
+++ b/ui/templates/ui/upload.html
@@ -51,7 +51,7 @@ to TechTV.</p>
       let videoId;
       for (videoId in videos) {
         let video = videos[videoId];
-        let videoFile = video.key.split("/")[2];
+        let videoFile = video.title;
         let progress = document.createElement("progress");
         progress.id = video.task;
         progress.max = 100;

--- a/ui/views.py
+++ b/ui/views.py
@@ -136,6 +136,7 @@ class UploadVideosFromDropbox(APIView):
 
             response_data[video.id] = {
                 "key": video.s3_key(),
+                "title": video.title,
                 "task": task_result.id,
             }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/odl-video-service/issues/38

#### What's this PR do?
Creates an S3 key for a video file as {user.id}/{uuid}/{uuid}.{extension} instead of  {user.id}/{uuid}/{base-filename}.{extension}

#### How should this be manually tested?
Upload a video and then check the S3 key link.  It should contain a UUID (2x) but not the filename.
