### PR TITLE
Added URLs for server status

### DIFF
--- a/odl_video/urls.py
+++ b/odl_video/urls.py
@@ -18,6 +18,7 @@ from django.contrib import admin
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+    url(r'^status/', include('server_status.urls')),
     url(r'^', include('ui.urls')),
     url(r'^', include('django.contrib.auth.urls')),
     url(r'^', include('cloudsync.urls')),


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
The url for server status had not been exposed

#### How should this be manually tested?
put 
```
STATUS_TOKEN=statustoken
```
in your `.env` and then visit 
`http://<address to your web>:8089/status/?token=statustoken`

You should see a JSON response