### PR TITLE
 Improved error handling, especially for celery tasks

### DIFF
--- a/cloudsync/conftest.py
+++ b/cloudsync/conftest.py
@@ -1,9 +1,6 @@
 """
 conftest for pytest in this module
 """
-import io
-import os
-
 import pytest
 import requests_mock
 import botocore.session
@@ -18,12 +15,6 @@ def reqmocker():
 
 
 @pytest.fixture
-def mock_video_url():
-    """Mocks video url"""
-    return "http://example.com/video.mp4"
-
-
-@pytest.fixture
 def mock_video_headers():
     """mocks video headers"""
     disp = "inline; filename=video.mp4; filename*=UTF-8''video.mp4"
@@ -32,13 +23,6 @@ def mock_video_headers():
         "Content-Length": "6250000",
         "Content-Disposition": disp,
     }
-
-
-@pytest.fixture
-def mock_video_file():
-    """Mocks video file"""
-    # 50 MB of random noise
-    return io.BytesIO(os.urandom(6250000))
 
 
 @pytest.fixture
@@ -76,17 +60,23 @@ class MockClientET:
     """
     job = None
     preset = None
+    error = None
 
     def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
         """Mock __init__"""
-        pass
+        if 'error' in kwargs:
+            self.error = kwargs['error']
 
     def read_job(self, **kwargs):  # pylint: disable=unused-argument
         """Mock read_job method"""
+        if self.error:
+            raise self.error
         return self.job
 
     def read_preset(self, *args, **kwargs):  # pylint: disable=unused-argument
         """Mock read_preset method"""
+        if self.error:
+            raise self.error
         return self.preset
 
 

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -8,12 +8,16 @@ from urllib.parse import unquote
 import requests
 import boto3
 from boto3.s3.transfer import TransferConfig
-from celery import shared_task
+from botocore.exceptions import ClientError
+from celery import shared_task, states, Task
 from celery.utils.log import get_task_logger
+from dj_elastictranscoder.models import EncodeJob
 from django.conf import settings
-from dj_elastictranscoder.transcoder import Transcoder
 
-from ui.models import VideoFile
+from cloudsync.utils import VideoTranscoder
+from ui.api import refresh_status
+from ui.models import VideoFile, Video
+from ui.constants import VideoStatus
 
 log = get_task_logger(__name__)
 CONTENT_DISPOSITION_RE = re.compile(
@@ -23,46 +27,91 @@ CONTENT_DISPOSITION_RE = re.compile(
 THUMBNAIL_PATTERN = "thumbnails/{}_thumbnail_{{count}}"
 
 
-@shared_task(bind=True)
-def stream_to_s3(self, url, s3_key):
+class VideoTask(Task):
+    """
+    Custom Celery Task class for video uploads and transcodes
+    """
+
+    def get_task_id(self):
+        """
+        Get the task id (depending on whether the task is chained or not)
+
+        Args:
+            request(Task.request): The task request
+
+        Returns:
+            The request id
+        """
+        if self.request.chain:
+            try:
+                return self.request.chain[0]['options']['task_id']
+            except (IndexError, KeyError,) as exc:
+                # Log the error and continue, using self.request.id instead
+                # The worst that will happen is that progress bar won't work.
+                log.error("Could not find task_id in chain: %s", str(exc))
+                return
+        return self.request.id
+
+
+@shared_task(bind=True, base=VideoTask)
+def stream_to_s3(self, video_id):
     """
     Stream the contents of the given URL to Amazon S3
     """
-    if not url:
+
+    if not video_id:
         return False
-    response = requests.get(url, stream=True)
-    response.raise_for_status()
+    try:
+        video = Video.objects.get(id=video_id)
+    except (Video.DoesNotExist, Video.MultipleObjectsReturned):
+        log.error("Exception retrieving video with id %d", video_id)
+        raise
+    video.update_status(VideoStatus.UPLOADING)
+
+    task_id = self.get_task_id()
+    try:
+        response = requests.get(video.source_url, stream=True, timeout=60)
+        response.raise_for_status()
+    except Exception:
+        video.update_status(VideoStatus.UPLOAD_FAILED)
+        self.update_state(task_id=task_id, state=states.FAILURE)
+        raise
+
     _, content_type, content_length = parse_content_metadata(response)
 
     s3 = boto3.resource('s3')
     bucket_name = settings.VIDEO_S3_BUCKET
     bucket = s3.Bucket(bucket_name)
-
-    # Need to bind this here, because otherwise it gets lost in the callback somehow
-    task_id = self.request.id
+    total_bytes_uploaded = 0
 
     def callback(bytes_uploaded):
         """
         Callback function after upload
         """
+        nonlocal total_bytes_uploaded
+        total_bytes_uploaded += bytes_uploaded
         data = {
-            "uploaded": bytes_uploaded,
+            "uploaded": total_bytes_uploaded,
             "total": content_length,
         }
         self.update_state(task_id=task_id, state="PROGRESS", meta=data)
 
     config = TransferConfig(**settings.AWS_S3_UPLOAD_TRANSFER_CONFIG)
+    try:
+        bucket.upload_fileobj(
+            Fileobj=response.raw,
+            Key=video.get_s3_key(),
+            ExtraArgs={"ContentType": content_type},
+            Callback=callback,
+            Config=config
+        )
+    except Exception:
+        video.update_status(VideoStatus.UPLOAD_FAILED)
+        self.update_state(task_id=task_id, state=states.FAILURE)
+        raise
 
-    bucket.upload_fileobj(
-        Fileobj=response.raw,
-        Key=s3_key,
-        ExtraArgs={"ContentType": content_type},
-        Callback=callback,
-        Config=config
-    )
 
-
-@shared_task(bind=True)
+@shared_task(bind=True, base=VideoTask)
 def transcode_from_s3(self, video_id):  # pylint: disable=unused-argument
     """
     Given an S3 object key, transcode that object using a video pipeline, overwrite the original when done.
@@ -70,11 +119,11 @@ def transcode_from_s3(self, video_id):  # pylint: disable=unused-argument
     Args:
         video_id(int): The video primary key
     """
-    if not settings.ET_PRESET_IDS:
-        raise ValueError("At least one transcode preset required in settings")
+    video = Video.objects.get(id=video_id)
+    task_id = self.get_task_id()
+    self.update_state(task_id=task_id, state=VideoStatus.TRANSCODING)
 
     video_file = VideoFile.objects.get(video__id=video_id, encoding='original')
-    video = video_file.video
 
     video_input = {
         'Key': video_file.s3_object_key,
@@ -95,14 +144,44 @@ def transcode_from_s3(self, video_id):  # pylint: disable=unused-argument
 
     # Generate thumbnails for the 1st encoding (no point in doing so for each).
     outputs[0]['ThumbnailPattern'] = THUMBNAIL_PATTERN.format(video_file.s3_basename)
-    transcoder = Transcoder(
+    transcoder = VideoTranscoder(
         settings.ET_PIPELINE_ID,
         settings.AWS_REGION,
         settings.AWS_ACCESS_KEY_ID,
         settings.AWS_SECRET_ACCESS_KEY
     )
-    transcoder.encode(video_input, outputs, Playlists=playlists)
-    transcoder.create_job_for_object(video)
+    try:
+        transcoder.encode(video_input, outputs, Playlists=playlists)
+    except ClientError as exc:
+        log.error('Transcode job creation failed for video %s', video_id)
+        video.update_status(VideoStatus.TRANSCODE_FAILED)
+        self.update_state(task_id=task_id, state=states.FAILURE)
+        if hasattr(exc, 'response'):
+            transcoder.message = exc.response
+        raise
+    finally:
+        transcoder.create_job_for_object(video)
+        if video.status != VideoStatus.TRANSCODE_FAILED:
+            video.update_status(VideoStatus.TRANSCODING)
+
+
+@shared_task(bind=True)
+def update_video_statuses(self):  # pylint: disable=unused-argument
+    """
+    Check on statuses of all transcoding videos and update their status if appropriate
+    """
+    transcoding_videos = Video.objects.filter(status=VideoStatus.TRANSCODING)
+    for video in transcoding_videos:
+        try:
+            refresh_status(video)
+        except EncodeJob.DoesNotExist:
+            # Log the exception but don't raise it so other videos can be checked.
+            log.exception("No EncodeJob object exists for video id %d", video.id)
+            video.update_status(VideoStatus.TRANSCODE_FAILED)
+        except ClientError as exc:
+            # Log the exception but don't raise it so other videos can be checked.
+            log.exception("AWS error when refreshing job status for video %d: %s", video.id, exc.response)
+            video.update_status(VideoStatus.TRANSCODE_FAILED)
 
 
 def parse_content_metadata(response):

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -1,37 +1,48 @@
 """
 Tests for tasks
 """
+import io
+import os
+
 import pytest
-from cloudsync.conftest import MockClientET, MockBoto
-from cloudsync.tasks import stream_to_s3, transcode_from_s3, Transcoder
+from botocore.exceptions import ClientError
+import celery
+from dj_elastictranscoder.models import EncodeJob
+from mock import PropertyMock
+
+from cloudsync.conftest import MockBoto
+from cloudsync.tasks import stream_to_s3, transcode_from_s3, VideoTask, update_video_statuses
 from ui.conftest import user, video, videofile  # pylint: disable=unused-import
+from ui.models import Video
+from ui.constants import VideoStatus
 
 
-def test_empty_url():
+def test_empty_video_id():
     """
-    Tests that an empty URL does not give a result
+    Tests that an empty video id does not give a result
     """
-    result = stream_to_s3("", "no_url")  # pylint: disable=no-value-for-parameter
+    result = stream_to_s3("")  # pylint: disable=no-value-for-parameter
     assert not result
 
 
 @pytest.mark.django_db
-def test_happy_path(mocker, reqmocker, mock_video_url, mock_video_headers, mock_video_file):
+def test_happy_path(mocker, reqmocker, mock_video_headers, video):  # pylint: disable=redefined-outer-name
     """
     Test that a file can be uploaded to a mocked S3 bucket.
     """
+    mock_video_file = io.BytesIO(os.urandom(6250000))
     reqmocker.get(
-        mock_video_url,
+        video.source_url,
         headers=mock_video_headers,
         body=mock_video_file,
     )
     mock_boto3 = mocker.patch('cloudsync.tasks.boto3')
     mock_bucket = mock_boto3.resource.return_value.Bucket.return_value
-    stream_to_s3(mock_video_url, 'video.mp4')  # pylint: disable=no-value-for-parameter
+    stream_to_s3(video.id)  # pylint: disable=no-value-for-parameter
 
     mock_bucket.upload_fileobj.assert_called_with(
         Fileobj=mocker.ANY,
-        Key="video.mp4",
+        Key=video.get_s3_key(),
         ExtraArgs={"ContentType": "video/mp4"},
         Callback=mocker.ANY,
         Config=mocker.ANY
@@ -42,20 +53,150 @@ def test_happy_path(mocker, reqmocker, mock_video_url, mock_video_headers, mock_
     mock_video_file.seek(0)
     expected = fileobj.read(50)
     assert actual == expected
+    assert Video.objects.get(id=video.id).status == VideoStatus.UPLOADING
 
 
-def test_transcode(mocker, user, video, videofile):  # pylint: disable=unused-argument,redefined-outer-name
+def test_upload_failure(mocker, reqmocker, mock_video_headers, video):  # pylint: disable=redefined-outer-name
+    """
+    Test that video status is updated properly after an upload failure
+    """
+    mock_video_file = io.BytesIO(os.urandom(6250000))
+    reqmocker.get(
+        video.source_url,
+        headers=mock_video_headers,
+        body=mock_video_file,
+    )
+    mocker.patch('cloudsync.tasks.boto3')
+    mocker.patch('cloudsync.tasks.requests.models.Response.raise_for_status', side_effect=Exception())
+    with pytest.raises(Exception):
+        stream_to_s3(video.id)  # pylint: disable=no-value-for-parameter
+    assert Video.objects.get(id=video.id).status == VideoStatus.UPLOAD_FAILED
+
+
+def test_transcode_failure(mocker, user, video, videofile):  # pylint: disable=unused-argument,redefined-outer-name
     """
     Test transcode task, verify there is an EncodeJob associated with the video to encode
+    """
+    job_result = {'Job': {'Id': '1498220566931-qtmtcu', 'Status': 'Error'}, 'Error': {'Code': 200, 'Message': 'FAIL'}}
+    mocker.patch.multiple('cloudsync.tasks.settings',
+                          ET_PRESET_IDS=('1351620000001-000061', '1351620000001-000040', '1351620000001-000020'),
+                          AWS_REGION='us-east-1', ET_PIPELINE_ID='foo')
+    mocker.patch('cloudsync.tasks.VideoTranscoder.encode',
+                 side_effect=ClientError(error_response=job_result, operation_name='ReadJob'))
+    mocker.patch('dj_elastictranscoder.transcoder.Session')
+    mocker.patch('celery.app.task.Task.update_state')
+    mocker.patch('ui.utils.boto3', MockBoto)
+    mocker.patch('ui.api.get_et_job',
+                 return_value=job_result['Job'])
+    # Transcode the video
+    with pytest.raises(ClientError):
+        transcode_from_s3(video.id)  # pylint: disable=no-value-for-parameter
+    assert len(video.encode_jobs.all()) == 1
+    assert Video.objects.get(id=video.id).status == VideoStatus.TRANSCODE_FAILED
+
+
+def test_transcode_starting(mocker, user, video, videofile):  # pylint: disable=unused-argument,redefined-outer-name
+    """
+    Test that video status is updated properly after a transcode failure
     """
     mocker.patch.multiple('cloudsync.tasks.settings',
                           ET_PRESET_IDS=('1351620000001-000061', '1351620000001-000040', '1351620000001-000020'),
                           AWS_REGION='us-east-1', ET_PIPELINE_ID='foo')
-    mocker.patch('cloudsync.tasks.Transcoder.encode')
-    mocker.patch.object(Transcoder, 'message', {'Job': {'Id': 'foo'}}, create=True)
-    MockClientET.preset = {'Preset': {'Thumbnails': {'MaxHeight': 190, 'MaxWidth': 100}, 'Container': 'mp4'}}
+    mocker.patch('cloudsync.tasks.VideoTranscoder.encode')
+    mocker.patch('dj_elastictranscoder.transcoder.Session')
+    mocker.patch('celery.app.task.Task.update_state')
+    mocker.patch('ui.api.process_transcode_results')
     mocker.patch('ui.utils.boto3', MockBoto)
-
-    # Transcode the video
+    mocker.patch('ui.api.get_et_job',
+                 return_value={'Id': '1498220566931-qtmtcu', 'Status': 'Complete'})
     transcode_from_s3(video.id)  # pylint: disable=no-value-for-parameter
     assert len(video.encode_jobs.all()) == 1
+    assert Video.objects.get(id=video.id).status == VideoStatus.TRANSCODING
+
+
+def test_video_task_chain(mocker):
+    """
+    Test that video task get_task_id method returns the correct id from the chain.
+    """
+    def ctx():
+        """ Return a mock context object """
+        return celery.app.task.Context({
+            'lang': 'py',
+            'task': 'cloudsync.tasks.stream_to_s3',
+            'id': '1853b857-84d8-4af4-8b19-1c307c1e07d5',
+            'chain': [{
+                'task': 'cloudsync.tasks.transcode_from_s3',
+                'args': [351],
+                'kwargs': {},
+                'options': {
+                    'task_id': '1a859e5a-8f71-4e01-9349-5ebc6dc66631'
+                }
+            }]
+        })
+    mocker.patch('cloudsync.tasks.VideoTask.request', new_callable=PropertyMock, return_value=ctx())
+    task = VideoTask()
+    assert task.get_task_id() == task.request.chain[0]['options']['task_id']
+
+
+def test_video_task_bad_chain(mocker):
+    """
+    Test that video task get_task_id method returns the task.id if the chain is not valid.
+    """
+    def ctx():
+        """ Return a mock context object """
+        return celery.app.task.Context({
+            'lang': 'py',
+            'task': 'cloudsync.tasks.stream_to_s3',
+            'id': '1853b857-84d8-4af4-8b19-1c307c1e07d5',
+            'chain': [{
+                'task': 'cloudsync.tasks.transcode_from_s3',
+                'args': [351],
+                'kwargs': {},
+                'options': {}
+            }]
+        })
+    mocker.patch('cloudsync.tasks.VideoTask.request', new_callable=PropertyMock, return_value=ctx())
+    task = VideoTask()
+    assert task.get_task_id() is None
+
+
+def test_video_task_no_chain(mocker):
+    """
+    Test that video task get_task_id method returns the task.id if the chain is not present.
+    """
+    def ctx():
+        """ Return a mock context object """
+        return celery.app.task.Context({
+            'lang': 'py',
+            'task': 'cloudsync.tasks.stream_to_s3',
+            'id': '1853b857-84d8-4af4-8b19-1c307c1e07d5',
+        })
+    mocker.patch('cloudsync.tasks.VideoTask.request', new_callable=PropertyMock, return_value=ctx())
+    task = VideoTask()
+    assert task.get_task_id() == task.request.id
+
+
+def test_update_video_statuses_nojob(mocker, video):  # pylint: disable=unused-argument,redefined-outer-name
+    """Test NoEncodeJob error handling"""
+    mocker.patch('cloudsync.tasks.refresh_status',
+                 side_effect=EncodeJob.DoesNotExist())
+    video.update_status(VideoStatus.TRANSCODING)
+    update_video_statuses()  # pylint: disable=no-value-for-parameter
+    assert VideoStatus.TRANSCODE_FAILED == Video.objects.get(id=video.id).status
+
+
+def test_update_video_statuses_clienterror(mocker, video):  # pylint: disable=unused-argument,redefined-outer-name
+    """Test NoEncodeJob error handling"""
+    job_result = {'Job': {'Id': '1498220566931-qtmtcu', 'Status': 'Error'}, 'Error': {'Code': 200, 'Message': 'FAIL'}}
+    mocker.patch('cloudsync.tasks.refresh_status',
+                 side_effect=ClientError(error_response=job_result, operation_name='ReadJob'))
+    video.update_status(VideoStatus.TRANSCODING)
+    update_video_statuses()  # pylint: disable=no-value-for-parameter
+    assert VideoStatus.TRANSCODE_FAILED == Video.objects.get(id=video.id).status
+
+
+@pytest.mark.django_db
+def test_stream_to_s3_no_video():
+    """Test DoesNotExistError"""
+    with pytest.raises(Video.DoesNotExist):
+        stream_to_s3(999999)  # pylint: disable=no-value-for-parameter

--- a/cloudsync/utils.py
+++ b/cloudsync/utils.py
@@ -1,0 +1,34 @@
+"""Utility classes/methods for cloudsync"""
+from uuid import uuid4
+
+from dj_elastictranscoder.models import EncodeJob
+from dj_elastictranscoder.transcoder import Transcoder
+from django.contrib.contenttypes.models import ContentType
+
+
+class VideoTranscoder(Transcoder):
+    """
+    Customized version of dj_elastictranscoder.transcoder
+    """
+    def create_job_for_object(self, obj):
+        """
+        Create an EncodeJob with the same message output as the Transcoder message
+
+        Args:
+            obj(Video): Video to create a job for
+
+        Returns:
+            EncodeJob object
+
+        """
+        content_type = ContentType.objects.get_for_model(obj)
+        uuid = str(uuid4())
+        if not hasattr(self, 'message'):
+            self.message = {'Job': {'Status': 'Error', 'Id': uuid}}  # pylint:disable=attribute-defined-outside-init
+        job = EncodeJob()
+        job.id = self.message['Job']['Id'] if 'Job' in self.message else uuid
+        job.message = self.message
+        job.content_type = content_type
+        job.object_id = obj.pk
+        job.save()
+        return job

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -7,6 +7,7 @@ import platform
 from urllib.parse import urljoin
 
 import dj_database_url
+from django.core.exceptions import ImproperlyConfigured
 
 from odl_video.envs import (
     get_any,
@@ -163,7 +164,12 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TIMEZONE = 'UTC'
-
+CELERY_BEAT_SCHEDULE = {
+    'update-statuses': {
+        'task': 'cloudsync.tasks.update_video_statuses',
+        'schedule': get_int('VIDEO_STATUS_UPDATE_FREQUENCY', 60)
+    }
+}
 
 # django cache back-ends
 CACHES = {
@@ -440,10 +446,14 @@ ET_PRESET_IDS = get_string(
     '1351620000001-200010,1351620000001-200020,1351620000001-200050'
 ).split(',')
 
+if ET_PRESET_IDS == ['']:  # This may happen if `ET_PRESET_IDS=` is in .env file.
+    raise ImproperlyConfigured('ET_PRESET_IDS cannot be blank, please check your settings & environment')
+
 VIDEO_CLOUDFRONT_DIST = get_string('VIDEO_CLOUDFRONT_DIST', '')
 VIDEO_S3_BUCKET = get_string('VIDEO_S3_BUCKET', 'odl-video-service')
 VIDEO_S3_TRANSCODE_BUCKET = get_string('VIDEO_S3_TRANSCODE_BUCKET', '{}-transcoded'.format(VIDEO_S3_BUCKET))
 VIDEO_S3_THUMBNAIL_BUCKET = get_string('VIDEO_S3_THUMBNAIL_BUCKET', '{}-thumbnails'.format(VIDEO_S3_BUCKET))
+
 
 # server-status
 STATUS_TOKEN = get_string("STATUS_TOKEN", "")

--- a/ui/conftest.py
+++ b/ui/conftest.py
@@ -65,7 +65,7 @@ def videofile(video):  # pylint: disable=redefined-outer-name
     """
     obj = VideoFile(
         video=video,
-        s3_object_key=video.s3_key(),
+        s3_object_key=video.get_s3_key(),
         encoding=EncodingNames.ORIGINAL,
         bucket_name=settings.VIDEO_S3_BUCKET
     )
@@ -81,7 +81,7 @@ def videofile_unencoded(video_unencoded):  # pylint: disable=redefined-outer-nam
     """
     obj = VideoFile(
         video=video_unencoded,
-        s3_object_key=video_unencoded.s3_key(),
+        s3_object_key=video_unencoded.get_s3_key(),
         encoding=EncodingNames.ORIGINAL,
         bucket_name=settings.VIDEO_S3_BUCKET
     )
@@ -97,7 +97,7 @@ def videofileHLS(video):  # pylint: disable=redefined-outer-name
     """
     obj = VideoFile(
         video=video,
-        s3_object_key=video.s3_key(),
+        s3_object_key=video.get_s3_key(),
         encoding=EncodingNames.HLS,
         bucket_name=settings.VIDEO_S3_BUCKET
     )

--- a/ui/constants.py
+++ b/ui/constants.py
@@ -1,0 +1,11 @@
+""" Statuses for Video objects """
+
+
+class VideoStatus:
+    """Simple class for possible video statuses"""
+    UPLOADING = 'Uploading'
+    UPLOAD_FAILED = 'Upload failed'
+    TRANSCODING = 'Transcoding'
+    TRANSCODE_FAILED = 'Transcode failed'
+    COMPLETE = 'Complete'
+    ERROR = 'Error'

--- a/ui/models.py
+++ b/ui/models.py
@@ -55,7 +55,7 @@ class Video(models.Model):
     s3_subkey = models.UUIDField(unique=True, null=False, blank=False, default=uuid4)
     encode_jobs = GenericRelation(EncodeJob)
 
-    def s3_key(self):
+    def get_s3_key(self):
         """
         Avoid duplicate S3 keys/filenames when transferring videos from Dropbox
 
@@ -87,6 +87,16 @@ class Video(models.Model):
         output_template = '{prefix}/{s3key}_{preset}'
         basename, _ = os.path.splitext(original_s3_key)
         return output_template.format(prefix=TRANSCODE_PREFIX, s3key=basename, preset=preset)
+
+    def update_status(self, status):
+        """
+        Assign and save the status of a Video
+
+        Args:
+            status(str): The status to assign the video
+        """
+        self.status = status
+        self.save()
 
     def __str__(self):
         return self.title or "<untitled video>"

--- a/ui/models_test.py
+++ b/ui/models_test.py
@@ -37,11 +37,11 @@ def test_s3_object_uniqueness(videofile):
 
 def test_video_model_s3keys(user):
     """
-    Test that the Video.s3_subkey and s3_key properties return expected values
+    Test that the Video.s3_subkey and get_s3_key properties return expected values
     """
     new_video = Video(source_url="http://fake.com/fake.mp4", creator=user)
     assert isinstance(new_video.s3_subkey, uuid.UUID)
-    s3key = new_video.s3_key()
+    s3key = new_video.get_s3_key()
     assert s3key is not None
     assert s3key == '{user}/{uuid}/video.mp4'.format(user=user.id, uuid=new_video.s3_subkey)
 

--- a/ui/templates/ui/upload.html
+++ b/ui/templates/ui/upload.html
@@ -30,12 +30,12 @@ to TechTV.</p>
           progress.value = data.info.uploaded;
           // get an update in one second
           setTimeout(updateStatus, 1000, taskId);
-        } else if (data.status == "SUCCESS") {
-          progress.max = 100;
-          progress.value = 100;
         } else if (data.status == "FAILURE") {
           let text = document.createTextNode("failed");
           progress.parentNode.appendChild(text);
+        } else {
+          progress.max = 100;
+          progress.value = 100;
         }
       });
     });

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -24,6 +24,10 @@ const devConfig = Object.assign({}, config, {
         'NODE_ENV': '"development"'
       }
     }),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'common',
+      minChunks: 2,
+    }),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NamedModulesPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/odl-video-service/issues/24 and https://github.com/mitodl/odl-video-service/issues/58

#### What's this PR do?
- New statuses for tasks to better track progress (Uploading, Transcoding, Upload Failed, Transcode Failed).
- Overrides default Transcoder.create_job class to record more detailed results info in EncodeJob objects
- Uses try-catch blocks to update statuses of videos and tasks when failures occur in celery tasks.
- Fixes progress bar on upload page.

#### How should this be manually tested?
- Upload a video file that's about 50 MB or larger.  Progress bar should begin filling in shortly.  Look at network requests and responses: responses should show amount of bytes transferred. When upload is complete, requests should stop being sent and the last response should show a status of 'Transcoding'.  Go to the video detail page, the video 'Encoding Status' should also be 'Transcoding'.  When transcoding is finished, the status should be shown as 'Complete'
- Choose a file to upload from dropbox, then rename the dropbox file after it appears on the upload list but before the progress bar starts filling in.  Eventually, after 15 minutes or so, the upload should fail after AWS gives up trying. Go to the video detail page and the 'Encoding Status' should be 'Upload failed'
- Rename a non-video dropbox file as "myvideo.mp4" and upload it.  Upload should complete successfully but transcoding should eventually fail, and the 'Encoding status' on the video detail page should be 'Transcoding failed'
- Go to ../admin/dj_elastictranscoder/encodejob/ and you should see EncodeJob objects for all videos whose transcoding tasks passed or failed, along with messages that contain the job results details.

