### PR TITLE
Upgraded django-server-status and other requirements

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -197,7 +197,7 @@ DATABASES = {
 
 # Celery
 # http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
-
+USE_CELERY = True
 CELERY_BROKER_URL = get_var("REDIS_URL", None)
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0
 djangorestframework==3.6.3
-django-server-status==0.3.2
+django-server-status==0.4.0
 django-webpack-loader==0.4.1
 factory_boy
 faker

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,72 +6,67 @@
 #
 -e git+https://github.com/mitodl/django-elastic-transcoder.git#egg=django-elastic-transcoder
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
-amqp==2.1.4
+amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via zeep
-appnope==0.1.0
 asn1crypto==0.22.0        # via cryptography
-backports.shutil-get-terminal-size==1.0.0
-billiard==3.5.0.2
+billiard==3.5.0.3         # via celery
 boto3==1.4.4
-botocore==1.5.80          # via boto3, s3transfer
+botocore==1.5.84          # via boto3, s3transfer
 cached-property==1.3.0    # via zeep
 celery==4.0.2
-certifi==2017.4.17
+certifi==2017.4.17        # via requests
 cffi==1.10.0              # via cryptography
-chardet==3.0.4
-contextlib2==0.5.5
+chardet==3.0.4            # via requests
+contextlib2==0.5.5        # via raven
 cryptography==1.8.1
-decorator==4.0.11
+decorator==4.1.1          # via ipython, traitlets
 defusedxml==0.5.0         # via zeep
-dj-database-url==0.4.2
+dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0
-django-server-status==0.3.2
+django-server-status==0.4.0
 django-webpack-loader==0.4.1
-django==1.10.5
+django==1.10.5            # via django-server-status
 djangorestframework==3.6.3
 docutils==0.13.1          # via botocore
-elasticsearch==5.4.0
-enum34==1.1.6
+elasticsearch==5.4.0      # via django-server-status
 factory-boy==2.8.1
 faker==0.7.17
 html5lib==0.999999999
-idna==2.5
-ipaddress==1.0.18
-ipython-genutils==0.2.0
-ipython==5.4.1
+idna==2.5                 # via cryptography, requests
+ipython-genutils==0.2.0   # via traitlets
+ipython==6.1.0
 isodate==0.5.4            # via zeep
+jedi==0.10.2              # via ipython
 jmespath==0.9.3           # via boto3, botocore
-kombu==4.0.2
+kombu==4.0.2              # via celery, django-server-status
 lxml==3.8.0               # via zeep
 mit-moira==0.0.3
-newrelic==2.86.3.70
+newrelic==2.88.1.73
 packaging==16.8           # via cryptography
-pathlib2==2.3.0
-pexpect==4.2.1
-pickleshare==0.7.4
-prompt-toolkit==1.0.14
+pexpect==4.2.1            # via ipython
+pickleshare==0.7.4        # via ipython
+prompt-toolkit==1.0.14    # via ipython
 psycopg2==2.6
-ptyprocess==0.5.2
-pycparser==2.17           # via cffi
-pygments==2.2.0
+ptyprocess==0.5.2         # via pexpect
+pycparser==2.18           # via cffi
+pygments==2.2.0           # via ipython
 pyparsing==2.2.0          # via packaging
-python-dateutil==2.6.0
+python-dateutil==2.6.1    # via botocore, faker
 pytz==2017.2
-pyyaml==3.12
+pyyaml==3.11
 raven==6.1.0
 redis==2.10.5
 requests-toolbelt==0.8.0  # via zeep
 requests==2.18.1
 s3transfer==0.1.10        # via boto3
-scandir==1.5
-simplegeneric==0.8.1
-six==1.10.0
-static3==0.5.1
-traitlets==4.3.2
-urllib3==1.21.1
+simplegeneric==0.8.1      # via ipython
+six==1.10.0               # via cryptography, django-server-status, faker, html5lib, packaging, prompt-toolkit, python-dateutil, traitlets, zeep
+static3==0.7.0            # via dj-static
+traitlets==4.3.2          # via ipython
+urllib3==1.21.1           # via elasticsearch, requests
 uwsgi==2.0.15
-vine==1.1.3
-wcwidth==0.1.7
-webencodings==0.5.1
+vine==1.1.4               # via amqp
+wcwidth==0.1.7            # via prompt-toolkit
+webencodings==0.5.1       # via html5lib
 zeep==2.2.0               # via mit-moira


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Upgrades the `django-server-status` library

#### How should this be manually tested?
go to `http://<ip_to_service>:8089/status/?token=<statustoken>`
you should be able to see something like this
```
{
    "redis":{
        "status":"up",
        "response_microseconds":1817,
        "uptime_in_seconds":396,
        "used_memory":1078984,
        "used_memory_peak":1221216
    },
    "postgresql":{
        "status":"up",
        "response_microseconds":2984
    },
    "celery":{
        "status":"up",
        "response_microseconds":48676
    },
    "status_all":"up"
}
```