### PR TITLE
Custom logout page

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -104,6 +104,9 @@ WEBPACK_DEV_SERVER_PORT = get_var('WEBPACK_DEV_SERVER_PORT', '8082')
 # Application definition
 
 INSTALLED_APPS = [
+    'ui.apps.UIConfig',
+    'cloudsync.apps.CloudSyncConfig',
+    'dj_elastictranscoder',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -113,9 +116,6 @@ INSTALLED_APPS = [
     'rest_framework',
     'server_status',
     'raven.contrib.django.raven_compat',
-    'ui.apps.UIConfig',
-    'cloudsync.apps.CloudSyncConfig',
-    'dj_elastictranscoder',
 ]
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -32,7 +32,7 @@
   {% if user.is_authenticated %}
     <p>You are logged in as {{ user.username }}. <a href="{% url 'logout' %}">Logout</a></p>
   {% else %}
-    <p><a href="{% url 'login' %}">Login</a></p>
+    <p><a href="{% url 'index' %}">Login</a></p>
   {% endif %}
   {% block content %}{% endblock %}
 </body>

--- a/ui/templates/registration/logged_out.html
+++ b/ui/templates/registration/logged_out.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Logout{% endblock %}
+{% block pagetitle %}Logout{% endblock %}
+{% block content %}
+You are now logged out.
+{% endblock %}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/odl-video-service/issues/56

#### What's this PR do?
- Adds a custom logout HTML template and changes the order of settings.INSTALLED_APPS so that a user is not redirected to the admin logout page after logging out.
- Changes the 'login' link on the base template to redirect to the index page (if touchstone integration is on, they will logged in via that; otherwise there will be a login form on the index page).

#### How should this be manually tested?
Log in, then click the 'log out' link.  You should be redirected to a simple logout page and not the admin logout page. Click the 'Login' link.  You should be redirected to the home page with a login form.