### PR TITLE
Fix videojs error on heroku

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -27,6 +27,11 @@ module.exports = Object.assign(prodConfig, {
         'NODE_ENV': '"production"'
       }
     }),
+    // This is necessary to make videojs & uglify work together:
+    // https://github.com/videojs/videojs-contrib-hls/issues/600#issuecomment-295730581
+    new webpack.DefinePlugin({
+      'typeof global': JSON.stringify('undefined')
+    }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #85 

#### What's this PR do?
Modifies `webpack.config.prod.js` by adding a DefinePlugin to alias `typeof global` to `undefined` based on recommendation here: https://github.com/videojs/videojs-contrib-hls/issues/600#issuecomment-295730581
