### PR TITLE
Update AWS transcoder presets based on LectureCapture settings

### DIFF
--- a/cloudsync/management/commands/createpresets.py
+++ b/cloudsync/management/commands/createpresets.py
@@ -38,5 +38,6 @@ class Command(BaseCommand):
                               aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
                               aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
         for preset in presets:
-            created = client.create_preset(**preset)
-            self.stdout.write("{}:{}".format(created['Preset']['Id'], created['Preset']['Name']))
+            preset['created'] = client.create_preset(**preset)
+        self.stdout.write('ET_PRESET_IDS={}'.format(','.join(
+            [preset['created']['Preset']['Id'] for preset in presets])))

--- a/config/et_presets.json
+++ b/config/et_presets.json
@@ -1,5 +1,24 @@
 [
   {
+    "Video": {
+      "BitRate": "900",
+      "Codec": "H.264",
+      "CodecOptions": {
+        "ColorSpaceConversionMode": "None",
+        "InterlacedMode": "Progressive",
+        "Level": "3.1",
+        "MaxReferenceFrames": "1",
+        "Profile": "main"
+      },
+      "DisplayAspectRatio": "auto",
+      "FixedGOP": "true",
+      "FrameRate": "30",
+      "KeyframesMaxDist": "90",
+      "MaxHeight": "360",
+      "MaxWidth": "640",
+      "PaddingPolicy": "NoPad",
+      "SizingPolicy": "Fit"
+    },
     "Audio": {
       "BitRate": "96",
       "Channels": "1",
@@ -19,16 +38,18 @@
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
-    },
+    }
+  },
+  {
     "Video": {
-      "BitRate": "1000",
+      "BitRate": "1300",
       "Codec": "H.264",
       "CodecOptions": {
         "ColorSpaceConversionMode": "None",
         "InterlacedMode": "Progressive",
-        "Level": "4",
+        "Level": "3.1",
         "MaxReferenceFrames": "1",
-        "Profile": "baseline"
+        "Profile": "main"
       },
       "DisplayAspectRatio": "auto",
       "FixedGOP": "true",
@@ -38,9 +59,7 @@
       "MaxWidth": "960",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
-    }
-  },
-  {
+    },
     "Audio": {
       "BitRate": "128",
       "Channels": "1",
@@ -52,7 +71,7 @@
     },
     "Container": "ts",
     "Description": "HLS for medium network bandwidth",
-    "Name": "HLS_1_8mpbs",
+    "Name": "HLS_1_5mpbs",
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
@@ -60,28 +79,28 @@
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
-    },
+    }
+  },
+  {
     "Video": {
-      "BitRate": "1708",
+      "BitRate": "1800",
       "Codec": "H.264",
       "CodecOptions": {
         "ColorSpaceConversionMode": "None",
         "InterlacedMode": "Progressive",
-        "Level": "3",
+        "Level": "3.1",
         "MaxReferenceFrames": "1",
-        "Profile": "baseline"
+        "Profile": "main"
       },
       "DisplayAspectRatio": "auto",
       "FixedGOP": "true",
       "FrameRate": "30",
       "KeyframesMaxDist": "90",
-      "MaxHeight": "540",
-      "MaxWidth": "960",
+      "MaxHeight": "720",
+      "MaxWidth": "1280",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
-    }
-  },
-  {
+    },
     "Audio": {
       "BitRate": "160",
       "Channels": "2",
@@ -101,28 +120,28 @@
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
-    },
+    }
+  },
+  {
     "Video": {
-      "BitRate": "1800",
+      "BitRate": "3800",
       "Codec": "H.264",
       "CodecOptions": {
         "ColorSpaceConversionMode": "None",
         "InterlacedMode": "Progressive",
-        "Level": "4",
+        "Level": "3.1",
         "MaxReferenceFrames": "1",
-        "Profile": "baseline"
+        "Profile": "main"
       },
       "DisplayAspectRatio": "auto",
       "FixedGOP": "true",
       "FrameRate": "30",
       "KeyframesMaxDist": "90",
-      "MaxHeight": "720",
-      "MaxWidth": "1280",
+      "MaxHeight": "1080",
+      "MaxWidth": "1920",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
-    }
-  },
-  {
+    },
     "Audio": {
       "BitRate": "224",
       "Channels": "2",
@@ -140,25 +159,6 @@
       "Interval": "300",
       "MaxHeight": "144",
       "MaxWidth": "192",
-      "PaddingPolicy": "NoPad",
-      "SizingPolicy": "Fit"
-    },
-    "Video": {
-      "BitRate": "4000",
-      "Codec": "H.264",
-      "CodecOptions": {
-        "ColorSpaceConversionMode": "None",
-        "InterlacedMode": "Progressive",
-        "Level": "4",
-        "MaxReferenceFrames": "1",
-        "Profile": "baseline"
-      },
-      "DisplayAspectRatio": "auto",
-      "FixedGOP": "true",
-      "FrameRate": "30",
-      "KeyframesMaxDist": "90",
-      "MaxHeight": "720",
-      "MaxWidth": "1280",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
     }

--- a/config/et_presets.json
+++ b/config/et_presets.json
@@ -1,257 +1,166 @@
 [
   {
+    "Audio": {
+      "BitRate": "96",
+      "Channels": "1",
+      "Codec": "AAC",
+      "CodecOptions": {
+        "Profile": "AAC-LC"
+      },
+      "SampleRate": "44100"
+    },
     "Container": "ts",
-    "Name": "HLS 1080P",
-    "Description": "HLS 1080P",
+    "Description": "HLS for low network bandwidth",
+    "Name": "HLS_AV_1_0mpbs",
     "Thumbnails": {
-      "Format": "png",
+      "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "108",
+      "MaxHeight": "144",
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
-      "SizingPolicy": "ShrinkToFit"
+      "SizingPolicy": "Fit"
     },
     "Video": {
-      "BitRate": "5400",
+      "BitRate": "1000",
       "Codec": "H.264",
       "CodecOptions": {
-        "BufferSize": "48600",
         "ColorSpaceConversionMode": "None",
         "InterlacedMode": "Progressive",
         "Level": "4",
-        "MaxBitRate": "5400",
-        "MaxReferenceFrames": "3",
-        "Profile": "main"
+        "MaxReferenceFrames": "1",
+        "Profile": "baseline"
       },
       "DisplayAspectRatio": "auto",
       "FixedGOP": "true",
-      "FrameRate": "auto",
+      "FrameRate": "30",
       "KeyframesMaxDist": "90",
-      "MaxFrameRate": "29.97",
-      "MaxHeight": "1080",
-      "MaxWidth": "1920",
+      "MaxHeight": "540",
+      "MaxWidth": "960",
       "PaddingPolicy": "NoPad",
-      "SizingPolicy": "ShrinkToFit",
-      "Watermarks": [
-        {
-          "HorizontalAlign": "Left",
-          "HorizontalOffset": "10%",
-          "Id": "TopLeft",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Top",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Right",
-          "HorizontalOffset": "10%",
-          "Id": "TopRight",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Top",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Left",
-          "HorizontalOffset": "10%",
-          "Id": "BottomLeft",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Bottom",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Right",
-          "HorizontalOffset": "10%",
-          "Id": "BottomRight",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Bottom",
-          "VerticalOffset": "10%"
-        }
-      ]
+      "SizingPolicy": "Fit"
     }
   },
   {
+    "Audio": {
+      "BitRate": "128",
+      "Channels": "1",
+      "Codec": "AAC",
+      "CodecOptions": {
+        "Profile": "AAC-LC"
+      },
+      "SampleRate": "44100"
+    },
     "Container": "ts",
-    "Name": "HLS 720P",
-    "Description": "HLS 720P",
+    "Description": "HLS for medium network bandwidth",
+    "Name": "HLS_1_8mpbs",
     "Thumbnails": {
-      "Format": "png",
+      "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "108",
+      "MaxHeight": "144",
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
-      "SizingPolicy": "ShrinkToFit"
+      "SizingPolicy": "Fit"
     },
     "Video": {
-      "BitRate": "2400",
+      "BitRate": "1708",
       "Codec": "H.264",
       "CodecOptions": {
-        "BufferSize": "21600",
         "ColorSpaceConversionMode": "None",
         "InterlacedMode": "Progressive",
-        "Level": "4",
-        "MaxBitRate": "2400",
-        "MaxReferenceFrames": "3",
-        "Profile": "main"
+        "Level": "3",
+        "MaxReferenceFrames": "1",
+        "Profile": "baseline"
       },
       "DisplayAspectRatio": "auto",
       "FixedGOP": "true",
-      "FrameRate": "auto",
+      "FrameRate": "30",
       "KeyframesMaxDist": "90",
-      "MaxFrameRate": "29.97",
+      "MaxHeight": "540",
+      "MaxWidth": "960",
+      "PaddingPolicy": "NoPad",
+      "SizingPolicy": "Fit"
+    }
+  },
+  {
+    "Audio": {
+      "BitRate": "160",
+      "Channels": "2",
+      "Codec": "AAC",
+      "CodecOptions": {
+        "Profile": "AAC-LC"
+      },
+      "SampleRate": "44100"
+    },
+    "Container": "ts",
+    "Description": "HLS for high network bandwidth",
+    "Name": "HLS_AV_2_0mpbs",
+    "Thumbnails": {
+      "Format": "jpg",
+      "Interval": "300",
+      "MaxHeight": "144",
+      "MaxWidth": "192",
+      "PaddingPolicy": "NoPad",
+      "SizingPolicy": "Fit"
+    },
+    "Video": {
+      "BitRate": "1800",
+      "Codec": "H.264",
+      "CodecOptions": {
+        "ColorSpaceConversionMode": "None",
+        "InterlacedMode": "Progressive",
+        "Level": "4",
+        "MaxReferenceFrames": "1",
+        "Profile": "baseline"
+      },
+      "DisplayAspectRatio": "auto",
+      "FixedGOP": "true",
+      "FrameRate": "30",
+      "KeyframesMaxDist": "90",
       "MaxHeight": "720",
       "MaxWidth": "1280",
       "PaddingPolicy": "NoPad",
-      "SizingPolicy": "ShrinkToFit",
-      "Watermarks": [
-        {
-          "HorizontalAlign": "Left",
-          "HorizontalOffset": "10%",
-          "Id": "TopLeft",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Top",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Right",
-          "HorizontalOffset": "10%",
-          "Id": "TopRight",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Top",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Left",
-          "HorizontalOffset": "10%",
-          "Id": "BottomLeft",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Bottom",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Right",
-          "HorizontalOffset": "10%",
-          "Id": "BottomRight",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Bottom",
-          "VerticalOffset": "10%"
-        }
-      ]
+      "SizingPolicy": "Fit"
     }
   },
   {
+    "Audio": {
+      "BitRate": "224",
+      "Channels": "2",
+      "Codec": "AAC",
+      "CodecOptions": {
+        "Profile": "AAC-LC"
+      },
+      "SampleRate": "44100"
+    },
     "Container": "ts",
-    "Name": "HLS 480P",
-    "Description": "HLS 480P",
+    "Description": "HLS for highest network bandwidth",
+    "Name": "HLS_AV_4_0mpbs",
     "Thumbnails": {
-      "Format": "png",
+      "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "108",
+      "MaxHeight": "144",
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
-      "SizingPolicy": "ShrinkToFit"
+      "SizingPolicy": "Fit"
     },
     "Video": {
-      "BitRate": "1200",
+      "BitRate": "4000",
       "Codec": "H.264",
       "CodecOptions": {
-        "BufferSize": "10800",
         "ColorSpaceConversionMode": "None",
         "InterlacedMode": "Progressive",
         "Level": "4",
-        "MaxBitRate": "1200",
-        "MaxReferenceFrames": "3",
-        "Profile": "main"
+        "MaxReferenceFrames": "1",
+        "Profile": "baseline"
       },
       "DisplayAspectRatio": "auto",
       "FixedGOP": "true",
-      "FrameRate": "auto",
+      "FrameRate": "30",
       "KeyframesMaxDist": "90",
-      "MaxFrameRate": "29.97",
-      "MaxHeight": "480",
-      "MaxWidth": "854",
+      "MaxHeight": "720",
+      "MaxWidth": "1280",
       "PaddingPolicy": "NoPad",
-      "SizingPolicy": "ShrinkToFit",
-      "Watermarks": [
-        {
-          "HorizontalAlign": "Left",
-          "HorizontalOffset": "10%",
-          "Id": "TopLeft",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Top",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Right",
-          "HorizontalOffset": "10%",
-          "Id": "TopRight",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Top",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Left",
-          "HorizontalOffset": "10%",
-          "Id": "BottomLeft",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Bottom",
-          "VerticalOffset": "10%"
-        },
-        {
-          "HorizontalAlign": "Right",
-          "HorizontalOffset": "10%",
-          "Id": "BottomRight",
-          "MaxHeight": "10%",
-          "MaxWidth": "10%",
-          "Opacity": "100",
-          "SizingPolicy": "ShrinkToFit",
-          "Target": "Content",
-          "VerticalAlign": "Bottom",
-          "VerticalOffset": "10%"
-        }
-      ]
+      "SizingPolicy": "Fit"
     }
   }
 ]

--- a/config/et_presets.json
+++ b/config/et_presets.json
@@ -1,5 +1,8 @@
 [
   {
+    "Name": "HLS_AV_1_0Mbps",
+    "Description": "HLS for low network bandwidth",
+    "Container": "ts",
     "Video": {
       "BitRate": "900",
       "Codec": "H.264",
@@ -28,19 +31,19 @@
       },
       "SampleRate": "44100"
     },
-    "Container": "ts",
-    "Description": "HLS for low network bandwidth",
-    "Name": "HLS_AV_1_0mpbs",
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "144",
+      "MaxHeight": "108",
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
     }
   },
   {
+    "Name": "HLS_AV_1_5Mbps",
+    "Description": "HLS for medium network bandwidth",
+    "Container": "ts",
     "Video": {
       "BitRate": "1300",
       "Codec": "H.264",
@@ -69,19 +72,19 @@
       },
       "SampleRate": "44100"
     },
-    "Container": "ts",
-    "Description": "HLS for medium network bandwidth",
-    "Name": "HLS_1_5mpbs",
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "144",
+      "MaxHeight": "108",
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
     }
   },
   {
+    "Name": "HLS_AV_2_0Mbps",
+    "Description": "HLS for high network bandwidth",
+    "Container": "ts",
     "Video": {
       "BitRate": "1800",
       "Codec": "H.264",
@@ -110,19 +113,19 @@
       },
       "SampleRate": "44100"
     },
-    "Container": "ts",
-    "Description": "HLS for high network bandwidth",
-    "Name": "HLS_AV_2_0mpbs",
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "144",
+      "MaxHeight": "108",
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
     }
   },
   {
+    "Name": "HLS_AV_4_0Mbps",
+    "Description": "HLS for highest network bandwidth",
+    "Container": "ts",
     "Video": {
       "BitRate": "3800",
       "Codec": "H.264",
@@ -151,13 +154,10 @@
       },
       "SampleRate": "44100"
     },
-    "Container": "ts",
-    "Description": "HLS for highest network bandwidth",
-    "Name": "HLS_AV_4_0mpbs",
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "144",
+      "MaxHeight": "108",
       "MaxWidth": "192",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #77

#### What's this PR do?
- Updates `config/presets.json` to define ElasticTranscoder presets similar to settings used for LectureCapture
- Tweaks the `createpresets` Django management command to output the new `ET_PRESET_IDS` that should be placed in the `.env` file

#### How should this be manually tested?
- `docker-compose run web python manage.py createpresets`
- Copy the ET_PRESET_IDS output to your .env file, there should be 4 id's
- `docker-compose build`
- `docker-compose up`

Upload a video.  Wait for it to be transcoded.  Verify the new presets were used, either by looking through the celery logs for the preset ids or by playing the video and looking at the network console to see which *.ts file it downloads to play: the file should include one of the presets in its filename.  For instance, if one of the presets is `1501169543456-xeiact` then it's video file would be `video_1501169543536-xeiact00000.ts`

