### PR TITLE
allow video object to have no moira lists

### DIFF
--- a/ui/models.py
+++ b/ui/models.py
@@ -51,7 +51,7 @@ class Video(models.Model):
     title = models.CharField(max_length=250, blank=True)
     description = models.TextField(blank=True)
     source_url = models.URLField()
-    moira_lists = models.ManyToManyField(MoiraList)
+    moira_lists = models.ManyToManyField(MoiraList, blank=True)
     status = models.TextField(
         null=False,
         default=VideoStatus.CREATED,


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #48 

#### What's this PR do?

Allows a video object to have null moira_lists

#### How should this be manually tested?

Go to the admin end edit a video object. Without this change, you'll get a validation error unless there's a moira list set. After this change, you should get no validation error. 

#### Any background context you want to provide?

According to the product description, moira lists should be optional. 
