### PR TITLE
Only staff users should be able to create collections

### DIFF
--- a/ui/forms.py
+++ b/ui/forms.py
@@ -71,7 +71,7 @@ class CollectionForm(ModelForm):
 
     class Meta:
         model = models.Collection
-        fields = ('title', 'description', 'owner', "view_lists", "admin_lists")
+        fields = ('title', 'description', 'owner', 'view_lists', 'admin_lists')
 
 
 class VideoForm(ModelForm):

--- a/ui/models.py
+++ b/ui/models.py
@@ -67,7 +67,7 @@ class CollectionManager(models.Manager):
         return self.filter(
             models.Q(view_lists__in=MoiraList.objects.filter(name__in=user_lists)) |
             models.Q(admin_lists__in=MoiraList.objects.filter(name__in=user_lists)) |
-            models.Q(owner=user))
+            models.Q(owner=user)).distinct()
 
     def all_admin(self, user):
         """
@@ -84,7 +84,7 @@ class CollectionManager(models.Manager):
             return self.all()
         return self.filter(
             models.Q(admin_lists__in=MoiraList.objects.filter(name__in=utils.user_moira_lists(user))) |
-            models.Q(owner=user))
+            models.Q(owner=user)).distinct()
 
 
 class Collection(models.Model):

--- a/ui/templates/ui/collection_list.html
+++ b/ui/templates/ui/collection_list.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 
+<h2>Collections</h2>
 <ul>
   {% for collection in collection_list %}
     <li><a href="{% url "collection-detail" collection.hexkey %}">{{ collection.title }}</a></li>
@@ -26,6 +27,14 @@
       <th>{{ form.description.label_tag }}</th>
       <td>{{ form.description }}</td>
     </tr>
+    <tr>
+      <th>{{ form.view_lists.label_tag }}</th>
+      <td>{{ form.view_lists }}</td>
+    </tr>
+    <tr>
+      <th>{{ form.admin_lists.label_tag }}</th>
+      <td>{{ form.admin_lists }}</td>
+    </tr>
   </table>
   {{ form.owner }}
   <input type="submit" value="Create" />
@@ -34,6 +43,11 @@
 <script>
   let CSRF = "{{ csrf_token }}";
 
+  let formatMoiraList = function(listVal) {
+      // Split the form value by commas or spaces and remove empty strings
+      return listVal.split(/[,\s]+/).filter(function(item){return item});
+  };
+
   let handleCreate = function(event) {
     event.preventDefault();
     let form = event.target;
@@ -41,8 +55,8 @@
       title: form.querySelector("[name=title]").value,
       description: form.querySelector("[name=description]").value,
       owner: form.querySelector("[name=owner]").value,
-      view_lists: [],
-      admin_lists: []
+      view_lists: formatMoiraList(form.querySelector("[name=view_lists]").value),
+      admin_lists: formatMoiraList(form.querySelector("[name=admin_lists]").value)
     };
     let headers = new Headers();
     headers.append("X-CSRFToken", CSRF);
@@ -62,5 +76,8 @@
     document.querySelector("form.create-collection").addEventListener("submit", handleCreate);
   });
 </script>
+{%  else %}
+<div>You do not have permission to create new video collections.</div>
 {%  endif %}
+
 {% endblock %}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes https://github.com/mitodl/odl-video-service/issues/5
Fixes https://github.com/mitodl/odl-video-service/issues/160

#### What's this PR do?
- Prevents a user from creating a collection (front-end and API) if user is not staff or superuser
- Prevents a collection from showing up more than once in the list when a user is both the  owner and a member of one of its admin/view moira lists.
- Also adds missing moira lists fields to front-end form

#### How should this be manually tested?
- Create a new user (not staff and not superuser)
- After logging in as that user, you should not see the collection creation form on the collection lists page
- If you try to post a new collection using the API, you should get an access denied message
- As admin, change the user to a staff user.
- Repeat the above: you should be able to see & use the collection creation form on the lists page, and be able to post a new collection using the API (but only if the owner id == the user id).
- Repeat the above as a superuser.  You should be able to see & use the collection creation form on the lists page, and be able to post a new collection using the API (with any owner id as long as it's an existing user and not null).
