### PR TITLE
Let read-only users see the collection detail page

### DIFF
--- a/ui/permissions.py
+++ b/ui/permissions.py
@@ -106,18 +106,16 @@ class HasCollectionPermissions(IsAuthenticated):
         return True
 
     def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return has_view_permission(obj, request)
         return has_admin_permission(obj, request)
 
 
-class HasViewPermissionsForVideo(IsAuthenticated):
+class HasVideoPermissions(IsAuthenticated):
     """Permission to view a video, based on its collection"""
     def has_object_permission(self, request, view, obj):
-        return has_view_permission(obj.collection, request)
-
-
-class HasAdminPermissionsForVideo(IsAuthenticated):
-    """Permission to edit a video, based on its collection"""
-    def has_object_permission(self, request, view, obj):
+        if request.method in SAFE_METHODS:
+            return has_view_permission(obj.collection, request)
         return has_admin_permission(obj.collection, request)
 
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -83,7 +83,7 @@ class CollectionDetail(TemplateView):
     def get_context_data(self, collection_key, **kwargs):  # pylint: disable=arguments-differ
         context = super().get_context_data(**kwargs)
         collection = get_object_or_404(Collection, key=collection_key)
-        if not ui_permissions.has_admin_permission(collection, self.request):
+        if not ui_permissions.has_view_permission(collection, self.request):
             raise PermissionDenied
         video_list = Video.objects.filter(collection=collection)
         default_settings = default_js_settings(self.request)
@@ -212,9 +212,9 @@ class CollectionViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         """
-        Custom get_queryset to filter collections that user has admin access to.
+        Custom get_queryset to filter collections.
         """
-        if self.request.user.is_superuser:
+        if self.kwargs.get('key') is not None:
             return Collection.objects.all()
         return Collection.objects.all_admin(self.request.user)
 
@@ -243,7 +243,7 @@ class VideoViewSet(ModelDetailViewset):
     )
     permission_classes = (
         permissions.IsAuthenticated,
-        ui_permissions.HasViewPermissionsForVideo
+        ui_permissions.HasVideoPermissions
     )
 
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -404,7 +404,7 @@ def test_collection_viewset_detail(mock_moira_client, logged_in_apiclient):
     collection.owner = other_user
     collection.save()
     result = client.delete(url)
-    assert result.status_code == status.HTTP_404_NOT_FOUND
+    assert result.status_code == status.HTTP_403_FORBIDDEN
 
     collection.owner = user
     collection.save()
@@ -476,13 +476,13 @@ def test_collection_detail_admin_permission(mock_moira_client, logged_in_apiclie
 
 def test_collection_detail_view_permission(mock_moira_client, logged_in_apiclient, user_view_list_data):
     """
-    Tests that a user cannot view a collection if user is a member of collection's view_lists
+    Tests that a user can view a collection if user is a member of collection's view_lists
     """
     client, _ = logged_in_apiclient
     mock_moira_client.return_value.user_lists.return_value = [user_view_list_data.moira_list.name]
     url = reverse('collection-detail', kwargs={'collection_key': user_view_list_data.collection.hexkey})
     result = client.get(url)
-    assert result.status_code == status.HTTP_403_FORBIDDEN
+    assert result.status_code == status.HTTP_200_OK
 
 
 def test_video_detail_view_permission(mock_moira_client, logged_in_apiclient, user_view_list_data):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #166 

#### What's this PR do?
Updates permissions and DRF ViewSets so that users who have read-only access to a collection will be able to view the collection detail page and its list of videos, but the collection list REST view will still only show the collections the user has admin access to.

#### How should this be manually tested?
- As admin, create 3 lists with 1+ videos each:
  - Collection 1: no moira list
  - Collection 2: 'odl-engineering' on view list
  - Collection 3: 'odl-engineering on admin list
- Create/login as another user with username == your MIT email
- Your collection list should only include Collection 3
- Manually enter the URL for Collection 2 (regular and REST API).  You should be able to view it with its list of videos.
- Manually enter the URL for Collection 1 (regular and REST API). You should not be able to view it.