### PR TITLE
Video share button

### DIFF
--- a/static/js/actions/videoDetailUi.js
+++ b/static/js/actions/videoDetailUi.js
@@ -3,8 +3,8 @@ import { createAction } from 'redux-actions';
 
 export const qualifiedName = (name: string) => `VIDEO_DETAIL_UI_${name}`;
 
-export const SET_DIALOG_VISIBILITY = qualifiedName('SET_DIALOG_VISIBILITY');
-export const setDialogVisibility = createAction(SET_DIALOG_VISIBILITY);
+export const SET_EDIT_DIALOG_VISIBILITY = qualifiedName('SET_EDIT_DIALOG_VISIBILITY');
+export const setEditDialogVisibility = createAction(SET_EDIT_DIALOG_VISIBILITY);
 
 export const SET_DRAWER_OPEN = qualifiedName('SET_DRAWER_OPEN');
 export const setDrawerOpen = createAction(SET_DRAWER_OPEN);
@@ -15,5 +15,11 @@ export const setTitle = createAction(SET_TITLE);
 export const SET_DESCRIPTION = qualifiedName('SET_DESCRIPTION');
 export const setDescription = createAction(SET_DESCRIPTION);
 
-export const CLEAR_DIALOG = qualifiedName('CLEAR_DIALOG');
-export const clearDialog = createAction(CLEAR_DIALOG);
+export const CLEAR_EDIT_DIALOG = qualifiedName('CLEAR_EDIT_DIALOG');
+export const clearEditDialog = createAction(CLEAR_EDIT_DIALOG);
+
+export const SET_SHARE_DIALOG_VISIBILITY = qualifiedName('SET_SHARE_DIALOG_VISIBILITY');
+export const setShareDialogVisibility = createAction(SET_SHARE_DIALOG_VISIBILITY);
+
+export const CLEAR_SHARE_DIALOG = qualifiedName('CLEAR_SHARE_DIALOG');
+export const clearShareDialog = createAction(CLEAR_SHARE_DIALOG);

--- a/static/js/components/material/Dialog.js
+++ b/static/js/components/material/Dialog.js
@@ -10,11 +10,16 @@ type DialogProps = {
   onCancel: () => void,
   children: React.Children,
   title: string,
+  cancelText: string,
+  submitText: string,
+  noSubmit: boolean,
+  id: string
 };
 
 export default class Dialog extends React.Component {
   dialog: null;
   dialogRoot: null;
+  // $FlowFixMe: Flow doesn't like the extra props that aren't part of mdc.dialog class
   props: DialogProps;
 
   componentDidMount() {
@@ -50,10 +55,10 @@ export default class Dialog extends React.Component {
   }
 
   render() {
-    const { title, children } = this.props;
+    const { title, children, cancelText, submitText, noSubmit, id } = this.props;
 
     return <aside
-      id="my-mdc-dialog"
+      id={id ? id : 'mdc-dialog'}
       className="mdc-dialog"
       role="alertdialog"
       aria-labelledby="my-mdc-dialog-label"
@@ -71,14 +76,17 @@ export default class Dialog extends React.Component {
         </section>
         <footer className="mdc-dialog__footer">
           <Button type="button" className="mdc-dialog__footer__button mdc-dialog__footer__button--cancel cancel-button">
-            Cancel
+            {cancelText || 'Cancel'}
           </Button>
-          <Button type="button" className="mdc-dialog__footer__button mdc-dialog__footer__button--accept edit-button">
-            Save
-          </Button>
+          {noSubmit ? null : (
+            <Button
+              type="button"
+              className="mdc-dialog__footer__button mdc-dialog__footer__button--accept edit-button">
+              {submitText || 'Save'}
+            </Button>)}
         </footer>
       </div>
-      <div className="mdc-dialog__backdrop" />
+      <div className="mdc-dialog__backdrop"/>
     </aside>;
   }
 

--- a/static/js/components/material/Textarea.js
+++ b/static/js/components/material/Textarea.js
@@ -1,0 +1,19 @@
+// @flow
+import React from 'react';
+
+export default class Textarea extends React.Component {
+  props: {
+    label: string,
+    id: string,
+  };
+
+  render() {
+    const { label, id, ...otherProps } = this.props;
+    return <div>
+      <label htmlFor={id}>{label}</label>
+      <div className="mdc-textfield">
+        <textarea className="mdc-textfield__input" id={id} {...otherProps} />
+      </div>
+    </div>;
+  }
+}

--- a/static/js/reducers/videoDetailUi.js
+++ b/static/js/reducers/videoDetailUi.js
@@ -2,43 +2,55 @@
 import type { Action } from '../flow/reduxTypes';
 
 import {
-  SET_DIALOG_VISIBILITY,
+  SET_EDIT_DIALOG_VISIBILITY,
   SET_DRAWER_OPEN,
   SET_TITLE,
   SET_DESCRIPTION,
-  CLEAR_DIALOG,
+  CLEAR_EDIT_DIALOG,
+  SET_SHARE_DIALOG_VISIBILITY,
+  CLEAR_SHARE_DIALOG
 } from '../actions/videoDetailUi';
 
 export type VideoDetailUIState = {
-  dialog: {
+  editDialog: {
     visible: boolean,
     title: string,
     description: string,
+  },
+  shareDialog: {
+    visible: boolean,
   },
   drawerOpen: boolean,
 };
 
 export const INITIAL_UI_STATE = {
-  dialog: {
+  editDialog: {
     visible: false,
     title: '',
     description: '',
+  },
+  shareDialog: {
+    visible: false,
   },
   drawerOpen: false,
 };
 
 const reducer = (state: VideoDetailUIState = INITIAL_UI_STATE, action: Action<any, null>) => {
   switch (action.type) {
-  case SET_DIALOG_VISIBILITY:
-    return {...state, dialog: {...state.dialog, visible: action.payload }};
+  case SET_EDIT_DIALOG_VISIBILITY:
+    return {...state, editDialog: {...state.editDialog, visible: action.payload }};
   case SET_TITLE:
-    return {...state, dialog: {...state.dialog, title: action.payload }};
+    return {...state, editDialog: {...state.editDialog, title: action.payload }};
   case SET_DESCRIPTION:
-    return {...state, dialog: {...state.dialog, description: action.payload }};
+    return {...state, editDialog: {...state.editDialog, description: action.payload }};
   case SET_DRAWER_OPEN:
     return {...state, drawerOpen: action.payload };
-  case CLEAR_DIALOG:
-    return {...state, dialog: INITIAL_UI_STATE.dialog };
+  case CLEAR_EDIT_DIALOG:
+    return {...state, editDialog: INITIAL_UI_STATE.editDialog };
+  case SET_SHARE_DIALOG_VISIBILITY:
+    return {...state, shareDialog: {...state.shareDialog, visible: action.payload }};
+  case CLEAR_SHARE_DIALOG:
+    return {...state, shareDialog: INITIAL_UI_STATE.shareDialog };
   default:
     return state;
   }

--- a/static/js/reducers/videoDetailUi_test.js
+++ b/static/js/reducers/videoDetailUi_test.js
@@ -5,8 +5,10 @@ import { assert } from 'chai';
 
 import rootReducer from '../reducers';
 import {
-  clearDialog,
-  setDialogVisibility,
+  clearEditDialog,
+  clearShareDialog,
+  setEditDialogVisibility,
+  setShareDialogVisibility,
   setDrawerOpen,
   setTitle,
   setDescription,
@@ -27,23 +29,32 @@ describe('videoDetailUi', () => {
     sandbox.restore();
   });
 
-  it('should clear the ui', () => {
+  it('should clear the edit dialog ui', () => {
     store.dispatch(setTitle("something"));
-    store.dispatch(clearDialog());
+    store.dispatch(clearEditDialog());
     assert.deepEqual(store.getState().videoDetailUi, INITIAL_UI_STATE);
   });
 
   it('sets the title', () => {
-    assertReducerResultState(setTitle, ui => ui.dialog.title, '');
+    assertReducerResultState(setTitle, ui => ui.editDialog.title, '');
   });
 
   it('sets the description', () => {
-    assertReducerResultState(setDescription, ui => ui.dialog.description, '');
+    assertReducerResultState(setDescription, ui => ui.editDialog.description, '');
   });
 
 
-  it('sets the dialog visibility', () => {
-    assertReducerResultState(setDialogVisibility, ui => ui.dialog.visible, false);
+  it('sets the edit dialog visibility', () => {
+    assertReducerResultState(setEditDialogVisibility, ui => ui.editDialog.visible, false);
+  });
+
+  it('sets the share dialog visibility', () => {
+    assertReducerResultState(setShareDialogVisibility, ui => ui.shareDialog.visible, false);
+  });
+
+  it('should clear the share dialog ui', () => {
+    store.dispatch(clearShareDialog());
+    assert.deepEqual(store.getState().videoDetailUi, INITIAL_UI_STATE);
   });
 
   it('sets the drawer visibility', () => {

--- a/ui/views.py
+++ b/ui/views.py
@@ -136,6 +136,8 @@ class VideoEmbed(TemplateView):
     def get_context_data(self, video_key, **kwargs):  # pylint: disable=arguments-differ
         context = super().get_context_data(**kwargs)
         video = get_object_or_404(Video, key=video_key)
+        if not ui_permissions.has_view_permission(video.collection, self.request):
+            raise PermissionDenied
         context['video'] = video
         context["js_settings_json"] = json.dumps({
             **default_js_settings(self.request),


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #164 

#### What's this PR do?
Makes the share button on the video detail page work: opens up a modal dialog with two readonly fields: Video URL and Embed HTML, plus a 'Close' button.

#### How should this be manually tested?
- Go to any video detail page.  Click the 'SHARE' button.  A dialog should open with two populated fields ('Video URL', 'Embed HTML'), a 'Close' button, and no 'Save' button.  The video URL should display just the video if opened in a new window, and the embed HTML should be valid.  Click 'Close' and the dialog should disappear.  Click 'Share' again to make sure it opens again.
- Click the 'Edit' button and make sure you can still edit and save the title and description.