### PR TITLE
Fix the height of the USwitch player iframe

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -22,7 +22,7 @@ export default class VideoPlayer extends React.Component {
       if (useIframeForUSwitch) {
         return <iframe
           src={embedUrl}
-          className="video-odl-medium"
+          className="uswitch-odl-medium"
           frameBorder="0"
           scrolling="no"
           allowFullScreen={true}

--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -40,7 +40,7 @@ describe('VideoPlayer', () => {
     let wrapper = renderPlayer({ useIframeForUSwitch: true });
     assert.deepEqual(wrapper.find("iframe").props(), {
       allowFullScreen: true,
-      className: "video-odl-medium",
+      className: "uswitch-odl-medium",
       frameBorder: "0",
       scrolling: "no",
       src: makeEmbedUrl(video.key),

--- a/static/scss/videoPlayer.scss
+++ b/static/scss/videoPlayer.scss
@@ -41,3 +41,9 @@
   top: 0;
   bottom: 0;
 }
+
+//Uswitch styles
+.uswitch-odl-medium {
+  width: 100%;
+  height: calc(100vh - 200px);
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #171 

#### What's this PR do?
Creates a new CSS class for the USwitch player iframe that gives it approximately the same height & width as the VideoJS player, and adjusts to the dimensions of the browser window.

#### How should this be manually tested?
- In the admin console, change any video to Multiangle and save
- Modify your `/etc/hosts` file so that `ovs.mit.edu` points to your local/docker IP 
- Go to the video's detail page using `ovs.mit.edu` as the domain.
- The size of the video should be about the same as for others that use the Video.JS player, and should adjust in size based on the dimensions of the browser window.
- Repeat for different browsers (Chrome, FF, Safari).