### PR TITLE
Increase the max thumbnail size to 600x338

### DIFF
--- a/config/et_presets.json
+++ b/config/et_presets.json
@@ -34,8 +34,8 @@
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "108",
-      "MaxWidth": "192",
+      "MaxHeight": "338",
+      "MaxWidth": "600",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
     }
@@ -75,8 +75,8 @@
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "108",
-      "MaxWidth": "192",
+      "MaxHeight": "338",
+      "MaxWidth": "600",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
     }
@@ -116,8 +116,8 @@
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "108",
-      "MaxWidth": "192",
+      "MaxHeight": "338",
+      "MaxWidth": "600",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
     }
@@ -157,8 +157,8 @@
     "Thumbnails": {
       "Format": "jpg",
       "Interval": "300",
-      "MaxHeight": "108",
-      "MaxWidth": "192",
+      "MaxHeight": "338",
+      "MaxWidth": "600",
       "PaddingPolicy": "NoPad",
       "SizingPolicy": "Fit"
     }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #173 

#### What's this PR do?
Changes the default max WidthxHeight of thumbnails from 192x108 to 600x338 

#### How should this be manually tested?
- Set `ET_PRESET_IDS=1504127981769-6cnqhq,1504127981819-v44xlx,1504127981867-06dkm6,1504127981921-c2jlwt` in your .env file
- `docker-compose up`
- Upload a video.
- When the video is done transcoding, go to `https://<VIDEO_CLOUDFRONT_DIST>.cloudfront.net/thumbnails/<VIDEO_KEY>/video_thumbnail_00001.jpg`
- The thumbnail should be approximately 600x338 (will vary a bit depending on the aspect ratio of the video).