### PR TITLE
Enable the sandwich menu on collection detail/list pages

### DIFF
--- a/static/js/actions/commonUi.js
+++ b/static/js/actions/commonUi.js
@@ -1,0 +1,8 @@
+// @flow
+import { createAction } from 'redux-actions';
+
+export const qualifiedName = (name: string) => `COMMON_UI_${name}`;
+
+export const SET_DRAWER_OPEN = qualifiedName('SET_DRAWER_OPEN');
+export const setDrawerOpen = createAction(SET_DRAWER_OPEN);
+

--- a/static/js/actions/videoDetailUi.js
+++ b/static/js/actions/videoDetailUi.js
@@ -6,9 +6,6 @@ export const qualifiedName = (name: string) => `VIDEO_DETAIL_UI_${name}`;
 export const SET_EDIT_DIALOG_VISIBILITY = qualifiedName('SET_EDIT_DIALOG_VISIBILITY');
 export const setEditDialogVisibility = createAction(SET_EDIT_DIALOG_VISIBILITY);
 
-export const SET_DRAWER_OPEN = qualifiedName('SET_DRAWER_OPEN');
-export const setDrawerOpen = createAction(SET_DRAWER_OPEN);
-
 export const SET_TITLE = qualifiedName('SET_TITLE');
 export const setTitle = createAction(SET_TITLE);
 

--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -28,6 +28,7 @@ class Drawer extends React.Component {
     this.drawer.listen('MDCTemporaryDrawer:close', onDrawerClose);
     this.updateRequirements();
 
+    // Close drawer on button click; this is a necessary hack to get around MDC limitations
     let item = document.querySelector('#collapse_item');
     if (item) {
       item.addEventListener('click', (evt: MouseEvent) => {
@@ -63,7 +64,7 @@ class Drawer extends React.Component {
     return <aside className="mdc-temporary-drawer mdc-typography" ref={div => this.drawerRoot = div}>
       <nav className="mdc-temporary-drawer__drawer">
         <nav className="mdc-temporary-drawer__content mdc-list">
-          <a id="collapse_item"  className="mdc-list-item mdc-link" href="#">
+          <a id="collapse_item" className="mdc-list-item mdc-link" href="#">
             {SETTINGS.user}
             <i className="material-icons mdc-list-item__end-detail" aria-hidden="true">keyboard_arrow_left</i>
           </a>

--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -27,6 +27,14 @@ class Drawer extends React.Component {
     this.drawer = new MDCTemporaryDrawer(this.drawerRoot);
     this.drawer.listen('MDCTemporaryDrawer:close', onDrawerClose);
     this.updateRequirements();
+
+    let item = document.querySelector('#collapse_item');
+    if (item) {
+      item.addEventListener('click', (evt: MouseEvent) => {
+        evt.preventDefault();
+        onDrawerClose();
+      }, false);
+    }
   }
 
   componentWillUnmount() {
@@ -54,8 +62,8 @@ class Drawer extends React.Component {
     const { collections } = this.props;
     return <aside className="mdc-temporary-drawer mdc-typography" ref={div => this.drawerRoot = div}>
       <nav className="mdc-temporary-drawer__drawer">
-        <nav id="nav-username" className="mdc-temporary-drawer__content mdc-list">
-          <a className="mdc-list-item mdc-link" href="#">
+        <nav className="mdc-temporary-drawer__content mdc-list">
+          <a id="collapse_item"  className="mdc-list-item mdc-link" href="#">
             {SETTINGS.user}
             <i className="material-icons mdc-list-item__end-detail" aria-hidden="true">keyboard_arrow_left</i>
           </a>

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -7,11 +7,14 @@ import _ from 'lodash';
 import OVSToolbar from '../components/OVSToolbar';
 import Footer from '../components/Footer';
 import VideoCard from '../components/VideoCard';
+import Drawer from '../components/material/Drawer';
 import { actions } from '../actions';
+import {setDrawerOpen} from '../actions/commonUi';
 import { getActiveCollectionDetail } from '../lib/collection';
 
 import type { Collection } from '../flow/collectionTypes';
 import type { Video } from '../flow/videoTypes';
+import type { CommonUIState } from "../reducers/commonUi";
 
 class CollectionDetailPage extends React.Component {
   props: {
@@ -21,6 +24,7 @@ class CollectionDetailPage extends React.Component {
     collectionKey: string,
     editable: boolean,
     needsUpdate: boolean,
+    commonUi: CommonUIState
   };
 
   componentDidMount() {
@@ -36,6 +40,11 @@ class CollectionDetailPage extends React.Component {
     if (needsUpdate) {
       dispatch(actions.collections.get(collectionKey));
     }
+  };
+
+  setDrawerOpen = (open: boolean): void => {
+    const { dispatch } = this.props;
+    dispatch(setDrawerOpen(open));
   };
 
   renderCollectionDescription = (description: ?string) => (
@@ -80,7 +89,7 @@ class CollectionDetailPage extends React.Component {
   };
 
   render() {
-    const { collection, collectionError } = this.props;
+    const { collection, collectionError, commonUi } = this.props;
 
     if (!collection) return null;
 
@@ -89,7 +98,8 @@ class CollectionDetailPage extends React.Component {
       : this.renderBody(collection);
 
     return <div>
-      <OVSToolbar setDrawerOpen={() => {}} />
+      <OVSToolbar setDrawerOpen={this.setDrawerOpen.bind(this, true)} />
+      <Drawer open={commonUi.drawerOpen} onDrawerClose={this.setDrawerOpen.bind(this, false)} />
       <div className="collection-detail-content">
         { detailBody }
       </div>
@@ -100,7 +110,7 @@ class CollectionDetailPage extends React.Component {
 
 const mapStateToProps = (state, ownProps) => {
   const { match } = ownProps;
-  const { collections } = state;
+  const { collections, commonUi } = state;
 
   const collection = collections.loaded && collections.data ? collections.data : null;
   const collectionError = collections.error || null;
@@ -113,7 +123,8 @@ const mapStateToProps = (state, ownProps) => {
     collectionKey,
     collection,
     collectionError,
-    needsUpdate
+    needsUpdate,
+    commonUi
   };
 };
 

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -9,12 +9,12 @@ import Footer from '../components/Footer';
 import VideoCard from '../components/VideoCard';
 import Drawer from '../components/material/Drawer';
 import { actions } from '../actions';
-import {setDrawerOpen} from '../actions/commonUi';
+import { setDrawerOpen } from '../actions/commonUi';
 import { getActiveCollectionDetail } from '../lib/collection';
 
 import type { Collection } from '../flow/collectionTypes';
 import type { Video } from '../flow/videoTypes';
-import type { CommonUIState } from "../reducers/commonUi";
+import type { CommonUiState } from "../reducers/commonUi";
 
 class CollectionDetailPage extends React.Component {
   props: {
@@ -24,7 +24,7 @@ class CollectionDetailPage extends React.Component {
     collectionKey: string,
     editable: boolean,
     needsUpdate: boolean,
-    commonUi: CommonUIState
+    commonUi: CommonUiState
   };
 
   componentDidMount() {

--- a/static/js/containers/CollectionDetailPage_test.js
+++ b/static/js/containers/CollectionDetailPage_test.js
@@ -91,4 +91,11 @@ describe('CollectionDetailPage', () => {
       assert.equal(titleText.indexOf(`(${videoCount})`) >= 0, shouldShow);
     });
   });
+
+  it('has a toolbar whose handler will dispatch an action to open the drawer', async () => {
+    let wrapper = await renderPage();
+    wrapper.find(".menu-button").simulate('click');
+    assert.isTrue(store.getState().commonUi.drawerOpen);
+  });
+
 });

--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -8,9 +8,11 @@ import { Link } from "react-router-dom";
 
 import { actions } from '../actions';
 import OVSToolbar from '../components/OVSToolbar';
+import Drawer from '../components/material/Drawer';
 import Footer from '../components/Footer';
 import { makeCollectionUrl } from "../lib/urls";
-
+import {setDrawerOpen} from "../actions/commonUi";
+import type { CommonUIState } from "../reducers/commonUi";
 import type { Collection } from "../flow/collectionTypes";
 
 class CollectionListPage extends React.Component {
@@ -19,6 +21,7 @@ class CollectionListPage extends React.Component {
     collections: Array<Collection>,
     editable: boolean,
     needsUpdate: boolean,
+    commonUi: CommonUIState
   };
 
   componentDidMount() {
@@ -34,6 +37,11 @@ class CollectionListPage extends React.Component {
     if (needsUpdate) {
       dispatch(actions.collectionsList.get());
     }
+  };
+
+  setDrawerOpen = (open: boolean): void => {
+    const { dispatch } = this.props;
+    dispatch(setDrawerOpen(open));
   };
 
   renderCollectionLinks() {
@@ -61,6 +69,7 @@ class CollectionListPage extends React.Component {
   }
 
   render() {
+    const {commonUi} = this.props;
     const formLink = SETTINGS.editable
       ? (
         <a href="/collection_form">
@@ -71,7 +80,8 @@ class CollectionListPage extends React.Component {
       : null;
 
     return <div>
-      <OVSToolbar setDrawerOpen={() => {}} />
+      <OVSToolbar setDrawerOpen={this.setDrawerOpen.bind(this, true)} />
+      <Drawer open={commonUi.drawerOpen} onDrawerClose={this.setDrawerOpen.bind(this, false)} />
       <div className="collection-list-content">
         <div className="centered-content">
           <h2>Collections</h2>
@@ -85,12 +95,13 @@ class CollectionListPage extends React.Component {
 }
 
 const mapStateToProps = (state) => {
-  const { collectionsList } = state;
+  const { collectionsList, commonUi } = state;
   const collections = collectionsList.loaded ? collectionsList.data : [];
   const needsUpdate = !collectionsList.processing && !collectionsList.loaded;
 
   return {
     collections,
+    commonUi,
     needsUpdate
   };
 };

--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -11,8 +11,8 @@ import OVSToolbar from '../components/OVSToolbar';
 import Drawer from '../components/material/Drawer';
 import Footer from '../components/Footer';
 import { makeCollectionUrl } from "../lib/urls";
-import {setDrawerOpen} from "../actions/commonUi";
-import type { CommonUIState } from "../reducers/commonUi";
+import { setDrawerOpen } from "../actions/commonUi";
+import type { CommonUiState } from "../reducers/commonUi";
 import type { Collection } from "../flow/collectionTypes";
 
 class CollectionListPage extends React.Component {
@@ -21,7 +21,7 @@ class CollectionListPage extends React.Component {
     collections: Array<Collection>,
     editable: boolean,
     needsUpdate: boolean,
-    commonUi: CommonUIState
+    commonUi: CommonUiState
   };
 
   componentDidMount() {
@@ -69,7 +69,7 @@ class CollectionListPage extends React.Component {
   }
 
   render() {
-    const {commonUi} = this.props;
+    const { commonUi } = this.props;
     const formLink = SETTINGS.editable
       ? (
         <a href="/collection_form">

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -7,7 +7,7 @@ import type { Dispatch } from "redux";
 import Button from '../components/material/Button';
 import Dialog from '../components/material/Dialog';
 import Drawer from '../components/material/Drawer';
-import Toolbar from '../components/material/Toolbar';
+import OVSToolbar from '../components/OVSToolbar';
 import Footer from '../components/Footer';
 import VideoPlayer from '../components/VideoPlayer';
 import Textfield from "../components/material/Textfield";
@@ -16,19 +16,20 @@ import Textarea from "../components/material/Textarea";
 import { actions } from '../actions';
 import {
   setEditDialogVisibility,
-  setDrawerOpen,
   setTitle,
   setDescription,
   clearEditDialog,
   setShareDialogVisibility,
   clearShareDialog
 } from '../actions/videoDetailUi';
+import {setDrawerOpen} from '../actions/commonUi';
 import { makeCollectionUrl, makeEmbedUrl } from '../lib/urls';
 import { videoIsProcessing, videoHasError } from '../lib/video';
 import { MM_DD_YYYY } from '../constants';
 
 import type { Video } from "../flow/videoTypes";
 import type { VideoDetailUIState } from "../reducers/videoDetailUi";
+import type { CommonUIState } from "../reducers/commonUi";
 
 class VideoDetailPage extends React.Component {
   props: {
@@ -37,6 +38,7 @@ class VideoDetailPage extends React.Component {
     videoKey: string,
     needsUpdate: boolean,
     videoDetailUi: VideoDetailUIState,
+    commonUi: CommonUIState,
     editable: boolean
   };
 
@@ -71,7 +73,7 @@ class VideoDetailPage extends React.Component {
   };
 
   submitForm = () => {
-    const { dispatch, videoKey, videoDetailUi } = this.props;
+    const { dispatch, videoKey, videoDetailUi} = this.props;
     const { editDialog: {title, description} } = videoDetailUi;
 
     dispatch(clearEditDialog());
@@ -126,7 +128,7 @@ class VideoDetailPage extends React.Component {
   };
 
   render() {
-    const { video, videoDetailUi, editable } = this.props;
+    const { video, videoDetailUi, commonUi, editable } = this.props;
     if (!video) {
       return null;
     }
@@ -134,13 +136,8 @@ class VideoDetailPage extends React.Component {
     const formattedCreation = moment(video.created_at).format(MM_DD_YYYY);
     const collectionUrl = makeCollectionUrl(video.collection_key);
     return <div>
-      <Toolbar onClickMenu={this.setDrawerOpen.bind(this, true)}>
-        <img src="/static/images/mit_logo_grey_red.png" className="logo"/>
-        <span className="title">
-          ODL Video Services
-        </span>
-      </Toolbar>
-      <Drawer open={videoDetailUi.drawerOpen} onDrawerClose={this.setDrawerOpen.bind(this, false)} />
+      <OVSToolbar setDrawerOpen={this.setDrawerOpen.bind(this, true)} />
+      <Drawer open={commonUi.drawerOpen} onDrawerClose={this.setDrawerOpen.bind(this, false)} />
       { video ? this.renderVideoPlayer(video) : null }
       <div className="summary">
         <p className="channelLink mdc-typography--subheading1">
@@ -221,14 +218,15 @@ class VideoDetailPage extends React.Component {
 
 const mapStateToProps = (state, ownProps) => {
   const { videoKey } = ownProps;
-  const { videos, videoDetailUi } = state;
+  const { videos, videoDetailUi, commonUi } = state;
   const video = videos.data ? videos.data.get(videoKey) : null;
   const needsUpdate = !videos.processing && !videos.loaded;
 
   return {
     video,
     needsUpdate,
-    videoDetailUi
+    videoDetailUi,
+    commonUi
   };
 };
 

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -22,14 +22,14 @@ import {
   setShareDialogVisibility,
   clearShareDialog
 } from '../actions/videoDetailUi';
-import {setDrawerOpen} from '../actions/commonUi';
+import { setDrawerOpen } from '../actions/commonUi';
 import { makeCollectionUrl, makeEmbedUrl } from '../lib/urls';
 import { videoIsProcessing, videoHasError } from '../lib/video';
 import { MM_DD_YYYY } from '../constants';
 
 import type { Video } from "../flow/videoTypes";
 import type { VideoDetailUIState } from "../reducers/videoDetailUi";
-import type { CommonUIState } from "../reducers/commonUi";
+import type { CommonUiState } from "../reducers/commonUi";
 
 class VideoDetailPage extends React.Component {
   props: {
@@ -38,7 +38,7 @@ class VideoDetailPage extends React.Component {
     videoKey: string,
     needsUpdate: boolean,
     videoDetailUi: VideoDetailUIState,
-    commonUi: CommonUIState,
+    commonUi: CommonUiState,
     editable: boolean
   };
 
@@ -73,7 +73,7 @@ class VideoDetailPage extends React.Component {
   };
 
   submitForm = () => {
-    const { dispatch, videoKey, videoDetailUi} = this.props;
+    const { dispatch, videoKey, videoDetailUi } = this.props;
     const { editDialog: {title, description} } = videoDetailUi;
 
     dispatch(clearEditDialog());

--- a/static/js/containers/VideoDetailPage_test.js
+++ b/static/js/containers/VideoDetailPage_test.js
@@ -176,6 +176,6 @@ describe('VideoDetailPage', () => {
   it('has a toolbar whose handler will dispatch an action to open the drawer', async () => {
     let wrapper = await renderPage();
     wrapper.find(".menu-button").simulate('click');
-    assert.isTrue(store.getState().videoDetailUi.drawerOpen);
+    assert.isTrue(store.getState().commonUi.drawerOpen);
   });
 });

--- a/static/js/reducers/commonUi.js
+++ b/static/js/reducers/commonUi.js
@@ -5,7 +5,7 @@ import {
   SET_DRAWER_OPEN
 } from '../actions/commonUi';
 
-export type CommonUIState = {
+export type CommonUiState = {
   drawerOpen: boolean
 };
 
@@ -13,7 +13,7 @@ export const INITIAL_UI_STATE = {
   drawerOpen: false
 };
 
-const reducer = (state: CommonUIState = INITIAL_UI_STATE, action: Action<any, null>) => {
+const reducer = (state: CommonUiState = INITIAL_UI_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case SET_DRAWER_OPEN:
     return {...state, drawerOpen: action.payload };

--- a/static/js/reducers/commonUi.js
+++ b/static/js/reducers/commonUi.js
@@ -1,0 +1,25 @@
+// @flow
+import type { Action } from '../flow/reduxTypes';
+
+import {
+  SET_DRAWER_OPEN
+} from '../actions/commonUi';
+
+export type CommonUIState = {
+  drawerOpen: boolean
+};
+
+export const INITIAL_UI_STATE = {
+  drawerOpen: false
+};
+
+const reducer = (state: CommonUIState = INITIAL_UI_STATE, action: Action<any, null>) => {
+  switch (action.type) {
+  case SET_DRAWER_OPEN:
+    return {...state, drawerOpen: action.payload };
+  default:
+    return state;
+  }
+};
+
+export default reducer;

--- a/static/js/reducers/commonUi_test.js
+++ b/static/js/reducers/commonUi_test.js
@@ -1,0 +1,37 @@
+// @flow
+import sinon from 'sinon';
+import configureTestStore from "redux-asserts";
+import { assert } from 'chai';
+
+import rootReducer from '../reducers';
+import { setDrawerOpen } from '../actions/commonUi';
+import { createAssertReducerResultState } from "../util/test_utils";
+import { INITIAL_UI_STATE } from "./commonUi";
+
+describe('CommonUi', () => {
+  let sandbox, assertReducerResultState, store;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    assertReducerResultState = createAssertReducerResultState(store, state => state.commonUi);
+    store = configureTestStore(rootReducer);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('Should open the drawer in the UI', () => {
+    store.dispatch(setDrawerOpen(true));
+    assert.deepEqual(store.getState().commonUi, {drawerOpen: true});
+  });
+
+  it('Should close the drawer in the UI', () => {
+    store.dispatch(setDrawerOpen(false));
+    assert.deepEqual(store.getState().commonUi, INITIAL_UI_STATE);
+  });
+
+  it('setting the drawer visibility changes state', () => {
+    assertReducerResultState(setDrawerOpen, ui => ui.drawerOpen, false);
+  });
+});

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -5,9 +5,11 @@ import { deriveReducers } from "redux-hammock";
 import { actions } from "../actions";
 import { endpoints } from "../lib/redux_rest";
 import videoDetailUi from './videoDetailUi';
+import commonUi from './commonUi';
 
 const reducers: Object = {
   videoDetailUi,
+  commonUi
 };
 endpoints.forEach(endpoint => {
   reducers[endpoint.name] = deriveReducers(endpoint, actions[endpoint.name]);

--- a/static/js/reducers/videoDetailUi.js
+++ b/static/js/reducers/videoDetailUi.js
@@ -3,7 +3,6 @@ import type { Action } from '../flow/reduxTypes';
 
 import {
   SET_EDIT_DIALOG_VISIBILITY,
-  SET_DRAWER_OPEN,
   SET_TITLE,
   SET_DESCRIPTION,
   CLEAR_EDIT_DIALOG,
@@ -19,8 +18,7 @@ export type VideoDetailUIState = {
   },
   shareDialog: {
     visible: boolean,
-  },
-  drawerOpen: boolean,
+  }
 };
 
 export const INITIAL_UI_STATE = {
@@ -31,8 +29,7 @@ export const INITIAL_UI_STATE = {
   },
   shareDialog: {
     visible: false,
-  },
-  drawerOpen: false,
+  }
 };
 
 const reducer = (state: VideoDetailUIState = INITIAL_UI_STATE, action: Action<any, null>) => {
@@ -43,8 +40,6 @@ const reducer = (state: VideoDetailUIState = INITIAL_UI_STATE, action: Action<an
     return {...state, editDialog: {...state.editDialog, title: action.payload }};
   case SET_DESCRIPTION:
     return {...state, editDialog: {...state.editDialog, description: action.payload }};
-  case SET_DRAWER_OPEN:
-    return {...state, drawerOpen: action.payload };
   case CLEAR_EDIT_DIALOG:
     return {...state, editDialog: INITIAL_UI_STATE.editDialog };
   case SET_SHARE_DIALOG_VISIBILITY:

--- a/static/js/reducers/videoDetailUi_test.js
+++ b/static/js/reducers/videoDetailUi_test.js
@@ -9,14 +9,13 @@ import {
   clearShareDialog,
   setEditDialogVisibility,
   setShareDialogVisibility,
-  setDrawerOpen,
   setTitle,
   setDescription,
 } from '../actions/videoDetailUi';
 import { createAssertReducerResultState } from "../util/test_utils";
 import { INITIAL_UI_STATE } from "./videoDetailUi";
 
-describe('videoDetailUi', () => {
+describe('VideoDetailUi', () => {
   let sandbox, assertReducerResultState, store;
 
   beforeEach(() => {
@@ -55,9 +54,5 @@ describe('videoDetailUi', () => {
   it('should clear the share dialog ui', () => {
     store.dispatch(clearShareDialog());
     assert.deepEqual(store.getState().videoDetailUi, INITIAL_UI_STATE);
-  });
-
-  it('sets the drawer visibility', () => {
-    assertReducerResultState(setDrawerOpen, ui => ui.drawerOpen, false);
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #186 

#### What's this PR do?
- Enables the sandwich menu on the collection detail and collection list pages.
- Moves actions and reducers code for the menu, common to both Collection and Video pages, to `commonUi` files: part of #175 

#### How should this be manually tested?
The sandwich menu should open on each of the following pages when clicking the button at the top left:
- Collections list (home page): `/collections`
- Collection detail pages: `/collections/collection_key`
- Video detail pages: `videos/video_key`
