### PR TITLE
Fix endless loop on forbidden collection pages

### DIFF
--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -38,7 +38,9 @@ class CollectionDetailPage extends React.Component {
   }
 
   componentDidUpdate() {
-    this.updateRequirements();
+    if (!this.props.collectionError) {
+      this.updateRequirements();
+    }
   }
 
   updateRequirements = () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #203 

#### What's this PR do?
Prevents endless requests on forbidden detail pages by adding a condition to `CollectionDetailPage.componentDidUpdate` to run `updateRequirements` only if `props.collectionError` is null.

#### How should this be manually tested?
- As user #1, create a new collection with no moira lists.
- Go to that collection's page, optionally add a video, page should load normally.
- As user #2 (non-admin), load the URL for the above collection.  
  - The header should load on the page with a 'You do not have permission to perform this action' message.  
  - Check the network console to make sure there are no endless requests.
