### PR TITLE
Enable google analytics for video & collection pages

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -1,12 +1,15 @@
 // @flow
 /* global videojs: true */
-import React from 'react';
+import React from "react";
 
 import { makeVideoSubtitleUrl } from "../lib/urls";
 import { getHLSEncodedUrl, videojs } from "../lib/video";
 import type { Video, VideoSubtitle } from "../flow/videoTypes";
 import { FULLSCREEN_API } from "../util/fullscreen_api";
 import { CANVASES } from "../constants";
+import { sendGAEvent } from "../util/google_analytics";
+
+const gaEvents = ["play", "pause", "seeked", "timeupdate", "fullscreen off", "fullscreen on", "ended"];
 
 const makeConfigForVideo = (video: Video): Object => ({
   autoplay: false,
@@ -19,14 +22,14 @@ const makeConfigForVideo = (video: Video): Object => ({
   playbackRates: [0.50, 0.75, 1.0, 1.25, 1.5, 2.0, 4.0],
   sources: [{
     src: getHLSEncodedUrl(video),
-    type: 'application/x-mpegURL',
+    type: "application/x-mpegURL",
   }]
 });
 
 const drawCanvasImage = function(canvas, videoNode, shiftX, shiftY) {
   const x = shiftX ? Math.floor(videoNode.videoWidth / 2) : 0;
   const y = shiftY ? Math.floor(videoNode.videoHeight / 2) : 0;
-  const context = canvas.getContext('2d');
+  const context = canvas.getContext("2d");
   context.drawImage(
     videoNode,
     x, y, Math.floor(videoNode.videoWidth / 2), Math.floor(videoNode.videoHeight / 2),
@@ -51,6 +54,7 @@ export default class VideoPlayer extends React.Component {
   videoNode: HTMLVideoElement;
   videoContainer: HTMLDivElement;
   cameras: HTMLDivElement;
+  percentTracked: Array<number>;
 
   updateSubtitles() {
     const { video } = this.props;
@@ -76,6 +80,18 @@ export default class VideoPlayer extends React.Component {
             srcLang: subtitle.language,
             label: subtitle.language_name,
           }, true);
+        }
+        // Add listeners to each track
+        let player = this.player;
+        for (let idx = 0; idx < this.player.textTracks().length; idx++) {
+          if (!trackUrls.includes(tracks[idx].src)) {
+            tracks[idx].addEventListener("modechange", function() {
+              sendGAEvent(
+                "video",
+                "modechange",
+                `Subtitles for ${this.label} ${this.mode}`, player.currentTime());
+            });
+          }
         }
       });
     }
@@ -103,11 +119,11 @@ export default class VideoPlayer extends React.Component {
     }
   }
 
-  cropVideo() {
+  cropVideo = () => {
     const { selectedCorner } = this.props;
     const shiftX = CANVASES[selectedCorner].shiftX;
     const shiftY = CANVASES[selectedCorner].shiftY;
-    const transformProps = ['transform', 'WebkitTransform', 'MozTransform', 'msTransform', 'OTransform'];
+    const transformProps = ["transform", "WebkitTransform", "MozTransform", "msTransform", "OTransform"];
 
     const prop = transformProps.find(property => this.player.el_.style[property] !== undefined) || transformProps[0];
     const aspectRatio = (this.player.videoWidth() / this.player.videoHeight());
@@ -129,55 +145,87 @@ export default class VideoPlayer extends React.Component {
     this.videoNode.style.left = `${left}px`;
     this.videoNode.style.top = `${top}px`;
     // $FlowFixMe prop does not have to be a number
-    this.videoNode.style[prop] = 'scale(2)';
+    this.videoNode.style[prop] = "scale(2)";
     this.configureCameras();
 
   }
 
-  toggleFullscreen() {
-    if (isFullscreen()) {
+  toggleFullscreen = () => {
+    let fullscreen = isFullscreen();
+    if (fullscreen) {
       // $FlowFixMe
       document[FULLSCREEN_API.exitFullscreen]();
     } else {
       // $FlowFixMe videoContainer.parentElement is not going to be null
       this.videoContainer.parentElement[FULLSCREEN_API.requestFullscreen]();
     }
+    this.player.el_.dispatchEvent(new Event(`fullscreen ${fullscreen ? "off" : "on"}`));
   }
 
-  componentDidMount() {
-    const { video } = this.props;
-    const cropVideo = this.cropVideo.bind(this);
-    const toggleFullscreen = this.toggleFullscreen.bind(this);
-    if (video.multiangle) {
-      videojs.getComponent('FullscreenToggle').prototype.handleClick = toggleFullscreen;
-    }
-    this.player = videojs(
-      this.videoNode, makeConfigForVideo(video), function onPlayerReady() {
-        this.enableTouchActivity();
-        if (video.multiangle) {
-          this.on('loadeddata', cropVideo);
-          this.on(FULLSCREEN_API.fullscreenchange, cropVideo);
-          window.addEventListener('resize', cropVideo);
-        }
+  sendEvent = (action: string, label: string) => {
+    if (action === "timeupdate") {
+      // Track percentage played in increments of 10
+      const currentTime = this.player.currentTime();
+      const duration = this.player.duration();
+      const percentPlayed = currentTime / duration * 100;
+      const percentRoundTen = percentPlayed - (percentPlayed % 10);
+      if (!this.percentTracked.includes(percentRoundTen)) {
+        sendGAEvent("video", action, "percentPlayed", percentRoundTen);
+        this.percentTracked.push(percentRoundTen);
       }
-    );
-    this.updateSubtitles();
+    } else {
+      sendGAEvent("video", action, label, this.player.currentTime());
+    }
   }
 
-  componentDidUpdate() {
-    this.updateSubtitles();
-  }
+ createEventHandler = (action: string, label: string) => {
+   const sendEvent = this.sendEvent;
+   this.player.on(action, function() {
+     sendEvent(action, label);
+   });
+ }
+
+ componentDidMount() {
+   const { video } = this.props;
+   const cropVideo = this.cropVideo;
+   const createEventHandler = this.createEventHandler;
+   const toggleFullscreen = this.toggleFullscreen;
+   if (video.multiangle) {
+     videojs.getComponent("FullscreenToggle").prototype.handleClick = toggleFullscreen;
+   }
+   this.percentTracked = [];
+   this.player = videojs(
+     this.videoNode, makeConfigForVideo(video), function onPlayerReady() {
+       this.enableTouchActivity();
+       if (video.multiangle) {
+         this.on("loadeddata", cropVideo);
+         this.on(FULLSCREEN_API.fullscreenchange, cropVideo);
+         window.addEventListener("resize", cropVideo);
+       }
+       this.on("loadeddata", function() {
+         gaEvents.forEach((event: string) => {
+           createEventHandler(event, event);
+         });
+       });
+     });
+   this.updateSubtitles();
+ }
+
+ componentDidUpdate() {
+   this.updateSubtitles();
+ }
 
   // destroy player on unmount
-  componentWillUnmount() {
-    if (this.player) {
-      this.player.dispose();
-    }
-  }
+ componentWillUnmount() {
+   if (this.player) {
+     this.player.dispose();
+   }
+ }
 
   clickCamera = async (corner: string) => {
     const { cornerFunc } = this.props;
     if (cornerFunc) {
+      sendGAEvent("video", 'changeCameraView', corner, this.player.currentTime());
       await cornerFunc(corner);
       this.cropVideo();
     }
@@ -188,7 +236,7 @@ export default class VideoPlayer extends React.Component {
     return (
       <div className="video-odl-center">
         <div
-          className={`video-odl-medium ${video.multiangle ? 'video-odl-multiangle' : ''}`}
+          className={`video-odl-medium ${video.multiangle ? "video-odl-multiangle" : ""}`}
           ref={node => this.videoContainer = node}>
           <div data-vjs-player>
             <video
@@ -205,7 +253,7 @@ export default class VideoPlayer extends React.Component {
             <div key={corner}>
               <canvas id={corner} key={corner}
                 onClick={this.clickCamera.bind(this, corner)}
-                className={`camera-box ${corner === selectedCorner ? 'camera-box-selected' : ''}`}
+                className={`camera-box ${corner === selectedCorner ? "camera-box-selected" : ""}`}
               />
             </div>)
           )}

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -26,7 +26,7 @@ import type { CommonUiState } from "../reducers/commonUi";
 import type { VideoUiState } from "../reducers/videoUi";
 import VideoSubtitleCard from "../components/VideoSubtitleCard";
 import { updateVideoJsSync } from "../actions/videoUi";
-
+import { initGA, sendGAPageView } from "../util/google_analytics";
 
 class VideoDetailPage extends React.Component {
   props: {
@@ -42,6 +42,8 @@ class VideoDetailPage extends React.Component {
 
   componentDidMount() {
     this.updateRequirements();
+    initGA();
+    sendGAPageView(window.location.pathname);
   }
 
   componentDidUpdate() {

--- a/static/js/containers/VideoEmbedPage.js
+++ b/static/js/containers/VideoEmbedPage.js
@@ -7,6 +7,7 @@ import { updateVideoJsSync } from "../actions/videoUi";
 import VideoPlayer from '../components/VideoPlayer';
 import type { Video } from "../flow/videoTypes";
 import type { VideoUiState } from "../reducers/videoUi";
+import { initGA, sendGAPageView } from "../util/google_analytics";
 
 class VideoEmbedPage extends React.Component {
 
@@ -17,6 +18,8 @@ class VideoEmbedPage extends React.Component {
   };
 
   componentDidMount() {
+    initGA();
+    sendGAPageView(window.location.pathname);
   }
 
   updateCorner = (corner: string) => {

--- a/static/js/util/google_analytics.js
+++ b/static/js/util/google_analytics.js
@@ -1,0 +1,39 @@
+// @flow
+/* global SETTINGS:false */
+import ga from "react-ga";
+import R from "ramda";
+
+const makeGAEvent = (category, action, label, value) => ({
+  category: category,
+  action:   action,
+  label:    label,
+  value:    Math.round(value)
+});
+
+const isValidNumber = (R.both(R.is(Number), R.complement(R.equals(NaN))));
+
+const removeInvalidValue = R.when(
+  R.compose(R.complement(isValidNumber), R.prop("value")),
+  R.dissoc("value")
+);
+const formatGAEvent = R.compose(removeInvalidValue, makeGAEvent);
+
+export const sendGAEvent = (
+  category: string,
+  action: string,
+  label: string,
+  value?: number
+) => {
+  ga.event(formatGAEvent(category, action, label, value));
+};
+
+export const sendGAPageView = (page: string) => {
+  ga.pageview(page);
+};
+
+export const initGA = () => {
+  const debug = SETTINGS.reactGaDebug === "true";
+  if (SETTINGS.gaTrackingID) {
+    ga.initialize(SETTINGS.gaTrackingID, { debug: debug });
+  }
+};

--- a/static/js/util/google_analytics_test.js
+++ b/static/js/util/google_analytics_test.js
@@ -1,0 +1,84 @@
+// @flow
+import sinon from "sinon";
+import ga from "react-ga";
+import { assert } from "chai";
+
+import { sendGAEvent } from "./google_analytics";
+
+describe("Google Analytics", () => {
+  let event, sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    event = sandbox.stub(ga, "event");
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe("sendGAEvent", () => {
+    it("should send an event to GA properly", () => {
+      sendGAEvent("category", "action", "label", 1);
+      assert(
+        event.calledWith({
+          category: "category",
+          action:   "action",
+          label:    "label",
+          value:    1
+        }),
+        "should be called with the right values"
+      );
+    });
+
+    it("should not include `value` if it is undefined", () => {
+      sendGAEvent("category", "action", "label");
+      assert(
+        event.calledWith({
+          category: "category",
+          action:   "action",
+          label:    "label"
+        }),
+        "there should not be a value for 'value'"
+      );
+    });
+
+    it("should not include `value` if it is not a valid number", () => {
+      // $FlowFixMe
+      sendGAEvent("category", "action", "label", "hello");
+      assert(
+        event.calledWith({
+          category: "category",
+          action:   "action",
+          label:    "label"
+        }),
+        "there should not be a value for 'value'"
+      );
+    });
+
+    it("`value` string should be converted to a valid integer if possible", () => {
+      // $FlowFixMe
+      sendGAEvent("category", "action", "label", "45.5");
+      assert(
+        event.calledWith({
+          category: "category",
+          action:   "action",
+          label:    "label",
+          value:    46
+        }),
+        "there should not be a value for 'value'"
+      );
+    });
+
+    it("`value` float should be converted to a valid integer if possible", () => {
+      sendGAEvent("category", "action", "label", 45.5);
+      assert(
+        event.calledWith({
+          category: "category",
+          action:   "action",
+          label:    "label",
+          value:    46
+        }),
+        "there should not be a value for 'value'"
+      );
+    });
+  });
+});


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #139
Fixes #304 
Fixes #305

#### What's this PR do?
- Adds google analytics tracking  (pageviews, video player events) to `/collections` and `/videos` pages

#### How should this be manually tested?
- Create a Google analytics account, use something like `http://ovs.mit.edu:8089` for the website URL
- Update your `/etc/hosts` file so that the above domain points to your docker IP.
- Set `GA_TRACKING_ID=<your account id>` in your `.env` file
- Go to the `REAL-TIME/Overview` tab of your Google Analytics account.
- In another tab, start visiting pages in OVS using 'http://ovs.mit.edu:8089" as the URL.  For each page wait a couple seconds after loading, and it should appear in the GA console under `Top Active Pages`
- On a video detail page, open up the network tab of the developer console.  Play, pause, and FF the video, turn subcaptions on/off, go in/out of fullscreen.  For each of these, a 'collect' POST request should be sent to Google Analytics.
