### PR TITLE
Fix scrollbar issue when dialog is closed.

### DIFF
--- a/static/js/components/material/Dialog.js
+++ b/static/js/components/material/Dialog.js
@@ -22,6 +22,18 @@ export default class Dialog extends React.Component {
   // $FlowFixMe: Flow doesn't like the extra props that aren't part of mdc.dialog class
   props: DialogProps;
 
+  showMdc() {
+    if (this.dialog) {
+      this.dialog.show();
+    }
+  }
+
+  destroyMdc() {
+    if (this.dialog) {
+      this.dialog.destroy();
+    }
+  }
+
   componentDidMount() {
     const { open, onAccept, onCancel } = this.props;
 
@@ -33,25 +45,20 @@ export default class Dialog extends React.Component {
     // $FlowFixMe: Flow thinks this.dialog might be null
     this.dialog.listen('MDCDialog:cancel', onCancel);
     if (open) {
-      // $FlowFixMe: Flow thinks this.dialog might be null
-      this.dialog.show();
+      this.showMdc();
     }
   }
 
   componentWillUnmount() {
-    if (this.dialog) {
-      this.dialog.destroy();
-    }
+    this.destroyMdc();
   }
 
   componentWillReceiveProps(nextProps: DialogProps) {
-    if (this.dialog) {
-      if (this.props.open !== nextProps.open) {
-        if (nextProps.open) {
-          this.dialog.show();
-        } else {
-          this.dialog.close();
-        }
+    if (this.props.open !== nextProps.open) {
+      if (nextProps.open) {
+        this.showMdc();
+      } else {
+        this.destroyMdc();
       }
     }
   }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #213 

#### What's this PR do?
Destroys MDC dialogs instead of closing them, and recreates them again as necessary.

#### How should this be manually tested?
- On a video detail page:
  - Scroll down, click the 'Edit' button, make changes, and click the 'Save' button.  The browser scrollbar should still work. Repeat multiple times to ensure the dialog continues to open and close properly.
  - Click the 'Share' button to open the dialog, then close it.  Make sure scrolling still works. Repeat multiple times.

- On a collection detail page with 2+ videos:
  - Click the edit button of at least 2 videos, make changes, save, then repeat again. Make sure the scrollbar still works and the dialogs still function properly.
  - Repeat the above with the video share buttons.
