### PR TITLE
Display video counts for collections

### DIFF
--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -48,6 +48,9 @@ class CollectionListPage extends React.Component {
             <Link to={makeCollectionUrl(collection.key)}>
               {collection.title}
             </Link>
+            <span className="mdc-list-item__text__secondary">
+              {collection.video_count} Videos
+            </span>
           </span>
         </li>
       ))}

--- a/static/js/containers/CollectionListPage_test.js
+++ b/static/js/containers/CollectionListPage_test.js
@@ -87,4 +87,10 @@ describe('CollectionListPage', () => {
     wrapper.find(".menu-button").simulate('click');
     assert.isTrue(store.getState().commonUi.drawerOpen);
   });
+
+  it('has video counts per collection', async () => {
+    let wrapper = await renderPage();
+    let counts = wrapper.find(".mdc-list-item__text__secondary");
+    assert.equal(counts.at(0).text(), `${collections[2].video_count} Videos`);
+  });
 });

--- a/static/js/factories/collection.js
+++ b/static/js/factories/collection.js
@@ -11,7 +11,9 @@ export const makeCollection = (collectionKey: string = casual.uuid): Collection 
   title: casual.text,
   description: casual.text,
   videos: makeVideos(2),
+  video_count: 2,
   view_lists: casual.array_of_words(2),
   admin_lists: casual.array_of_words(2),
   is_admin: true
 });
+

--- a/static/js/flow/collectionTypes.js
+++ b/static/js/flow/collectionTypes.js
@@ -7,7 +7,8 @@ export type CollectionListItem = {
   title:              string,
   description:        ?string,
   view_lists:         Array<string>,
-  admin_lists:        Array<string>
+  admin_lists:        Array<string>,
+  video_count:        number
 };
 
 export type Collection = CollectionListItem & {

--- a/static/js/lib/collection.js
+++ b/static/js/lib/collection.js
@@ -44,6 +44,7 @@ export function makeInitializedForm(collection: ?CollectionListItem): Collection
       description: '',
       view_lists: [],
       admin_lists: [],
+      video_count: 0
     };
   }
   let viewChoice = collection.view_lists.length === 0
@@ -60,6 +61,7 @@ export function makeInitializedForm(collection: ?CollectionListItem): Collection
     viewChoice: viewChoice,
     viewLists: _.join(collection.view_lists, ','),
     adminChoice: adminChoice,
-    adminLists: _.join(collection.admin_lists, ',')
+    adminLists: _.join(collection.admin_lists, ','),
+    videoCount: collection.video_count
   };
 }

--- a/static/js/lib/collection_test.js
+++ b/static/js/lib/collection_test.js
@@ -74,6 +74,7 @@ describe('collection library function', () => {
       adminLists: "",
       viewChoice: PERM_CHOICE_NONE,
       viewLists: "",
+      videoCount: 0
     });
   });
 
@@ -87,6 +88,7 @@ describe('collection library function', () => {
       adminLists: collection.admin_lists.join(","),
       viewChoice: PERM_CHOICE_LISTS,
       viewLists: collection.view_lists.join(","),
+      videoCount: collection.video_count
     });
   });
 });

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -1,5 +1,5 @@
 $mit-red: #a31e31;
-$body-bg-color: #f5f5f5;
+$body-bg-color: #fff;
 $linkcolor: #2568be;
 $icon-color: #007de1;
 $icon-hover: #30a2fd;

--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -108,6 +108,7 @@ class CollectionSerializer(serializers.ModelSerializer):
     Serializer for Collection Model
     """
     key = serializers.SerializerMethodField()
+    video_count = serializers.SerializerMethodField()
     videos = VideoSerializer(many=True, read_only=True)
     view_lists = SingleAttrRelatedField(
         model=models.MoiraList, attribute="name", many=True, allow_empty=True
@@ -120,6 +121,10 @@ class CollectionSerializer(serializers.ModelSerializer):
     def get_key(self, obj):
         """Custom getter for the key"""
         return obj.hexkey
+
+    def get_video_count(self, obj):
+        """Custom getter for video count"""
+        return obj.videos.count()
 
     def get_is_admin(self, obj):
         """Custom field to indicate whether or not the requesting user is an admin"""
@@ -135,6 +140,7 @@ class CollectionSerializer(serializers.ModelSerializer):
             'title',
             'description',
             'videos',
+            'video_count',
             'view_lists',
             'admin_lists',
             'is_admin',
@@ -143,6 +149,7 @@ class CollectionSerializer(serializers.ModelSerializer):
             'key',
             'created_at',
             'videos',
+            'video_count',
             'is_admin',
         )
 
@@ -152,6 +159,7 @@ class CollectionListSerializer(serializers.ModelSerializer):
     Serializer for Collection Model
     """
     key = serializers.SerializerMethodField()
+    video_count = serializers.SerializerMethodField()
     view_lists = SingleAttrRelatedField(
         model=models.MoiraList, attribute="name", many=True, allow_empty=True
     )
@@ -169,6 +177,10 @@ class CollectionListSerializer(serializers.ModelSerializer):
         """Custom getter for the key"""
         return obj.hexkey
 
+    def get_video_count(self, obj):
+        """Custom getter for video count"""
+        return obj.videos.count()
+
     class Meta:
         model = models.Collection
         fields = (
@@ -177,11 +189,13 @@ class CollectionListSerializer(serializers.ModelSerializer):
             'title',
             'description',
             'view_lists',
-            'admin_lists'
+            'admin_lists',
+            'video_count',
         )
         read_only_fields = (
             'key',
             'created_at',
+            'video_count',
         )
 
 

--- a/ui/serializers_test.py
+++ b/ui/serializers_test.py
@@ -25,6 +25,7 @@ def test_collection_serializer():
         'title': collection.title,
         'description': collection.description,
         'videos': serializers.VideoSerializer(videos, many=True).data,
+        'video_count': len(videos),
         'view_lists': [],
         'admin_lists': [],
         'is_admin': None
@@ -63,7 +64,8 @@ def test_collection_list_serializer():
         'title': collection.title,
         'description': collection.description,
         'view_lists': [],
-        'admin_lists': []
+        'admin_lists': [],
+        'video_count': collection.videos.count(),
     }
     assert serializers.CollectionListSerializer(collection).data == expected
 


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #241 
- Changes the body bgcolor to `#fff` (Robert's request).

#### What's this PR do?
Displays the number of videos for each collection on the collection list page (`/collections/`)

#### How should this be manually tested?
- Log in & go to home page 
- If necessary, create some collections and upload videos to each.
- You should see `n Videos` for each collection:

![image](https://user-images.githubusercontent.com/20047260/30445436-eebe1b20-9953-11e7-941a-0866ff0e7240.png)