### PR TITLE
Added max height and inner scroll bar to dialog body

### DIFF
--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -16,10 +16,6 @@ body {
   line-height: 1.4rem;
 }
 
-.mdc-dialog__body {
-  font-size: 1rem;
-}
-
 p.channelLink {
   margin-bottom: 0px;
 }
@@ -63,6 +59,21 @@ button {
     font-size: 18px;
     font-weight: 400;
     margin: 10px 0 7px 10px;
+  }
+}
+
+/*---------------------------------------
+   SECTION:  DIALOG STYLES
+-----------------------------------------*/
+
+.mdc-dialog {
+  .mdc-dialog__surface {
+    max-height: 90%;
+  }
+
+  .mdc-dialog__body {
+    font-size: 1rem;
+    overflow-y: scroll;
   }
 }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #205 

#### What's this PR do?
Adds max height and inner scroll bar to dialog body

#### How should this be manually tested?
Open a dialog and resize the window vertically. The header and footer should display as normal, and the body content section should collapse and become scrollable.

#### Any background context you want to provide?
OSX defaults to hiding the internal scroll bar, which can be a UX issue (users might not know that the section is scrollable). I did a lot of tinkering to see what would get them remain visible in, but couldn't quite figure it out. We can dig a little deeper if we think it's a dealbreaker

#### Screenshots (if appropriate)
<img width="1076" alt="ss 2017-09-18 at 14 35 23" src="https://user-images.githubusercontent.com/14932219/30558991-1e191bce-9c81-11e7-9847-5473c7a0ffbb.png">
<img width="962" alt="ss 2017-09-18 at 14 47 34" src="https://user-images.githubusercontent.com/14932219/30558989-1e153d42-9c81-11e7-9caa-c4488fef3f78.png">
<img width="920" alt="ss 2017-09-18 at 14 47 47" src="https://user-images.githubusercontent.com/14932219/30558990-1e15a9c6-9c81-11e7-88dc-5a7447e0227c.png">

