### PR TITLE
Expanded collections list to include view-enabled collections

### DIFF
--- a/ui/factories.py
+++ b/ui/factories.py
@@ -10,6 +10,7 @@ from factory import (
     SubFactory,
     LazyAttribute,
     Trait,
+    post_generation,
 )
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText, FuzzyInteger
@@ -40,6 +41,22 @@ class CollectionFactory(DjangoModelFactory):
 
     class Meta:
         model = models.Collection
+
+    @post_generation
+    def admin_lists(self, create, extracted, **kwargs):  # pylint:disable=unused-argument
+        """Post-generation hook to handle admin_lists (if provided)"""
+        if create and extracted:
+            # An object was created and admin_lists were passed in
+            for moira_list in extracted:
+                self.admin_lists.add(moira_list)
+
+    @post_generation
+    def view_lists(self, create, extracted, **kwargs):  # pylint:disable=unused-argument
+        """Post-generation hook to handle admin_lists (if provided)"""
+        if create and extracted:
+            # An object was created and view_lists were passed in
+            for moira_list in extracted:
+                self.view_lists.add(moira_list)
 
 
 class VideoFactory(DjangoModelFactory):

--- a/ui/models.py
+++ b/ui/models.py
@@ -59,12 +59,12 @@ class CollectionManager(models.Manager):
         Returns:
             A list of collections the user has view access to.
         """
-        user_lists = utils.user_moira_lists(user)
         if user.is_superuser:
             return self.all()
+        moira_list_qset = MoiraList.objects.filter(name__in=utils.user_moira_lists(user))
         return self.filter(
-            models.Q(view_lists__in=MoiraList.objects.filter(name__in=user_lists)) |
-            models.Q(admin_lists__in=MoiraList.objects.filter(name__in=user_lists)) |
+            models.Q(view_lists__in=moira_list_qset) |
+            models.Q(admin_lists__in=moira_list_qset) |
             models.Q(owner=user)).distinct()
 
     def all_admin(self, user):

--- a/ui/views.py
+++ b/ui/views.py
@@ -187,7 +187,7 @@ class CollectionViewSet(viewsets.ModelViewSet):
         """
         if self.kwargs.get('key') is not None:
             return Collection.objects.all()
-        return Collection.objects.all_admin(self.request.user)
+        return Collection.objects.all_viewable(self.request.user)
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #250

#### What's this PR do?
Expands collections list to include collections that a user has view permissions for (as opposed to admin-only)

#### How should this be manually tested?
- Create a user (non-staff, non-superuser) that belongs to one moira list
- Change/create a collection that includes the above moira list in it's view permissions

On master, that collection should not be visible to your user. On this branch, it should.

