### PR TITLE
Set logout redirect

### DIFF
--- a/ui/urls.py
+++ b/ui/urls.py
@@ -1,5 +1,7 @@
 """urls for ui"""
+from django.conf import settings
 from django.conf.urls import url, include
+from django.contrib.auth.views import logout as django_logout_view
 from rest_framework import routers
 from ui import views
 
@@ -11,6 +13,7 @@ urlpatterns = [
     url(r'^$', views.Index.as_view(), name='index'),
     url(r'^register/$', views.register, name='register'),
     url(r'^login/$', views.ui_login, name='login'),
+    url(r'^logout/$', django_logout_view, {'next_page': settings.LOGIN_URL}),
 
     url(r'^collections/', views.CollectionReactView.as_view(), name='collection-react-view'),
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #208

#### What's this PR do?
Sets logout redirect

#### How should this be manually tested?
Logout via the drawer, make sure you are sent directly to the login page

#### Any background context you want to provide?
I don't _think_ this will complicate anything with the touchstone login flow, but we may want to get some other opinions on that. The fact that we have a route defined for `/login`, which shouldn't be used with touchstone, makes me think it won't be problematic
