### PR TITLE
Fixes Safari Layout bug on Collection Details page

### DIFF
--- a/static/js/components/VideoCard.js
+++ b/static/js/components/VideoCard.js
@@ -63,7 +63,7 @@ const VideoCard = (props: VideoCardProps) => {
         !hasError &&
         <a className="material-icons share-link" onClick={props.showShareDialog}>share</a>
       }
-      </div>
+    </div>
   </Card>;
 };
 

--- a/static/js/components/VideoCard.js
+++ b/static/js/components/VideoCard.js
@@ -53,17 +53,17 @@ const VideoCard = (props: VideoCardProps) => {
       <h4 className="mdc-typography--subheading2">
         { title }
       </h4>
-      <div className="actions">
-        {
-          props.isAdmin &&
-          <a className="material-icons edit-link" onClick={props.showEditDialog}>mode_edit</a>
-        }
-        {
-          !hasError &&
-          <a className="material-icons share-link" onClick={props.showShareDialog}>share</a>
-        }
-      </div>
     </div>
+    <div className="actions">
+      {
+        props.isAdmin &&
+        <a className="material-icons edit-link" onClick={props.showEditDialog}>mode_edit</a>
+      }
+      {
+        !hasError &&
+        <a className="material-icons share-link" onClick={props.showShareDialog}>share</a>
+      }
+      </div>
   </Card>;
 };
 

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -177,6 +177,7 @@ $video-card-width: 31.33%;
       background-color: #ffffff;
       width: $video-card-width;
       overflow: hidden;
+      position: relative;
 
       @include breakpoint(mobile) {
         width: 47%;
@@ -193,7 +194,7 @@ $video-card-width: 31.33%;
       .message {
         padding: 25px;
         min-height: 180px;
-        background-color: #313131;
+        background-color: #272727;
         color: #fff;
 
         a, a:hover, a:visited {
@@ -232,36 +233,30 @@ $video-card-width: 31.33%;
       }
 
       .video-card-body {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
         padding: 10px 15px 14px;
-        height: 100%;
+        margin: 0 0 29px 0;
 
         h4 {
-          flex-shrink: 1;
           margin: 0;
           padding: 8px;
           line-height: 1.3rem;
-          overflow: hidden;
           font-weight: 400;
 
           a {
             color: rgba(0,0,0,.87);
           }
         }
+      }
 
-        .actions {
-          align-self: flex-end;
-          flex-wrap: nowrap;
-          flex-shrink: 0;
-          margin: 17px 0 0 0;
-          padding: 0 6px;
-          color: #9a9a9a;
+      .actions {
+        margin: 0;
+        padding: 0 6px;
+        position: absolute;
+        bottom: 11px;
+        right: 15px;
 
-          * {
-            margin-left: 10px;
-          }
+        * {
+          margin-left: 10px;
         }
       }
     }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #244

#### What's this PR do?
This fixes a layout issue in Safari, where Safari is apparently incorrectly implementing flex display. The goal is to both fix the bug (where video titles were not being displayed at all), and also to have the action icons in a video card always be sticking to the bottom of the video card. I did this by absolute positioning the icons inside the card.

#### How should this be manually tested?
See that it looks like in the mock, and that the css is valid, and that it works in Safari.

#### Where should the reviewer start?
Open the video app in Safari.

Should look like this:

![image](https://user-images.githubusercontent.com/20047260/30606974-7f035dbc-9d41-11e7-916c-4851549f8117.png)
