### PR TITLE
Responsive styles for widescreen layout of collection page

### DIFF
--- a/static/scss/_breakpoints.scss
+++ b/static/scss/_breakpoints.scss
@@ -1,14 +1,22 @@
 @mixin breakpoint($name) {
-  @if $name == desktop {
-    @media (min-width: 1000px) {
+  @if $name == ultrawide {
+    @media (min-width: 2100px) {
+      @content;
+    }
+  } @else if $name == widescreen {
+    @media (min-width: 1600px) and (max-width: 2099px) {
+      @content;
+    }
+  } @else if $name == desktop {
+    @media (min-width: 1000px) and (max-width: 1599px) {
       @content;
     }
   } @else if $name == mobile {
-    @media (max-width: 999px) {
+    @media (min-width: 580px) and (max-width: 999px) {
       @content;
     }
   } @else if $name == phone {
-    @media (max-width: 580px) {
+    @media (max-width: 579px) {
       @content;
     }
   }

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -1,4 +1,4 @@
-$video-card-width: 31.33%;
+$video-card-width: 19%;
 
 .collection-list-content,
 .collection-detail-content {
@@ -82,7 +82,6 @@ $video-card-width: 31.33%;
   .centered-content {
     margin: 0 auto;
     width: 90%;
-    max-width: 1480px;
     box-sizing: border-box;
 
     @include breakpoint(mobile) {
@@ -173,15 +172,25 @@ $video-card-width: 31.33%;
     align-items: stretch;
 
     .video-card {
-      margin: 0 1% 40px;
+      margin: 0 .5% 40px;
       background-color: #ffffff;
       width: $video-card-width;
       overflow: hidden;
       position: relative;
 
-      @include breakpoint(mobile) {
-        width: 47%;
+      @include breakpoint(widescreen) {
+        width: 23.6%;
+        margin: 0 .7% 40px;
       }
+
+      @include breakpoint(desktop) {
+        width: 31.33%;
+      }
+
+      @include breakpoint(mobile) {
+        width: 48%;
+      }
+
       @include breakpoint(phone) {
         width: 100%;
         margin: 0 0 25px;

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -185,10 +185,12 @@ $video-card-width: 19%;
 
       @include breakpoint(desktop) {
         width: 31.33%;
+        margin: 0 1% 40px;
       }
 
       @include breakpoint(mobile) {
         width: 48%;
+        margin: 0 1% 40px;
       }
 
       @include breakpoint(phone) {


### PR DESCRIPTION
#### What's this PR do?
This PR makes the collection detail page responsive for widescreen and ultra-widescreen layouts. Specifically, at widescreen we show a grid of 4 across, at ultrawide, we show 5 across.

#### How should this be manually tested?
See that the responsive styles work, and the code is valid.

