### PR TITLE
Fixed bug with unusable scrollbars after saving a dialog form

### DIFF
--- a/static/js/components/dialogs/CollectionFormDialog.js
+++ b/static/js/components/dialogs/CollectionFormDialog.js
@@ -80,7 +80,6 @@ class CollectionFormDialog extends React.Component {
     const {
       dispatch,
       history,
-      hideDialog,
       collectionUi: { isNew },
       collectionForm,
     } = this.props;
@@ -98,7 +97,6 @@ class CollectionFormDialog extends React.Component {
     } else {
       await dispatch(actions.collections.patch(collectionForm.key, payload));
     }
-    hideDialog();
     dispatch(uiActions.clearCollectionForm());
   };
 
@@ -125,7 +123,7 @@ class CollectionFormDialog extends React.Component {
         title={title}
         cancelText="Cancel"
         submitText={submitText}
-        onCancel={hideDialog}
+        hideDialog={hideDialog}
         onAccept={this.submitForm}
         open={open}
       >

--- a/static/js/components/dialogs/CollectionFormDialog_test.js
+++ b/static/js/components/dialogs/CollectionFormDialog_test.js
@@ -155,7 +155,6 @@ describe('CollectionFormDialog', () => {
           sinon.assert.calledWith(apiStub, collection.key, expectedRequestPayload);
           sinon.assert.notCalled(historyPushStub);
         }
-        sinon.assert.calledWith(hideDialogStub);
         assert.isTrue(store.getState().collectionUi.isNew);
       });
     });

--- a/static/js/components/dialogs/EditVideoFormDialog.js
+++ b/static/js/components/dialogs/EditVideoFormDialog.js
@@ -67,7 +67,6 @@ class EditVideoFormDialog extends React.Component {
   submitForm = async () => {
     const {
       dispatch,
-      hideDialog,
       commonUi: { editVideoForm },
       shouldUpdateCollection
     } = this.props;
@@ -77,7 +76,6 @@ class EditVideoFormDialog extends React.Component {
       description: editVideoForm.description
     };
     let video = await dispatch(actions.videos.patch(editVideoForm.key, patchData));
-    hideDialog();
     this.initializeFormWithVideo(video);
     if (shouldUpdateCollection) {
       dispatch(actions.collections.get(video.collection_key));
@@ -97,7 +95,7 @@ class EditVideoFormDialog extends React.Component {
       cancelText="Cancel"
       submitText="Save Changes"
       noSubmit={false}
-      onCancel={hideDialog}
+      hideDialog={hideDialog}
       onAccept={this.submitForm}
       open={open}
     >

--- a/static/js/components/dialogs/ShareVideoDialog.js
+++ b/static/js/components/dialogs/ShareVideoDialog.js
@@ -29,7 +29,7 @@ class ShareVideoDialog extends React.Component {
       id="share-video-dialog"
       cancelText="Close"
       open={open}
-      onCancel={hideDialog}
+      hideDialog={hideDialog}
       noSubmit={true}
     >
       <div className="mdc-form-field mdc-form-field--align-end">

--- a/static/js/components/dialogs/hoc_test.js
+++ b/static/js/components/dialogs/hoc_test.js
@@ -44,7 +44,7 @@ describe('Dialog higher-order component', () => {
           cancelText="Close"
           submitText=""
           noSubmit={true}
-          onCancel={this.props.hideDialog}
+          hideDialog={this.props.hideDialog}
           open={this.props.open}
         >
           Fake Dialog
@@ -109,7 +109,7 @@ describe('Dialog higher-order component', () => {
 
     await listenForActions([SHOW_DIALOG, HIDE_DIALOG], () => {
       wrapper.find(selectors.OPEN_BTN).prop('onClick')();
-      wrapper.find("Dialog").prop('onCancel')();
+      wrapper.find("Dialog").prop('hideDialog')();
     });
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #251

#### What's this PR do?
Fixes bug with unusable scrollbars after saving a dialog form

#### How should this be manually tested?
Open a dialog with a form (edit collection, edit video), make a change, save, then try to scroll on the page after the dialog goes away.
