### PR TITLE
Send emails to admin moira lists

### DIFF
--- a/ui/permissions.py
+++ b/ui/permissions.py
@@ -13,23 +13,11 @@ from rest_framework.permissions import (
 )
 
 from ui.models import Collection
-from ui.utils import user_moira_lists
+from ui.utils import has_common_lists
 
 log = logging.getLogger(__name__)
 
 User = get_user_model()
-
-
-def has_common_lists(user, list_names):
-    """
-    Return true if the user's moira lists overlap with the collection's
-
-    Returns:
-        bool: True if there is any name in list_names which is in the user's moira lists
-    """
-    if user.is_anonymous():
-        return False
-    return len(set(user_moira_lists(user)).intersection(list_names)) > 0
 
 
 def is_staff_or_superuser(user):

--- a/ui/permissions_test.py
+++ b/ui/permissions_test.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.exceptions import ValidationError
-from urllib3.exceptions import SSLError
 
 from ui import factories, permissions
 from ui.factories import CollectionFactory, MoiraListFactory
@@ -561,26 +560,6 @@ def test_collections_admin(mock_moira_client, collection, moira_list, alt_moira_
     mock_moira_client.return_value.user_lists.return_value = [moira_list.name]
     assert collection in Collection.objects.all_admin(alt_moira_data.user)
     assert alt_moira_data.collection not in Collection.objects.all_admin(alt_moira_data.user)
-
-
-def test_user_moira_lists(mock_moira_client, moira_list):
-    """
-    Test that the correct list is returned by user_moira_lists
-    """
-    mock_moira_client.return_value.user_lists.return_value = [moira_list.name]
-    other_user = factories.UserFactory(email='someone@mit.edu')
-    lists = permissions.user_moira_lists(other_user)
-    assert lists == [moira_list.name]
-
-
-def test_user_moira_lists_error(mock_moira_client):
-    """
-    Test that an empty list is returned if the Moira client can't connect
-    """
-    mock_moira_client.side_effect = SSLError()
-    other_user = factories.UserFactory()
-    lists = permissions.user_moira_lists(other_user)
-    assert lists == []
 
 
 def test_subtitle_view_permission_no_matching_lists(mock_moira_client,

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -66,8 +66,20 @@ def user_moira_lists(user):
         moira = get_moira_client()
         return moira.user_lists(moira_user.username, moira_user.type)
     except Exception as exc:  # pylint: disable=broad-except
-        log.exception('Something went wrong with the moira client: %s', str(exc))
+        log.exception('Something went wrong with the moira client for user %s: %s', user.email, str(exc))
         return []
+
+
+def has_common_lists(user, list_names):
+    """
+    Return true if the user's moira lists overlap with the collection's
+
+    Returns:
+        bool: True if there is any name in list_names which is in the user's moira lists
+    """
+    if user.is_anonymous():
+        return False
+    return len(set(user_moira_lists(user)).intersection(list_names)) > 0
 
 
 def get_et_job(job_id):


### PR DESCRIPTION
#### What are the relevant tickets?
#154 

#### What's this PR do?
Sends emails to the admin lists for a collection ('odl-engineering' -> 'odl-engineering@mit.edu', and also to the collection owner if not already in those lists.

#### How should this be manually tested?
NOTE: This might be difficult to test unless you already have existing moira lists with only yourself as a member, since it seems to take awhile for the list emails to work.

- Add valid values for `MAILGUN_KEY` and `MAILGUN_URL` to your .env file.
- Create a moira list with yourself as a member
- As a django user who does not have your MIT email address, but a personal email address, create/modify a collection with the above list as an admin list.
- Upload a short video
- Wait for an email sent to both your email addresses - should get 1 each.
- Repeat the above, but as a django user with your MIT email address.  You should get 1 email sent to your MIT address.
