### PR TITLE
Smaller responsive video thumbnails on Collection Details page

### DIFF
--- a/static/scss/_breakpoints.scss
+++ b/static/scss/_breakpoints.scss
@@ -8,11 +8,11 @@
       @content;
     }
   } @else if $name == desktop {
-    @media (min-width: 1000px) and (max-width: 1599px) {
+    @media (min-width: 1200px) and (max-width: 1599px) {
       @content;
     }
   } @else if $name == mobile {
-    @media (min-width: 580px) and (max-width: 999px) {
+    @media (min-width: 580px) and (max-width: 1199px) {
       @content;
     }
   } @else if $name == phone {

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -1,4 +1,4 @@
-$video-card-width: 19%;
+$video-card-width: 15.6%;
 
 .collection-list-content,
 .collection-detail-content {
@@ -172,30 +172,30 @@ $video-card-width: 19%;
     align-items: stretch;
 
     .video-card {
-      margin: 0 .5% 40px;
-      background-color: #ffffff;
+      margin: 0 .5% 24px;
       width: $video-card-width;
       overflow: hidden;
       position: relative;
+      box-sizing: border-box;
 
       @include breakpoint(widescreen) {
-        width: 23.6%;
-        margin: 0 .7% 40px;
+        width: 19%;
+        margin: 0 .5% 24px;
       }
 
       @include breakpoint(desktop) {
-        width: 31.33%;
-        margin: 0 1% 40px;
+        width: 24%;
+        margin: 0 .5% 24px;
       }
 
       @include breakpoint(mobile) {
-        width: 48%;
-        margin: 0 1% 40px;
+        width: 32%;
+        margin: 0 .5% 24px;
       }
 
       @include breakpoint(phone) {
         width: 100%;
-        margin: 0 0 25px;
+        margin: 0 0 24px;
       }
 
       &:hover {
@@ -225,6 +225,11 @@ $video-card-width: 19%;
       }
 
       .thumbnail {
+        width: 100%;
+        position: relative;
+        padding-top: 56.25%;
+        overflow: hidden;
+        background: black;
 
         a {
           width: 100%;
@@ -233,7 +238,13 @@ $video-card-width: 19%;
         }
 
         img {
-          width: 100%;
+          height: 100%;
+          position: absolute;
+          margin: auto;
+          top: 0;
+          left: 0;
+          bottom: 0;
+          right: 0;
         }
       }
 
@@ -241,17 +252,19 @@ $video-card-width: 19%;
         display: flex;
         flex-direction: column;
         height: 100%;
+        background: #fff;
       }
 
       .video-card-body {
-        padding: 10px 15px 14px;
-        margin: 0 0 29px 0;
+        padding: 15px 16px 16px;
+        margin: 0;
 
         h4 {
           margin: 0;
-          padding: 8px;
-          line-height: 1.3rem;
+          padding: 0;
+          line-height: 1.3;
           font-weight: 400;
+          font-size: .9rem;
 
           a {
             color: rgba(0,0,0,.87);
@@ -265,6 +278,7 @@ $video-card-width: 19%;
         position: absolute;
         bottom: 11px;
         right: 15px;
+        display: none;
 
         * {
           margin-left: 10px;

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -203,17 +203,24 @@ $video-card-width: 15.6%;
       }
 
       .message {
-        padding: 25px;
-        min-height: 180px;
+        padding: 56.25% 0 0;
         background-color: #272727;
         color: #fff;
+        position: relative;
+        overflow: hidden;
+
+        >div {
+          position: absolute;
+          top: 26px;
+          padding: 0 6%;
+        }
 
         a, a:hover, a:visited {
           color: $darkgray-bg-link;
         }
 
         h5 {
-          margin: 16px 0;
+          margin: 0 0 16px 0;
           font-family: Roboto, sans-serif;
           font-size: 17px;
           font-weight: 500;
@@ -221,6 +228,7 @@ $video-card-width: 15.6%;
 
         p {
           opacity: 0.8;
+          font-size: 15px;
         }
       }
 


### PR DESCRIPTION
#### What's this PR do?
This PR makes the thumbnails on the collection details page smaller, and also removes the action buttons on the video card. The video card thumbnails are different sizes depending on the browser width at 5 different screen size ranges (media queries).

Part of the goal is also to remove the "Actions" (ie. Edit and Share) from the Video Card. This PR simply hides the Actions div with display: none. A follow up issue will deal with removing the actual code for the actions and fixing all the tests, javascript, etc.

#### How should this be manually tested?
See that everything works correctly and the css is valid.
