### PR TITLE
Improved lecture capture default video titles

### DIFF
--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -153,7 +153,8 @@ def update_video_statuses(self):  # pylint: disable=unused-argument
 @shared_task(bind=True)
 def monitor_watch_bucket(self):  # pylint: disable=unused-argument
     """
-    Check the watch bucket for any files and import them if found
+    Check the watch bucket for any files and import them if found. All files found in the
+    S3 bucket indicated by 'VIDEO_S3_WATCH_BUCKET' is assumed to be a lecture capture video.
     """
     watch_bucket = get_bucket(settings.VIDEO_S3_WATCH_BUCKET)
     for key in watch_bucket.objects.all():


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #270

#### What's this PR do?
Improves lecture capture default video titles

#### How should this be manually tested?
First, you'll need permission to upload a video to the S3 watch bucket. Once you have that...

1. Put a file titled `MIT-6.046-2017-Spring-lec-mit-0000-2017apr06-0404-L01.mp4` in your OVS project root directory
1. Upload the file to the watch bucket
    ```python
    # In a Django shell...
    from django.conf import settings
    import boto3
    s3 = boto3.resource('s3')
    bucket = s3.Bucket(settings.VIDEO_S3_WATCH_BUCKET)
    filename = 'MIT-6.046-2017-Spring-lec-mit-0000-2017apr06-0404-L01.mp4'
    bucket.upload_file(filename, filename)
    # Wait several seconds to make sure the file uploaded successfully...
    # ...then process the file. This will normally be done in a celery task.
    from ui.utils import get_et_preset, get_bucket, get_et_job
    from cloudsync.api import process_watch_file
    watch_bucket = get_bucket(settings.VIDEO_S3_WATCH_BUCKET)
    for key in watch_bucket.objects.all():
        process_watch_file(key.key)
    ```
1. Check the collection title and video title in the UI once the video is processed. The video title should be "Lecture - April 06, 2017"

#### Where should the reviewer start?
`cloudsync/api.py`

#### Screenshots (if appropriate)
![ss 2017-09-27 at 14 55 44](https://user-images.githubusercontent.com/14932219/30931911-f8e9e83c-a393-11e7-899e-479157f9d489.png)

