### PR TITLE
Fixes Firefox layout bug in video cards thumbnails

### DIFF
--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -129,39 +129,39 @@ class VideoDetailPage extends React.Component {
         <div className="mdc-layout-grid__inner">
           <div className="summary mdc-layout-grid__cell--span-7">
             <div className="card video-summary-card">
-            <p className="channelLink mdc-typography--subheading1">
-              <a className="collection-link" href={collectionUrl}>
-                {video.collection_title}
-              </a>
-            </p>
-            <h2 className="video-title mdc-typography--title">
-              {video.title}
-            </h2>
-            { video.description &&
+              <p className="channelLink mdc-typography--subheading1">
+                <a className="collection-link" href={collectionUrl}>
+                  {video.collection_title}
+                </a>
+              </p>
+              <h2 className="video-title mdc-typography--title">
+                {video.title}
+              </h2>
+              { video.description &&
               <p className="video-description mdc-typography--body1">
                 {video.description}
               </p>
-            }
-            <div className="upload-date mdc-typography--subheading1 fontgray">
-              Uploaded {formattedCreation}
-            </div>
-            <div className="actions">
-              {
-                editable &&
-                <Button
-                  className="edit mdc-button--raised"
-                  onClick={showDialog.bind(this, DIALOGS.EDIT_VIDEO)}
-                >
-                  <span className="material-icons">edit</span> Edit
-                </Button>
               }
-              <Button
-                className="share mdc-button--raised"
-                onClick={showDialog.bind(this, DIALOGS.SHARE_VIDEO)}
-              >
-                <span className="material-icons ">share</span> Share
-              </Button>
-            </div>
+              <div className="upload-date mdc-typography--subheading1 fontgray">
+                Uploaded {formattedCreation}
+              </div>
+              <div className="actions">
+                {
+                  editable &&
+                  <Button
+                    className="edit mdc-button--raised"
+                    onClick={showDialog.bind(this, DIALOGS.EDIT_VIDEO)}
+                  >
+                  <span className="material-icons">edit</span> Edit
+                  </Button>
+                }
+                <Button
+                  className="share mdc-button--raised"
+                  onClick={showDialog.bind(this, DIALOGS.SHARE_VIDEO)}
+                >
+                  <span className="material-icons ">share</span> Share
+                </Button>
+              </div>
             </div>
           </div>
           <div className="video-subtitles mdc-layout-grid__cell--span-5">

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -128,6 +128,7 @@ class VideoDetailPage extends React.Component {
       <div className="mdc-layout-grid mdc-video-detail">
         <div className="mdc-layout-grid__inner">
           <div className="summary mdc-layout-grid__cell--span-7">
+            <div className="card video-summary-card">
             <p className="channelLink mdc-typography--subheading1">
               <a className="collection-link" href={collectionUrl}>
                 {video.collection_title}
@@ -141,10 +142,10 @@ class VideoDetailPage extends React.Component {
                 {video.description}
               </p>
             }
-            <span className="upload-date mdc-typography--subheading1 fontgray">
+            <div className="upload-date mdc-typography--subheading1 fontgray">
               Uploaded {formattedCreation}
-            </span>
-            <span className="actions">
+            </div>
+            <div className="actions">
               {
                 editable &&
                 <Button
@@ -160,7 +161,8 @@ class VideoDetailPage extends React.Component {
               >
                 <span className="material-icons ">share</span> Share
               </Button>
-            </span>
+            </div>
+            </div>
           </div>
           <div className="video-subtitles mdc-layout-grid__cell--span-5">
             <VideoSubtitleCard

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -152,7 +152,7 @@ class VideoDetailPage extends React.Component {
                     className="edit mdc-button--raised"
                     onClick={showDialog.bind(this, DIALOGS.EDIT_VIDEO)}
                   >
-                  <span className="material-icons">edit</span> Edit
+                    <span className="material-icons">edit</span> Edit
                   </Button>
                 }
                 <Button

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -1,11 +1,11 @@
 $mit-red: #a31e31;
-$body-bg-color: #fff;
+$body-bg-color: #f1f1f1;
 $linkcolor: #2568be;
 $icon-color: #ababab;
 $icon-hover: #007de1;
 $fontgray: #666;
 $card-bg-color: #fff;
-$card-shadow: #c7c7c7;
+$card-shadow: rgba(0,0,0,.25);
 $blue-button: #007ee5;
 $dropbox-button-bgcolor: #007ee5;
 $lightgray-bg: #ececec;

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -1,5 +1,5 @@
 $mit-red: #a31e31;
-$body-bg-color: #f1f1f1;
+$body-bg-color: #fff;
 $linkcolor: #2568be;
 $icon-color: #ababab;
 $icon-hover: #007de1;

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -257,8 +257,6 @@ $video-card-width: 15.6%;
       }
 
       .card-contents {
-        display: flex;
-        flex-direction: column;
         height: 100%;
         background: #fff;
       }

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -16,10 +16,6 @@ body {
   line-height: 1.4rem;
 }
 
-p.channelLink {
-  margin-bottom: 0px;
-}
-
 a, a:link, a:visited, a:active {
   color: $linkcolor;
   text-decoration: none;
@@ -57,7 +53,7 @@ button {
 
 .card {
   background-color: $card-bg-color;
-  box-shadow: 1px 2px 11px $card-shadow;
+  box-shadow: 1px 3px 4px $card-shadow;
   border-radius: 3px;
 
   .title {

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -53,7 +53,7 @@ button {
 
 .card {
   background-color: $card-bg-color;
-  box-shadow: 1px 3px 4px $card-shadow;
+  box-shadow: 1px 1px 8px $card-shadow;
   border-radius: 3px;
 
   .title {

--- a/static/scss/videoDetail.scss
+++ b/static/scss/videoDetail.scss
@@ -16,6 +16,14 @@
   @include breakpoint(phone) {
     margin: 30px auto 80px;
   }
+
+  .video-summary-card {
+    padding: 26px 5% 38px;
+
+    p.channelLink {
+      margin: 0px;
+    }
+  }
 }
 
 .actions {


### PR DESCRIPTION
#### What are the relevant tickets?
closes #287 

#### What's this PR do?
This fixes the firefox layout bug by removing a display flex property that was no longer needed. This PR also adds a card to the video details page for the video summary info.

#### How should this be manually tested?
See that everything looks correct in chrome, firefox etc.
