### PR TITLE
Release 0.2.1

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,89 @@
 Release Notes
 =============
 
+Version 0.2.1
+-------------
+
+- Fixes Firefox layout bug in video cards thumbnails (#288)
+- Improved lecture capture default video titles
+- Smaller responsive video thumbnails on Collection Details page (#276)
+- Release 0.2.0
+- Send emails to admin moira lists
+- Fixed bug with unusable scrollbars after saving a dialog form
+- Very minor tweaks (#268)
+- Subtitles for videos
+- Responsive styles for widescreen layout of collection page (#263)
+- Added message for collections with no videos added yet
+- Revert &#34;Fixed bug with redirect destination after touchstone login&#34;
+- Fixes Safari Layout bug on Collection Details page (#255)
+- Fixed bug with redirect destination after touchstone login
+- Set logout redirect
+- Expanded collections list to include view-enabled collections
+- A few more style tweaks to OVS (#247)
+- Removed unused forms (#246)
+- Video counts on collection list page
+- Added max height and inner scroll bar to dialog body
+- Add dialog for creating a new collection (#240)
+- Improved upload UI
+- More styling fixes (#234)
+- Remove owner from serializers, other code cleanup (#237)
+- Sort collections by reverse creation date
+- Fix scrollbar bug with dialogs
+- Enabled video share button on collection detail page
+- Enabled video edit button on collection detail page
+- more UI tweaks (#214)
+- Fix endless loop on forbidden collection pages
+- Added collection edit dialog form
+- Changed default mailgun_url to video.odl.mit.edu domain instead of micromasters as this service has its own mailgun domain
+- Styling the side-drawer (#197)
+- Merge pull request #193 from mitodl/mb/sandwich2
+- footer styles (#194)
+- OVS style changes (#191)
+- Sandwich menu content
+- Created React pages for collection list and detail
+- Let read-only users see the collection detail page
+- Increased the thumbnail size to 600x338
+- Fix height of the USwitch player iframe
+- Working share button
+- style changes to video details page (#162)
+- Restrict collection creation to staff users or superusers.
+- Moira list permissions
+- Indentation error
+- Tweaked regular expression after testing on classroom machine
+- Added some logic to parse output of s3 sync command and get the file names that have been uploaded and then use that list to move those specific files to the synced folder. Also added an entry in the settings file to point to the s3_sync_results_file
+- Implemented video detail page display
+- Reformatted paths for synced and done folders
+- Added function to move files that have been uploaded to S3 to a local folder on the host. Also added that folder to the settings file
+- Use environmental variables as x509 keys
+- Added email notifications on Video change of status
+- Added try/except block for reading config file
+- Monitor and process video files in an S3 watch bucket
+- Changes based on feedback
+- PEP8 compliance changes, feedback from Giovanni, and removed an un-needed setting in the ini file
+- Enable JS tests for travis (#131)
+- Add collectstatic step (#133)
+- Standardize docker-compose.yml
+- Changes based on feedback and removed AWS CLI install since script would need to be run as admin and we want to avoid doing that
+- Fixed bug with multiangle
+- Changes based on feedback
+- Fixed some small problems in the UI
+- Fixed a typo and some spacing
+- Automatically upload videos from specified folder to s3 bucket - Issue#100 - https://github.com/mitodl/odl-video-service/issues/100 Added two files, s3_sync and a setting ini file.
+- Adding scripts for the pre-post compile
+- Added Collections and refactored UI flow
+- Update USwitch component
+- Reformat JSON
+- Update presets
+- Hide the logo in the middle of the video that appears when not playing.
+- Removed scriptjs
+- Fixed and added tests
+- Put USwitch player in an iframe, fix mosaic window, code review improvements
+- Fix tests
+- USwitch player for multiangle videos
+- Introduced mandatory settings
+- Video statuses restricted to a list
+- - Updated AWS transcoder presets JSON to reflect LectureCapture settings     - Tweaked the createpresets management command to output `ET_PRESET_IDS=[list of generated preset ids]
+
 Version 0.2.0
 -------------
 

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -153,7 +153,8 @@ def update_video_statuses(self):  # pylint: disable=unused-argument
 @shared_task(bind=True)
 def monitor_watch_bucket(self):  # pylint: disable=unused-argument
     """
-    Check the watch bucket for any files and import them if found
+    Check the watch bucket for any files and import them if found. All files found in the
+    S3 bucket indicated by 'VIDEO_S3_WATCH_BUCKET' is assumed to be a lecture capture video.
     """
     watch_bucket = get_bucket(settings.VIDEO_S3_WATCH_BUCKET)
     for key in watch_bucket.objects.all():

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -17,7 +17,7 @@ from odl_video.envs import (
     get_string,
 )
 
-VERSION = "0.1.0"
+VERSION = "0.2.1"
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -128,39 +128,41 @@ class VideoDetailPage extends React.Component {
       <div className="mdc-layout-grid mdc-video-detail">
         <div className="mdc-layout-grid__inner">
           <div className="summary mdc-layout-grid__cell--span-7">
-            <p className="channelLink mdc-typography--subheading1">
-              <a className="collection-link" href={collectionUrl}>
-                {video.collection_title}
-              </a>
-            </p>
-            <h2 className="video-title mdc-typography--title">
-              {video.title}
-            </h2>
-            { video.description &&
+            <div className="card video-summary-card">
+              <p className="channelLink mdc-typography--subheading1">
+                <a className="collection-link" href={collectionUrl}>
+                  {video.collection_title}
+                </a>
+              </p>
+              <h2 className="video-title mdc-typography--title">
+                {video.title}
+              </h2>
+              { video.description &&
               <p className="video-description mdc-typography--body1">
                 {video.description}
               </p>
-            }
-            <span className="upload-date mdc-typography--subheading1 fontgray">
-              Uploaded {formattedCreation}
-            </span>
-            <span className="actions">
-              {
-                editable &&
-                <Button
-                  className="edit mdc-button--raised"
-                  onClick={showDialog.bind(this, DIALOGS.EDIT_VIDEO)}
-                >
-                  <span className="material-icons">edit</span> Edit
-                </Button>
               }
-              <Button
-                className="share mdc-button--raised"
-                onClick={showDialog.bind(this, DIALOGS.SHARE_VIDEO)}
-              >
-                <span className="material-icons ">share</span> Share
-              </Button>
-            </span>
+              <div className="upload-date mdc-typography--subheading1 fontgray">
+                Uploaded {formattedCreation}
+              </div>
+              <div className="actions">
+                {
+                  editable &&
+                  <Button
+                    className="edit mdc-button--raised"
+                    onClick={showDialog.bind(this, DIALOGS.EDIT_VIDEO)}
+                  >
+                    <span className="material-icons">edit</span> Edit
+                  </Button>
+                }
+                <Button
+                  className="share mdc-button--raised"
+                  onClick={showDialog.bind(this, DIALOGS.SHARE_VIDEO)}
+                >
+                  <span className="material-icons ">share</span> Share
+                </Button>
+              </div>
+            </div>
           </div>
           <div className="video-subtitles mdc-layout-grid__cell--span-5">
             <VideoSubtitleCard

--- a/static/scss/_breakpoints.scss
+++ b/static/scss/_breakpoints.scss
@@ -8,11 +8,11 @@
       @content;
     }
   } @else if $name == desktop {
-    @media (min-width: 1000px) and (max-width: 1599px) {
+    @media (min-width: 1200px) and (max-width: 1599px) {
       @content;
     }
   } @else if $name == mobile {
-    @media (min-width: 580px) and (max-width: 999px) {
+    @media (min-width: 580px) and (max-width: 1199px) {
       @content;
     }
   } @else if $name == phone {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -5,7 +5,7 @@ $icon-color: #ababab;
 $icon-hover: #007de1;
 $fontgray: #666;
 $card-bg-color: #fff;
-$card-shadow: #c7c7c7;
+$card-shadow: rgba(0,0,0,.25);
 $blue-button: #007ee5;
 $dropbox-button-bgcolor: #007ee5;
 $lightgray-bg: #ececec;

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -257,8 +257,6 @@ $video-card-width: 15.6%;
       }
 
       .card-contents {
-        display: flex;
-        flex-direction: column;
         height: 100%;
         background: #fff;
       }

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -1,4 +1,4 @@
-$video-card-width: 19%;
+$video-card-width: 15.6%;
 
 .collection-list-content,
 .collection-detail-content {
@@ -172,30 +172,30 @@ $video-card-width: 19%;
     align-items: stretch;
 
     .video-card {
-      margin: 0 .5% 40px;
-      background-color: #ffffff;
+      margin: 0 .5% 24px;
       width: $video-card-width;
       overflow: hidden;
       position: relative;
+      box-sizing: border-box;
 
       @include breakpoint(widescreen) {
-        width: 23.6%;
-        margin: 0 .7% 40px;
+        width: 19%;
+        margin: 0 .5% 24px;
       }
 
       @include breakpoint(desktop) {
-        width: 31.33%;
-        margin: 0 1% 40px;
+        width: 24%;
+        margin: 0 .5% 24px;
       }
 
       @include breakpoint(mobile) {
-        width: 48%;
-        margin: 0 1% 40px;
+        width: 32%;
+        margin: 0 .5% 24px;
       }
 
       @include breakpoint(phone) {
         width: 100%;
-        margin: 0 0 25px;
+        margin: 0 0 24px;
       }
 
       &:hover {
@@ -203,17 +203,24 @@ $video-card-width: 19%;
       }
 
       .message {
-        padding: 25px;
-        min-height: 180px;
+        padding: 56.25% 0 0;
         background-color: #272727;
         color: #fff;
+        position: relative;
+        overflow: hidden;
+
+        >div {
+          position: absolute;
+          top: 26px;
+          padding: 0 6%;
+        }
 
         a, a:hover, a:visited {
           color: $darkgray-bg-link;
         }
 
         h5 {
-          margin: 16px 0;
+          margin: 0 0 16px 0;
           font-family: Roboto, sans-serif;
           font-size: 17px;
           font-weight: 500;
@@ -221,10 +228,16 @@ $video-card-width: 19%;
 
         p {
           opacity: 0.8;
+          font-size: 15px;
         }
       }
 
       .thumbnail {
+        width: 100%;
+        position: relative;
+        padding-top: 56.25%;
+        overflow: hidden;
+        background: black;
 
         a {
           width: 100%;
@@ -233,7 +246,13 @@ $video-card-width: 19%;
         }
 
         img {
-          width: 100%;
+          height: 100%;
+          position: absolute;
+          margin: auto;
+          top: 0;
+          left: 0;
+          bottom: 0;
+          right: 0;
         }
       }
 
@@ -241,17 +260,19 @@ $video-card-width: 19%;
         display: flex;
         flex-direction: column;
         height: 100%;
+        background: #fff;
       }
 
       .video-card-body {
-        padding: 10px 15px 14px;
-        margin: 0 0 29px 0;
+        padding: 15px 16px 16px;
+        margin: 0;
 
         h4 {
           margin: 0;
-          padding: 8px;
-          line-height: 1.3rem;
+          padding: 0;
+          line-height: 1.3;
           font-weight: 400;
+          font-size: .9rem;
 
           a {
             color: rgba(0,0,0,.87);
@@ -265,6 +286,7 @@ $video-card-width: 19%;
         position: absolute;
         bottom: 11px;
         right: 15px;
+        display: none;
 
         * {
           margin-left: 10px;

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -16,10 +16,6 @@ body {
   line-height: 1.4rem;
 }
 
-p.channelLink {
-  margin-bottom: 0px;
-}
-
 a, a:link, a:visited, a:active {
   color: $linkcolor;
   text-decoration: none;
@@ -57,7 +53,7 @@ button {
 
 .card {
   background-color: $card-bg-color;
-  box-shadow: 1px 2px 11px $card-shadow;
+  box-shadow: 1px 1px 8px $card-shadow;
   border-radius: 3px;
 
   .title {

--- a/static/scss/videoDetail.scss
+++ b/static/scss/videoDetail.scss
@@ -16,6 +16,14 @@
   @include breakpoint(phone) {
     margin: 30px auto 80px;
   }
+
+  .video-summary-card {
+    padding: 26px 5% 38px;
+
+    p.channelLink {
+      margin: 0px;
+    }
+  }
 }
 
 .actions {


### PR DESCRIPTION
## Robert W House
  - [ ] Fixes Firefox layout bug in video cards thumbnails (#288) ([31cd87a9](../commit/31cd87a902cb22be3286d0e9427800cfc693fe52))
  - [ ] Smaller responsive video thumbnails on Collection Details page (#276) ([912dfa02](../commit/912dfa02239a3d19beacd5af7f999c44f92de930))
  - [ ] Very minor tweaks (#268) ([365a9230](../commit/365a9230e88d9fedeeab18f100e8824179eae4e6))
  - [ ] Responsive styles for widescreen layout of collection page (#263) ([e83798d0](../commit/e83798d080102b5701978fdfe9ee6eab55f3d99b))
  - [ ] Fixes Safari Layout bug on Collection Details page (#255) ([41ed74e2](../commit/41ed74e2ec0f29e7be53860aaf00795a370b1408))
  - [ ] A few more style tweaks to OVS (#247) ([52e9c5dc](../commit/52e9c5dc7d994b1d102573e33a1087e0ca549e6c))
  - [ ] More styling fixes (#234) ([ae296d4c](../commit/ae296d4c7e4198cb539e2b7ee7d40bc9f2f8d7b8))
  - [ ] more UI tweaks (#214) ([f8d461bd](../commit/f8d461bd30d06e7ce1984c0e3002912e04e0bd32))
  - [ ] Styling the side-drawer (#197) ([1df768ff](../commit/1df768ff9117f78e6e669bcf2167c875b1fb442b))
  - [ ] footer styles (#194) ([52c1e797](../commit/52c1e797651b249b4b8f3995aaebe782488ba93b))
  - [ ] OVS style changes (#191) ([bf93ae8d](../commit/bf93ae8d15ce569bfab98c2ae6023e7db856d444))
  - [ ] style changes to video details page (#162) ([38416ae0](../commit/38416ae0985709867160d4dbbb45324eca3ee3fc))

## Gavin Sidebottom
  - [ ] Improved lecture capture default video titles ([c2ab31a9](../commit/c2ab31a9067261e85465cb10d599d2f098351aef))
  - [ ] Release 0.2.0 ([7dbfa6f5](../commit/7dbfa6f5383a5816d887aadd46ce2cd35426a33b))
  - [ ] Fixed bug with unusable scrollbars after saving a dialog form ([6a29867c](../commit/6a29867cf7bdec29dfdcfa75163a1f1ec9fd595f))
  - [ ] Added message for collections with no videos added yet ([92e9884b](../commit/92e9884b2e378e3898e786120f6dd5220d8f5ed2))
  - [ ] Revert &#34;Fixed bug with redirect destination after touchstone login&#34; ([d0391833](../commit/d0391833083df6f754243829ea7962ec7872fc72))
  - [ ] Fixed bug with redirect destination after touchstone login ([7cbe878c](../commit/7cbe878cdbb7e210ebc00f0c423d506b597558a8))
  - [ ] Set logout redirect ([d7ac57a4](../commit/d7ac57a461790b4f8e6e3ce2b00ed3aba3feca89))
  - [ ] Expanded collections list to include view-enabled collections ([163c8cca](../commit/163c8ccae2d1e4ce48963654511d273d4a96bb1f))
  - [ ] Added max height and inner scroll bar to dialog body ([14a92061](../commit/14a92061bbb2c5f44c2e2f8a28e753ef1cf3e138))
  - [ ] Improved upload UI ([9fdfa190](../commit/9fdfa19030cdb116b06784baa9e94d29b125c49a))
  - [ ] Enabled video share button on collection detail page ([27bfaf7a](../commit/27bfaf7ad2a089fbb284078c2d24f9e6d5b31642))
  - [ ] Enabled video edit button on collection detail page ([12ed34e1](../commit/12ed34e1dbc5a4c3bcd7b8c5614dec7c4915fa80))
  - [ ] Added collection edit dialog form ([8dfc5ff1](../commit/8dfc5ff1770a39fc0ef21f21c22b32cb66eff500))
  - [ ] Created React pages for collection list and detail ([15641336](../commit/15641336fd542980cb200eae631cbdb6d47fa90b))

## Matt Bertrand
  - [ ] Send emails to admin moira lists ([b9fca7b1](../commit/b9fca7b1038bd758da0abd04f49c8535d7be9a29))
  - [ ] Subtitles for videos ([2b2ee994](../commit/2b2ee99499025881c6b4b370c5b59dfafd22c2eb))
  - [ ] Video counts on collection list page ([5c88728d](../commit/5c88728df7b09409369b289b2f6261d0908c0eed))
  - [ ] Sort collections by reverse creation date ([c88254f0](../commit/c88254f0c6a1f08e49297d82d8c4fd3c4b81db58))
  - [ ] Fix scrollbar bug with dialogs ([f38f6e90](../commit/f38f6e90073c273249d800d3e01caf17ab1b815e))
  - [ ] Fix endless loop on forbidden collection pages ([cecb63b4](../commit/cecb63b494dcd73f6fd8f5dffccfc29fb6cfe36c))
  - [ ] Merge pull request #193 from mitodl/mb/sandwich2 ([49344b5c](../commit/49344b5c8e7e15ed135e78806bf879fcae7d8a91))
  - [ ] Sandwich menu content ([9fd32683](../commit/9fd32683afbfe0974dd32b545027bf790c6ab62e))
  - [ ] Let read-only users see the collection detail page ([f34d4fb1](../commit/f34d4fb1e6d4ceb2eea0da46464531eb7a77f925))
  - [ ] Increased the thumbnail size to 600x338 ([957a2e6d](../commit/957a2e6dc5dbd9d8add86b27ec82a085d16c4afb))
  - [ ] Fix height of the USwitch player iframe ([bf08de03](../commit/bf08de030a07f15db79e642247c3c955fefe71dc))
  - [ ] Working share button ([62e7cc39](../commit/62e7cc39a5a8f4982d81843ff68062af78544e53))
  - [ ] Restrict collection creation to staff users or superusers. ([84fc4bb7](../commit/84fc4bb74b4fc3df6f4b30806275905e5b29dd88))
  - [ ] Moira list permissions ([42971b18](../commit/42971b188619a20533d6232d44f3789dd05f5433))
  - [ ] Use environmental variables as x509 keys ([6beb8c88](../commit/6beb8c88b35247215f88f1f3312a18263285a825))
  - [ ] Monitor and process video files in an S3 watch bucket ([d9a359ea](../commit/d9a359ea8433fc6357efc73d8c8400875144fb29))
  - [ ] Standardize docker-compose.yml ([0cfb0762](../commit/0cfb0762883c6159c915283af235ecc60dd254a9))
  - [ ] Update USwitch component ([c7fb0ecc](../commit/c7fb0ecc1675562ca28f879b34dffea19c4eaa7d))
  - [ ] Reformat JSON ([6e318e69](../commit/6e318e696678915204c87936196c1743b6ebf3a5))
  - [ ] Update presets ([4dd097da](../commit/4dd097da90aadd3adb359587b2d73d73f257f4d9))
  - [ ] Hide the logo in the middle of the video that appears when not playing. ([34a4551f](../commit/34a4551fbdf4283e2043a0b087febefe7264017a))
  - [ ] Removed scriptjs ([c1e8d232](../commit/c1e8d232b1c37961b0468d837758fddabae7dd6e))
  - [ ] Fixed and added tests ([a6b6c114](../commit/a6b6c1148b4fca8ed92a1e18ee3f8b409a6f6d31))
  - [ ] Put USwitch player in an iframe, fix mosaic window, code review improvements ([0987bd1f](../commit/0987bd1f7de828e64b60d68b01af1b5f1ca37417))
  - [ ] Fix tests ([b87b2c45](../commit/b87b2c45703d12f14cbf996d3f9bad792f9dc39a))
  - [ ] USwitch player for multiangle videos ([f7278427](../commit/f72784279203c47a9be584d3fc0d1bac4465e23b))
  - [ ] - Updated AWS transcoder presets JSON to reflect LectureCapture settings     - Tweaked the createpresets management command to output `ET_PRESET_IDS=[list of generated preset ids] ([9e9d15ca](../commit/9e9d15cab9f9fb6c550ccf0da36b3d7b491d6ade))

## George Schneeloch
  - [ ] Removed unused forms (#246) ([31c59309](../commit/31c5930916f059697ba7e3237caaaf52bdbf78f0))
  - [ ] Add dialog for creating a new collection (#240) ([33c1a765](../commit/33c1a765511b96519fc777667455a32853dc08f5))
  - [ ] Remove owner from serializers, other code cleanup (#237) ([d62a1df6](../commit/d62a1df6cac5aa30ff003ab69cc328e77f8c42a0))
  - [ ] Implemented video detail page display ([7b61b0d5](../commit/7b61b0d5bd6ea34d5435230c999110c9f43b44d7))
  - [ ] Enable JS tests for travis (#131) ([865a031d](../commit/865a031d477db56c50f35f69fbfcfad27e032a24))
  - [ ] Add collectstatic step (#133) ([835a8292](../commit/835a829273b1dc365d2410bb99a315166e454e9f))

## sar
  - [ ] Changed default mailgun_url to video.odl.mit.edu domain instead of micromasters as this service has its own mailgun domain ([6088fcbb](../commit/6088fcbb3d7162aadb03a4ffbf2bf2e493a0467f))
  - [ ] Indentation error ([45de34d4](../commit/45de34d4874e0a560f7d9ce02a6e50e55f754675))
  - [ ] Tweaked regular expression after testing on classroom machine ([be0468c6](../commit/be0468c615467934d25e67ba704b6e0ee3a2c792))
  - [ ] Added some logic to parse output of s3 sync command and get the file names that have been uploaded and then use that list to move those specific files to the synced folder. Also added an entry in the settings file to point to the s3_sync_results_file ([f8bf234d](../commit/f8bf234d5c89d7ab262415d847e6c831e793b745))
  - [ ] Reformatted paths for synced and done folders ([daed4918](../commit/daed491834ba56a8bed77171363045de102cf37a))
  - [ ] Added function to move files that have been uploaded to S3 to a local folder on the host. Also added that folder to the settings file ([be42c005](../commit/be42c005897834774e9eea69fc06f34127698a6b))
  - [ ] Added try/except block for reading config file ([da3ff858](../commit/da3ff85873941c05f4e0132e7d87c11933d7b081))
  - [ ] Changes based on feedback ([57d250e3](../commit/57d250e326605b5d67436c84c2f93496e6f22bef))
  - [ ] PEP8 compliance changes, feedback from Giovanni, and removed an un-needed setting in the ini file ([8a3edbce](../commit/8a3edbce77afe4cce603b3f063912ef3e4d8a233))
  - [ ] Changes based on feedback and removed AWS CLI install since script would need to be run as admin and we want to avoid doing that ([434fb673](../commit/434fb67344d9bc3a1516d2addb6f697261e6ac96))
  - [ ] Changes based on feedback ([c8344852](../commit/c8344852ca42bdde197b50f4eb205de6310a3f0a))
  - [ ] Fixed a typo and some spacing ([e128da8a](../commit/e128da8aa3c6f4729074cd0e57631ed89180b2e6))
  - [ ] Automatically upload videos from specified folder to s3 bucket - Issue#100 - https://github.com/mitodl/odl-video-service/issues/100 Added two files, s3_sync and a setting ini file. ([d0d2288c](../commit/d0d2288c20cca932f45af3f5c05b974e950fb329))

## Giovanni Di Milia
  - [ ] Added email notifications on Video change of status ([3844c391](../commit/3844c391ce7f8258699736c2c645ff0bb73ba6cf))
  - [ ] Fixed bug with multiangle ([b36bd9ff](../commit/b36bd9ff5a07866745e9e09304139d3bd9ebe676))
  - [ ] Fixed some small problems in the UI ([1624a941](../commit/1624a9418026fa257655bda4d4a989336b775f38))
  - [ ] Adding scripts for the pre-post compile ([2c456b56](../commit/2c456b561dfd959395aa5003e09e669e7d68c95f))
  - [ ] Added Collections and refactored UI flow ([cc7a2825](../commit/cc7a2825fe363276455f7d70220b8d044b40c668))
  - [ ] Introduced mandatory settings ([57c0c4a2](../commit/57c0c4a270ba0132041b4d34cdedee3a3155ffb9))
  - [ ] Video statuses restricted to a list ([0ebe1ff7](../commit/0ebe1ff7168b62600e2159ab76a28b67af337f15))