### PR TITLE
Add validation for MAILGUN_URL and MAILGUN_KEY

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -289,8 +289,12 @@ EMAIL_USE_TLS = get_bool('ODL_VIDEO_EMAIL_TLS', False)
 EMAIL_SUPPORT = get_string('ODL_VIDEO_SUPPORT_EMAIL', 'support@example.com')
 DEFAULT_FROM_EMAIL = get_string('ODL_VIDEO_FROM_EMAIL', 'webmaster@localhost')
 
-MAILGUN_URL = get_string('MAILGUN_URL', 'https://api.mailgun.net/v3/video.odl.mit.edu')
+MAILGUN_URL = get_string('MAILGUN_URL', None)
+if not MAILGUN_URL:
+    raise ImproperlyConfigured("MAILGUN_URL not set")
 MAILGUN_KEY = get_string('MAILGUN_KEY', None)
+if not MAILGUN_KEY:
+    raise ImproperlyConfigured("MAILGUN_KEY not set")
 MAILGUN_BATCH_CHUNK_SIZE = get_int('MAILGUN_BATCH_CHUNK_SIZE', 1000)
 MAILGUN_RECIPIENT_OVERRIDE = get_string('MAILGUN_RECIPIENT_OVERRIDE', None)
 MAILGUN_FROM_EMAIL = get_string('MAILGUN_FROM_EMAIL', 'no-reply@example.com')


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/issues/3599

#### What's this PR do?
Adds validation for `MAILGUN_URL` and `MAILGUN_KEY` and removes the default value which will need to be provided via environment variable instead

#### How should this be manually tested?
Make sure your `.env` includes the same value as the value used in the default in `settings.py`