### PR TITLE
Add missing return

### DIFF
--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -61,6 +61,7 @@ def send_notification_email(video):
         email_template = NotificationEmail.objects.get(notification_type=STATUS_TO_NOTIFICATION[video.status])
     except NotificationEmail.DoesNotExist:
         log.error("No template found for error %s", STATUS_TO_NOTIFICATION[video.status])
+        return
 
     try:
         api.MailgunClient.send_individual_email(


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adds a missing `return`. After the `log.error` the variable referenced in the next function call won't exist and would cause a separate exception (this was logged and silenced)

#### How should this be manually tested?
N/A