### PR TITLE
Remove default MAILGUN_URL, this should be set in .env instead

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -289,7 +289,7 @@ EMAIL_USE_TLS = get_bool('ODL_VIDEO_EMAIL_TLS', False)
 EMAIL_SUPPORT = get_string('ODL_VIDEO_SUPPORT_EMAIL', 'support@example.com')
 DEFAULT_FROM_EMAIL = get_string('ODL_VIDEO_FROM_EMAIL', 'webmaster@localhost')
 
-MAILGUN_URL = get_string('MAILGUN_URL', 'https://api.mailgun.net/v3/video.odl.mit.edu')
+MAILGUN_URL = get_string('MAILGUN_URL', None)
 MAILGUN_KEY = get_string('MAILGUN_KEY', None)
 MAILGUN_BATCH_CHUNK_SIZE = get_int('MAILGUN_BATCH_CHUNK_SIZE', 1000)
 MAILGUN_RECIPIENT_OVERRIDE = get_string('MAILGUN_RECIPIENT_OVERRIDE', None)


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes the default value for `MAILGUN_URL`

#### How should this be manually tested?
If `MAILGUN_URL` is set in .env the app should start successfully
