### PR TITLE
Add no-throw-literal eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,8 @@
     "mocha/no-top-level-hooks": [2],
     "mocha/no-identical-title": [2],
     "mocha/no-nested-tests": [2],
-    "no-sequences": [2]
+    "no-sequences": [2],
+    "no-throw-literal": [2],
   },
   "env": {
     "es6": true,

--- a/static/js/components/dialogs/EditVideoFormDialog_test.js
+++ b/static/js/components/dialogs/EditVideoFormDialog_test.js
@@ -67,7 +67,7 @@ describe('EditVideoFormDialog', () => {
     ], () => {
       wrapper = renderComponent();
     });
-    if (!wrapper) throw "Render failed";
+    if (!wrapper) throw new Error("Render failed");
 
     assert.notEqual(previousFormState.key, store.getState().commonUi.editVideoForm.key);
     assert.equal(wrapper.find(selectors.TITLE_INPUT).prop('value'), video.title);
@@ -89,7 +89,7 @@ describe('EditVideoFormDialog', () => {
     ], () => {
       wrapper = renderComponent();
     });
-    if (!wrapper) throw "Render failed";
+    if (!wrapper) throw new Error("Render failed");
 
     let newValues = {
       title: "New Title",

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -47,7 +47,7 @@ describe("Drawer", () => {
       );
     });
     if (!wrapper) {
-      throw "Never will happen, make flow happy";
+      throw new Error("Never will happen, make flow happy");
     }
     return wrapper;
   };

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -75,7 +75,7 @@ class CollectionDetailPage extends React.Component {
 
   handleUpload = async (chosenFiles: Array<Object>) => {
     const { dispatch, collection } = this.props;
-    if (!collection) throw "Collection does not exist";
+    if (!collection) throw new Error("Collection does not exist");
     await dispatch(actions.uploadVideo.post(collection.key, chosenFiles));
     // Reload the collection after the video upload request succeeds
     dispatch(actions.collections.get(collection.key));

--- a/static/js/containers/CollectionDetailPage_test.js
+++ b/static/js/containers/CollectionDetailPage_test.js
@@ -67,7 +67,7 @@ describe('CollectionDetailPage', () => {
         </Provider>
       );
     });
-    if (!wrapper) throw "Never will happen, make flow happy";
+    if (!wrapper) throw new Error("Never will happen, make flow happy");
     return wrapper;
   };
 

--- a/static/js/containers/CollectionListPage_test.js
+++ b/static/js/containers/CollectionListPage_test.js
@@ -54,7 +54,7 @@ describe('CollectionListPage', () => {
         </MemoryRouter>
       );
     });
-    if (!wrapper) throw "Never will happen, make flow happy";
+    if (!wrapper) throw new Error("Never will happen, make flow happy");
     return wrapper;
   };
 

--- a/static/js/containers/VideoDetailPage_test.js
+++ b/static/js/containers/VideoDetailPage_test.js
@@ -57,7 +57,7 @@ describe('VideoDetailPage', () => {
       );
     });
     if (!wrapper) {
-      throw "Never will happen, make flow happy";
+      throw new Error("Never will happen, make flow happy");
     }
     return wrapper;
   };


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adds `no-throw-literal` eslint rule which forbids `throw "error"` in favor or `throw new Error("error")` which preserves a stack trace from the object's construction

#### How should this be manually tested?
N/A
