### PR TITLE
Add playback rate control button, stop autoplay

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -9,13 +9,14 @@ import { FULLSCREEN_API } from "../util/fullscreen_api";
 import { CANVASES } from "../constants";
 
 const makeConfigForVideo = (video: Video): Object => ({
-  autoplay: true,
+  autoplay: false,
   controls: true,
   fluid: false,
   playsinline: true,
   html5: {
     nativeTextTracks: false
   },
+  playbackRates: [0.50, 0.75, 1.0, 1.25, 1.5, 2.0, 4.0],
   sources: [{
     src: getHLSEncodedUrl(video),
     type: 'application/x-mpegURL',

--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -67,13 +67,14 @@ describe('VideoPlayer', (props = {}) => {
     let args = videojsStub.firstCall.args;
     assert.equal(args[0].tagName, "VIDEO");
     assert.deepEqual(args[1], {
-      autoplay: true,
+      autoplay: false,
       controls: true,
       fluid: false,
       playsinline: true,
       html5: {
         nativeTextTracks: false
       },
+      playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 4.0],
       sources: [
         {
           type: 'application/x-mpegURL',
@@ -161,5 +162,10 @@ describe('VideoPlayer', (props = {}) => {
     assert.equal(wrapper.instance().player.tracks.length, 2);
     assert.equal(wrapper.instance().player.tracks[0].src,  makeVideoSubtitleUrl(captionToKeep));
     assert.equal(wrapper.instance().player.tracks[1].src,  makeVideoSubtitleUrl(captionToAdd));
+  });
+
+  it('has a playback speed button on the control bar', () => {
+    let wrapper = renderPlayer();
+    assert.isDefined(wrapper.find('.vjs-playback-rate-value'));
   });
 });


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #107 
Closes #98

#### What's this PR do?
- Adds a playback rate control button to the VideoJS control bar, with options of ~~0.25, 0.5, 1, 1.5, 2, and 4x (same as USwitch)~~ 0.5, 0.75, 1.0, 1.25, 1.5, 2.0 (same as EdX).
- Sets autoplay to false

#### How should this be manually tested?
- Go to any video detail page.  It should not start playing automatically and there should be a `1x` on the control bar for the video.
- Hover over the control, you should see the other available speeds.
- Choose other speeds and the video/audio playback rate should change accordingly.