### PR TITLE
Raise custom 'MoiraException' on any moira-related error

### DIFF
--- a/cloudsync/api_test.py
+++ b/cloudsync/api_test.py
@@ -89,6 +89,7 @@ def test_refresh_status_video_job_status_error(mocker):
         }
     }
     mocker.patch('ui.utils.boto3', MockBoto)
+    mocker.patch('ui.models.tasks')
     api.refresh_status(video, encodejob)
     assert video.status == VideoStatus.TRANSCODE_FAILED_VIDEO
 
@@ -102,6 +103,7 @@ def test_refresh_status_video_job_status_complete(mocker):
     MockClientET.job = {'Job': {'Id': '1498220566931-qtmtcu', 'Status': 'Complete'}}
     mocker.patch('ui.utils.boto3', MockBoto)
     mocker.patch('cloudsync.api.process_transcode_results')
+    mocker.patch('ui.models.tasks')
     api.refresh_status(video, encodejob)
     assert video.status == VideoStatus.COMPLETE
 
@@ -421,6 +423,7 @@ def test_transcode_job_failure(mocker, videofile):
     mocker.patch.multiple('cloudsync.tasks.settings',
                           ET_PRESET_IDS=('1351620000001-000020',),
                           AWS_REGION='us-east-1', ET_PIPELINE_ID='foo')
+    mocker.patch('ui.models.tasks')
     mock_encoder = mocker.patch('cloudsync.api.VideoTranscoder.encode',
                                 side_effect=ClientError(error_response=job_result, operation_name='ReadJob'))
     with pytest.raises(ClientError):

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -118,6 +118,7 @@ def test_transcode_failure(mocker, videofile):
     mocker.patch('dj_elastictranscoder.transcoder.Session')
     mocker.patch('celery.app.task.Task.update_state')
     mocker.patch('ui.utils.boto3', MockBoto)
+    mocker.patch('ui.models.tasks')
     mocker.patch('cloudsync.api.get_et_job',
                  return_value=job_result['Job'])
     # Transcode the video
@@ -213,6 +214,7 @@ def test_update_video_statuses_nojob(mocker, video):  # pylint: disable=unused-a
     """Test NoEncodeJob error handling"""
     mocker.patch('cloudsync.tasks.refresh_status',
                  side_effect=EncodeJob.DoesNotExist())
+    mocker.patch('ui.models.tasks')
     video.update_status(VideoStatus.TRANSCODING)
     update_video_statuses()  # pylint: disable=no-value-for-parameter
     assert VideoStatus.TRANSCODE_FAILED_INTERNAL == Video.objects.get(id=video.id).status
@@ -223,6 +225,7 @@ def test_update_video_statuses_clienterror(mocker, video):  # pylint: disable=un
     job_result = {'Job': {'Id': '1498220566931-qtmtcu', 'Status': 'Error'}, 'Error': {'Code': 200, 'Message': 'FAIL'}}
     mocker.patch('cloudsync.tasks.refresh_status',
                  side_effect=ClientError(error_response=job_result, operation_name='ReadJob'))
+    mocker.patch('ui.models.tasks')
     video.update_status(VideoStatus.TRANSCODING)
     update_video_statuses()  # pylint: disable=no-value-for-parameter
     assert VideoStatus.TRANSCODE_FAILED_INTERNAL == Video.objects.get(id=video.id).status

--- a/ui/exceptions.py
+++ b/ui/exceptions.py
@@ -1,0 +1,5 @@
+""" Custom exceptions"""
+
+
+class MoiraException(Exception):
+    """Custom exception to be used when something goes wrong with Moira API calls"""

--- a/ui/models.py
+++ b/ui/models.py
@@ -16,6 +16,7 @@ from mail import tasks
 from ui import utils
 from ui.constants import VideoStatus
 from ui.encodings import EncodingNames
+from ui.exceptions import MoiraException
 from ui.tasks import delete_s3_objects
 
 TRANSCODE_PREFIX = 'transcoded'
@@ -35,7 +36,10 @@ class MoiraList(models.Model):
 
         """
         moira = utils.get_moira_client()
-        return set(moira.list_members(self.name, type=''))
+        try:
+            return set(moira.list_members(self.name, type=''))
+        except Exception as exc:
+            raise MoiraException('Something went wrong with getting moira-list members') from exc
 
     def __str__(self):
         return self.name

--- a/ui/permissions_test.py
+++ b/ui/permissions_test.py
@@ -188,13 +188,15 @@ def test_is_collection_admin_anonymous_users(collection_permission, collection, 
                                                        collection) is False
 
 
-def test_is_collection_admin_user_different_from_collecton_owner(collection_permission,
+def test_is_collection_admin_user_different_from_collecton_owner(mocker,
+                                                                 collection_permission,
                                                                  collection,
                                                                  request_data):
     """
     Test for HasCollectionPermissions.has_object_permission to verify
     that user who does not own the collection does not have permission
     """
+    mocker.patch('ui.utils.user_moira_lists', return_value=[])
     assert collection_permission.has_object_permission(request_data.request,
                                                        request_data.view,
                                                        collection) is False
@@ -324,12 +326,13 @@ def test_can_upload_to_collection_other_key(can_upload_to_collection_permission,
     assert can_upload_to_collection_permission.has_permission(request_data.request, request_data.view) is False
 
 
-def test_can_upload_to_collection_other_owner(can_upload_to_collection_permission, collection, request_data):
+def test_can_upload_to_collection_other_owner(mocker, can_upload_to_collection_permission, collection, request_data):
     """
     Test for CanUploadToCollection with a collection having another owner
     """
     request_data.request.method = 'POST'
     request_data.request.data = {'collection': collection.hexkey}
+    mocker.patch('ui.utils.user_moira_lists')
     assert can_upload_to_collection_permission.has_permission(request_data.request, request_data.view) is False
 
 
@@ -352,11 +355,12 @@ def test_video_view_permission_anonymous_users(video_permission, video, request_
     assert video_permission.has_object_permission(request_data_anon.request, request_data_anon.view, video) is False
 
 
-def test_video_view_permission_other_user(video_permission, video, request_data):
+def test_video_view_permission_other_user(mocker, video_permission, video, request_data):
     """
     Test for HasVideoPermissions.has_object_permission to verify
     that user who does not own the video's collection does not have permission
     """
+    mocker.patch('ui.utils.user_moira_lists')
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is False
 
 
@@ -438,11 +442,12 @@ def test_video_admin_permission_anonymous_users(video_permission, video, request
     assert video_permission.has_object_permission(request_data_anon.request, request_data_anon.view, video) is False
 
 
-def test_video_admin_permission_other_user(video_permission, video, request_data):
+def test_video_admin_permission_other_user(mocker, video_permission, video, request_data):
     """
     Test for HasAdminPermissionsForVideo.has_object_permission to verify
     that user who does not own the video's collection does not have permission
     """
+    mocker.patch('ui.utils.user_moira_lists', return_value=[])
     request_data.request.method = 'POST'
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is False
 

--- a/ui/utils_test.py
+++ b/ui/utils_test.py
@@ -1,10 +1,9 @@
 """Tests for utils methods"""
 from tempfile import NamedTemporaryFile
-from urllib3.exceptions import SSLError
-
 import pytest
 
 from ui import factories
+from ui.exceptions import MoiraException
 from ui.utils import write_to_file, get_moira_client, user_moira_lists
 
 
@@ -62,9 +61,9 @@ def test_user_moira_lists(mock_moira_client):
 
 def test_user_moira_lists_error(mock_moira_client):
     """
-    Test that an empty list is returned if the Moira client can't connect
+    Test that a Moira exception is raised if moira client call fails
     """
-    mock_moira_client.side_effect = SSLError()
+    mock_moira_client.side_effect = MoiraException()
     other_user = factories.UserFactory()
-    lists = user_moira_lists(other_user)
-    assert lists == []
+    with pytest.raises(MoiraException):
+        user_moira_lists(other_user)


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #307

#### What's this PR do?
Raises a `MoiraException` if any error occurs when making calls to the Moira API

#### How should this be manually tested?
- Disconnect wifi
- Log in to OVS using a non-superuser account
- Go to any video detail URL
- You should get a 'MoiraException' the page:
```
MoiraException at /videos/b6491433151144e080e4769c823bdd88/
('Something went wrong with moira client for user %s: %s', 'mattbert@mit.edu', 
'(\'Something went wrong with moira client: %s\', 
"HTTPSConnectionPool(host=\'moiraws.mit.edu\', port=443): Max retries exceeded with url: /moiraws/services/moira?wsdl 
(Caused by NewConnectionError(\'<urllib3.connection.VerifiedHTTPSConnection object at 0x7f78205aca20>: 
Failed to establish a new connection: [Errno -2] Name or service not known\',))")')
```