### PR TITLE
Add templates for 403, 404, 500 views

### DIFF
--- a/odl_video/urls.py
+++ b/odl_video/urls.py
@@ -24,3 +24,7 @@ urlpatterns = [
     url(r'^', include('cloudsync.urls')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]
+
+handler403 = 'ui.views.permission_denied_403_view'
+handler404 = 'ui.views.page_not_found_404_view'
+handler500 = 'ui.views.error_500_view'

--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -79,7 +79,7 @@ class Drawer extends React.Component {
           <a id="collapse_item" className="mdc-list-item mdc-link" href="#" ref={
             node => this.collapseItemButton = node
           }>
-            {SETTINGS.user}
+            {SETTINGS.email ? SETTINGS.email : (SETTINGS.user ? SETTINGS.user : "Not logged in")}
           </a>
         </nav>
         <header className="mdc-temporary-drawer__header">

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -22,7 +22,8 @@ describe("Drawer", () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     store = configureTestStore(rootReducer);
-    SETTINGS.user = 'foo@mit.edu';
+    SETTINGS.email = 'foo@mit.edu';
+    SETTINGS.user = 'foo_user';
     collections = [makeCollection(), makeCollection()];
     listenForActions = store.createListenForActions();
     getCollectionsStub = sandbox.stub(api, 'getCollections').returns(Promise.resolve(collections));
@@ -56,6 +57,21 @@ describe("Drawer", () => {
     let wrapper = await renderDrawer();
     let drawerNode = wrapper.find('.mdc-list-item .mdc-link').at(0);
     assert.isTrue(drawerNode.text().startsWith('foo@mit.edu'));
+  });
+
+  it('shows the username if the email is not present', async() => {
+    SETTINGS.email = null;
+    let wrapper = await renderDrawer();
+    let drawerNode = wrapper.find('.mdc-list-item .mdc-link').at(0);
+    assert.isTrue(drawerNode.text().startsWith('foo_user'));
+  });
+
+  it('shows a message if the user is not logged in', async() => {
+    SETTINGS.email = null;
+    SETTINGS.user = null;
+    let wrapper = await renderDrawer();
+    let drawerNode = wrapper.find('.mdc-list-item .mdc-link').at(0);
+    assert.isTrue(drawerNode.text().startsWith('Not logged in'));
   });
 
   it('drawer element is rendered with collections', async () => {

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -6,10 +6,8 @@ import type { Dispatch } from 'redux';
 import R from 'ramda';
 import _ from 'lodash';
 
-import OVSToolbar from '../components/OVSToolbar';
-import Footer from '../components/Footer';
+import WithDrawer from './WithDrawer';
 import VideoCard from '../components/VideoCard';
-import Drawer from '../components/material/Drawer';
 import Button from "../components/material/Button";
 import EditVideoFormDialog from '../components/dialogs/EditVideoFormDialog';
 import ShareVideoDialog from '../components/dialogs/ShareVideoDialog';
@@ -18,7 +16,6 @@ import { withDialogs } from '../components/dialogs/hoc';
 import DropboxChooser from 'react-dropbox-chooser';
 
 import { actions } from '../actions';
-import * as commonUiActions from '../actions/commonUi';
 import * as collectionUiActions from '../actions/collectionUi';
 import { getActiveCollectionDetail } from '../lib/collection';
 import { DIALOGS } from '../constants';
@@ -66,11 +63,6 @@ class CollectionDetailPage extends React.Component {
     const { dispatch, showDialog } = this.props;
     dispatch(collectionUiActions.setSelectedVideoKey(videoKey));
     showDialog(DIALOGS.SHARE_VIDEO);
-  };
-
-  setDrawerOpen = (open: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(commonUiActions.setDrawerOpen(open));
   };
 
   handleUpload = async (chosenFiles: Array<Object>) => {
@@ -172,7 +164,7 @@ class CollectionDetailPage extends React.Component {
   };
 
   render() {
-    const { collection, collectionError, commonUi } = this.props;
+    const { collection, collectionError } = this.props;
 
     if (!collection) return null;
 
@@ -180,14 +172,11 @@ class CollectionDetailPage extends React.Component {
       ? this.renderError(collectionError)
       : this.renderBody(collection);
 
-    return <div>
-      <OVSToolbar setDrawerOpen={this.setDrawerOpen.bind(this, true)} />
-      <Drawer open={commonUi.drawerOpen} onDrawerClose={this.setDrawerOpen.bind(this, false)} />
+    return <WithDrawer>
       <div className="collection-detail-content">
         { detailBody }
       </div>
-      <Footer />
-    </div>;
+    </WithDrawer>;
   }
 }
 

--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -8,11 +8,8 @@ import type { Dispatch } from "redux";
 import { Link } from "react-router-dom";
 
 import { DIALOGS } from "../constants";
-import * as commonUiActions from '../actions/commonUi';
 import * as collectionUiActions from '../actions/collectionUi';
-import OVSToolbar from '../components/OVSToolbar';
-import Drawer from '../components/material/Drawer';
-import Footer from '../components/Footer';
+import WithDrawer from "./WithDrawer";
 import CollectionFormDialog from "../components/dialogs/CollectionFormDialog";
 import { withDialogs } from "../components/dialogs/hoc";
 import { makeCollectionUrl } from "../lib/urls";
@@ -26,11 +23,6 @@ class CollectionListPage extends React.Component {
     editable: boolean,
     needsUpdate: boolean,
     commonUi: CommonUiState
-  };
-
-  setDrawerOpen = (open: boolean): void => {
-    const { dispatch } = this.props;
-    dispatch(commonUiActions.setDrawerOpen(open));
   };
 
   renderCollectionLinks() {
@@ -64,7 +56,6 @@ class CollectionListPage extends React.Component {
   };
 
   render() {
-    const { commonUi } = this.props;
     const formLink = SETTINGS.editable
       ? (
         <a className="button-link create-collection-button" onClick={this.openNewCollectionDialog}>
@@ -74,9 +65,7 @@ class CollectionListPage extends React.Component {
       )
       : null;
 
-    return <div>
-      <OVSToolbar setDrawerOpen={this.setDrawerOpen.bind(this, true)} />
-      <Drawer open={commonUi.drawerOpen} onDrawerClose={this.setDrawerOpen.bind(this, false)} />
+    return <WithDrawer>
       <div className="collection-list-content">
         <div className="card centered-content">
           <h2 className="mdc-typography--title">My Collections</h2>
@@ -84,8 +73,7 @@ class CollectionListPage extends React.Component {
           { formLink }
         </div>
       </div>
-      <Footer />
-    </div>;
+    </WithDrawer>;
   }
 }
 

--- a/static/js/containers/ErrorPage.js
+++ b/static/js/containers/ErrorPage.js
@@ -1,0 +1,53 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+
+import WithDrawer from './WithDrawer';
+
+export default class ErrorPage extends React.Component {
+  errorTitle = () => {
+    switch (SETTINGS.status_code) {
+    case 403:
+      return 'You do not have permission to view this video';
+    case 404:
+      return 'Page not found';
+    default:
+      return 'Oops! Something went wrong...';
+    }
+  };
+
+  errorMessage = () => {
+    switch (SETTINGS.status_code) {
+    case 403:
+      return <span>
+        If you want permission to view this video please{" "}
+        <a href={`mailto:${SETTINGS.support_email_address}`}>
+          Contact ODL Video Services
+        </a>.
+      </span>;
+    case 404:
+      return <span>
+        This is a 404 error. This is not the page you were looking for.
+      </span>;
+    default:
+      return <span>
+        This is a 500 error. Something went wrong with the software.
+        If this continues to happen please{" "}
+        <a href={`mailto:${SETTINGS.support_email_address}`}>
+          Contact Support
+        </a>.
+      </span>;
+    }
+  }
+
+  render() {
+    return <WithDrawer>
+      <div className="error-page">
+        <div className="content">
+          <span className="title">{this.errorTitle()}</span>
+          <p className="message">{this.errorMessage()}</p>
+        </div>
+      </div>
+    </WithDrawer>;
+  }
+}

--- a/static/js/containers/ErrorPage_test.js
+++ b/static/js/containers/ErrorPage_test.js
@@ -1,0 +1,72 @@
+// @flow
+/* global SETTINGS */
+import React from 'react';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { assert } from 'chai';
+import configureTestStore from 'redux-asserts';
+import { Provider } from 'react-redux';
+
+import * as api from '../lib/api';
+import ErrorPage from './ErrorPage';
+import { actions } from '../actions';
+import rootReducer from '../reducers';
+import { makeCollection } from "../factories/collection";
+
+describe('ErrorPage', () => {
+  let sandbox, store, collections, listenForActions;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    store = configureTestStore(rootReducer);
+    listenForActions = store.createListenForActions();
+    collections = [makeCollection(), makeCollection(), makeCollection()];
+
+    sandbox.stub(api, 'getCollections').returns(Promise.resolve(collections));
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const renderPage = async (props = {}) => {
+    let wrapper;
+
+    await listenForActions([
+      actions.collectionsList.get.requestType,
+      actions.collectionsList.get.successType,
+    ], () => {
+      wrapper = mount(
+        <Provider store={store}>
+          <ErrorPage
+            {...props}
+          />
+        </Provider>
+      );
+    });
+    if (!wrapper) throw new Error("Never will happen, make flow happy");
+    return wrapper;
+  };
+
+  for (const [status, title, message] of [
+    [
+      403,
+      'You do not have permission to view this video',
+      'If you want permission to view this video please Contact ODL Video Services.',
+    ],
+    [404, 'Page not found', 'This is a 404 error. This is not the page you were looking for.'],
+    [
+      500,
+      'Oops! Something went wrong...',
+      'This is a 500 error. Something went wrong with the software.' +
+      ' If this continues to happen please Contact Support.',
+    ],
+  ]) {
+    it(`renders an error for status=${status}`, async () => {
+      SETTINGS.status_code = status;
+      const wrapper = await renderPage();
+      assert.equal(wrapper.find(".error-page .title").text().trim(), title);
+      assert.equal(wrapper.find(".error-page .message").text().trim(), message);
+    });
+  }
+});

--- a/static/js/containers/WithDrawer.js
+++ b/static/js/containers/WithDrawer.js
@@ -1,0 +1,50 @@
+// @flow
+/* global SETTINGS: false */
+import React from 'react';
+import R from 'ramda';
+import { connect } from 'react-redux';
+
+import { DIALOGS } from "../constants";
+import * as commonUiActions from '../actions/commonUi';
+import OVSToolbar from '../components/OVSToolbar';
+import Drawer from '../components/material/Drawer';
+import Footer from '../components/Footer';
+import CollectionFormDialog from "../components/dialogs/CollectionFormDialog";
+import { withDialogs } from "../components/dialogs/hoc";
+
+class WithDrawer extends React.Component {
+  setDrawerOpen = (open: boolean): void => {
+    const { dispatch } = this.props;
+    dispatch(commonUiActions.setDrawerOpen(open));
+  };
+
+  render() {
+    const { children, commonUi } = this.props;
+
+    return <div>
+      <OVSToolbar setDrawerOpen={this.setDrawerOpen.bind(this, true)} />
+      <Drawer open={commonUi.drawerOpen} onDrawerClose={this.setDrawerOpen.bind(this, false)} />
+      {children}
+      <Footer />
+    </div>;
+  }
+}
+
+const mapStateToProps = (state) => {
+  const { collectionsList, commonUi } = state;
+  const collections = collectionsList.loaded ? collectionsList.data : [];
+  const needsUpdate = !collectionsList.processing && !collectionsList.loaded;
+
+  return {
+    collections,
+    commonUi,
+    needsUpdate
+  };
+};
+
+export default R.compose(
+  connect(mapStateToProps),
+  withDialogs([
+    {name: DIALOGS.COLLECTION_FORM, component: CollectionFormDialog},
+  ])
+)(WithDrawer);

--- a/static/js/entry/error.js
+++ b/static/js/entry/error.js
@@ -1,0 +1,27 @@
+// @flow
+/* global SETTINGS:false */
+__webpack_public_path__ = SETTINGS.public_path;  // eslint-disable-line no-undef, camelcase
+import 'react-hot-loader/patch';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+import ErrorPage from '../containers/ErrorPage';
+import configureStore from '../store/configureStore';
+
+// Object.entries polyfill
+import entries from 'object.entries';
+if (!Object.entries) {
+  entries.shim();
+}
+
+const store = configureStore();
+
+const rootEl = document.getElementById("container");
+
+ReactDOM.render(
+  <Provider store={store}>
+    <ErrorPage />
+  </Provider>,
+  rootEl
+);

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -10,9 +10,11 @@ declare var SETTINGS: {
   video: Video,
   videoKey: string,
   editable: boolean,
-  user: string,
+  user: ?string,
+  email: ?string,
   dropbox_key: string,
-  support_email_address: string
+  support_email_address: string,
+  status_code?: number
 };
 
 // mocha

--- a/static/scss/errorPage.scss
+++ b/static/scss/errorPage.scss
@@ -1,0 +1,21 @@
+.error-page {
+  background-color: #f0f0f0;
+  margin: 50px;
+  padding: 100px 50px;
+
+  .content {
+    margin: 0 auto;
+    text-align: center;
+    max-width: 500px;
+
+    .title {
+      font-weight: 600;
+      font-size: 24px;
+      color: #444444;
+    }
+
+    .message {
+      font-size: 16px;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -23,3 +23,4 @@
 @import 'videoPlayer';
 @import 'collection';
 @import 'sideDrawer';
+@import 'errorPage';

--- a/ui/templates/error.html
+++ b/ui/templates/error.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}OVS{% endblock %}
+{% block pagetitle %}OVS{% endblock %}
+{% block content %}
+{% load render_bundle %}
+
+<div id="container"></div>
+
+{% render_bundle 'error' %}
+{% endblock %}

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -472,3 +472,28 @@ def test_upload_subtitles_authentication(mock_moira_client, logged_in_apiclient,
     # call with user on admin list
     mock_moira_client.return_value.user_lists.return_value = [moira_list.name]
     assert client.post(url, input_data, format='multipart').status_code == status.HTTP_202_ACCEPTED
+
+
+@pytest.mark.parametrize("logged_in", [True, False])
+def test_page_not_found(logged_in, logged_in_apiclient, settings):
+    """
+    We should show the React container for our 404 page
+    """
+    settings.VIDEO_CLOUDFRONT_BASE_URL = 'cloudfront_base_url'
+    settings.GA_TRACKING_ID = 'tracking_id'
+    settings.EMAIL_SUPPORT = 'support'
+
+    client, user = logged_in_apiclient
+    if not logged_in:
+        client.logout()
+    resp = client.get("/definitely_not_a_real_page/")
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    assert json.loads(resp.context[0]['js_settings_json']) == {
+        'cloudfront_base_url': settings.VIDEO_CLOUDFRONT_BASE_URL,
+        'gaTrackingID': settings.GA_TRACKING_ID,
+        'public_path': '/static/bundles/',
+        'status_code': status.HTTP_404_NOT_FOUND,
+        'support_email_address': settings.EMAIL_SUPPORT,
+        'email': user.email if logged_in else None,
+        'user': user.username if logged_in else None,
+    }

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -108,7 +108,8 @@ def test_video_detail(logged_in_client, mocker):
         "public_path": '/static/bundles/',
         "videoKey": videofileHLS.video.hexkey,
         "cloudfront_base_url": settings.VIDEO_CLOUDFRONT_BASE_URL,
-        "user": user.email,
+        "user": user.username,
+        "email": user.email,
         "support_email_address": settings.EMAIL_SUPPORT,
     }
 
@@ -131,7 +132,8 @@ def test_video_embed(logged_in_client, mocker, settings):  # pylint: disable=red
         "gaTrackingID": settings.GA_TRACKING_ID,
         "public_path": "/static/bundles/",
         "cloudfront_base_url": settings.VIDEO_CLOUDFRONT_BASE_URL,
-        "user": user.email,
+        "user": user.username,
+        "email": user.email,
         "support_email_address": settings.EMAIL_SUPPORT,
     }
 

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -6,6 +6,7 @@ module.exports = {
   config: {
     entry: {
       'collections': ['babel-polyfill', './static/js/entry/collections'],
+      'error': ['babel-polyfill', './static/js/entry/error'],
       'video_detail': ['babel-polyfill', './static/js/entry/video_detail'],
       'video_embed': ['babel-polyfill', './static/js/entry/video_embed'],
       'style': './static/js/entry/style',


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #116 

#### What's this PR do?
Adds empty templates for 403, 404 and 500 views

#### How should this be manually tested?
Choose a view (for example `ui_login`) and raise one of these three exceptions: `PermissionDenied`, `NotFound`, `KeyError` for 403, 404 and 500 respectively. Set `DEBUG = False` in your settings. Verify that the appropriate template shows up and has the right status code in the network tab of your browser
