### PR TITLE
Remove auth endpoints

### DIFF
--- a/odl_video/urls.py
+++ b/odl_video/urls.py
@@ -20,9 +20,7 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^status/', include('server_status.urls')),
     url(r'^', include('ui.urls')),
-    url(r'^', include('django.contrib.auth.urls')),
     url(r'^', include('cloudsync.urls')),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]
 
 handler403 = 'ui.views.permission_denied_403_view'


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #311 

#### What's this PR do?
Removes references to Django endpoints

#### How should this be manually tested?
Go to `/login`. You should see a 404 page
