### PR TITLE
Moira list validation

### DIFF
--- a/static/js/actions/collectionUi.js
+++ b/static/js/actions/collectionUi.js
@@ -51,3 +51,6 @@ export const showEditCollectionDialog = (collection: Collection) =>
     dispatch(initCollectionForm(makeInitializedForm(collection)));
     dispatch(showDialog(DIALOGS.COLLECTION_FORM));
   };
+
+export const VALIDATE_FORM = qualifiedName('VALIDATE_COLLECTION_FORM');
+export const validateForm = createAction(VALIDATE_FORM);

--- a/static/js/components/dialogs/CollectionFormDialog_test.js
+++ b/static/js/components/dialogs/CollectionFormDialog_test.js
@@ -26,7 +26,7 @@ import {
   SET_VIEW_LISTS,
   showNewCollectionDialog,
   showEditCollectionDialog,
-  CLEAR_COLLECTION_FORM,
+  CLEAR_COLLECTION_FORM, VALIDATE_FORM,
 } from '../../actions/collectionUi';
 import {
   INITIAL_UI_STATE,
@@ -102,6 +102,31 @@ describe('CollectionFormDialog', () => {
           assert.equal(getCollectionForm(state.collectionUi)[prop], newValue);
         });
       }
+
+      it('stores form submission errors in state', async () => {
+        let wrapper = await renderComponent();
+        let expectedActionTypes;
+        const expectedError = 'Error: only absolute urls are supported';
+        if (isNew) {
+          expectedActionTypes = [
+            actions.collectionsList.post.requestType,
+            'RECEIVE_POST_COLLECTIONS_LIST_FAILURE',
+            VALIDATE_FORM
+          ];
+        } else {
+          expectedActionTypes = [
+            actions.collections.patch.requestType,
+            'RECEIVE_PATCH_COLLECTIONS_FAILURE',
+            VALIDATE_FORM
+          ];
+        }
+        await listenForActions(expectedActionTypes, () => {
+          // Calling click handler directly due to MDC limitations (can't use enzyme's 'simulate')
+          wrapper.find('Dialog').prop('onAccept')();
+        });
+
+        assert.equal(store.getState().collectionUi.errors, expectedError);
+      });
 
       it('sends a request to the right endpoint when the form is submitted', async () => {
         let listInput = "list1,list2,list3";

--- a/static/js/components/material/Dialog.js
+++ b/static/js/components/material/Dialog.js
@@ -14,7 +14,8 @@ type DialogProps = {
   cancelText: string,
   submitText: string,
   noSubmit: boolean,
-  id: string
+  id: string,
+  validateOnClick?: boolean
 };
 
 export default class Dialog extends React.Component {
@@ -53,12 +54,14 @@ export default class Dialog extends React.Component {
 
   // This function only exists because of false Flow errors
   attachDialogListeners = (dialog: Object) => {
-    const { onAccept, onCancel, hideDialog } = this.props;
+    const { onAccept, onCancel, hideDialog, validateOnClick } = this.props;
 
     if (onAccept) {
       dialog.listen('MDCDialog:accept', onAccept);
     }
-    dialog.listen('MDCDialog:accept', hideDialog);
+    if (!validateOnClick) {
+      dialog.listen('MDCDialog:accept', hideDialog);
+    }
     if (onCancel) {
       dialog.listen('MDCDialog:cancel', onCancel);
     }
@@ -78,7 +81,8 @@ export default class Dialog extends React.Component {
   }
 
   render() {
-    const { title, children, cancelText, submitText, noSubmit, id, open } = this.props;
+    const { title, children, cancelText, submitText, noSubmit, id, open,
+      onCancel, onAccept, validateOnClick } = this.props;
 
     // Hack to avoid showing unstyled dialog contents before the stylesheets are ready
     let styleProp = open ? {} : {display: 'none'};
@@ -102,13 +106,19 @@ export default class Dialog extends React.Component {
           {children}
         </section>
         <footer className="mdc-dialog__footer">
-          <Button type="button" className="mdc-dialog__footer__button mdc-dialog__footer__button--cancel cancel-button">
+          <Button
+            type="button"
+            onClick={onCancel}
+            className={`mdc-dialog__footer__button cancel-button
+              ${!validateOnClick ? 'mdc-dialog__footer__button--cancel' : ''}`}>
             {cancelText || 'Cancel'}
           </Button>
           {noSubmit ? null : (
             <Button
               type="button"
-              className="mdc-dialog__footer__button mdc-dialog__footer__button--accept edit-button">
+              onClick={onAccept}
+              className={`mdc-dialog__footer__button edit-button
+                ${!validateOnClick ? 'mdc-dialog__footer__button--accept' : ''}`}>
               {submitText || 'Save'}
             </Button>)}
         </footer>

--- a/static/js/components/material/Textfield.js
+++ b/static/js/components/material/Textfield.js
@@ -1,15 +1,16 @@
 // @flow
 import React from 'react';
+import R from 'ramda';
 
 export default class Textfield extends React.Component {
   props: {
     id: string,
     label?: string,
-    placeholder?: string
+    validationMessage?: string
   };
 
   render() {
-    const { label, id, ...otherProps } = this.props;
+    const { label, id, validationMessage, ...otherProps } = this.props;
 
     let renderedLabel = label
       ? <label htmlFor={id}>{label}</label>
@@ -18,7 +19,16 @@ export default class Textfield extends React.Component {
     return <div className="mdc-textfield-container">
       { renderedLabel }
       <div className="mdc-textfield">
-        <input type="text" className="mdc-textfield__input" id={id} {...otherProps} />
+        <input type="text"
+          className={`${validationMessage ? 'mdc-textfield__input__invalid' : ''} mdc-textfield__input `}
+          id={id}
+          {...otherProps}
+        />
+        {  R.isEmpty(validationMessage) || R.isNil(validationMessage)
+          ? null
+          : <div className="validation-message">
+            {validationMessage}
+          </div>}
       </div>
     </div>;
   }

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -157,20 +157,12 @@ class CollectionDetailPage extends React.Component {
     </div>;
   }
 
-  renderError = (collectionError: Object) => {
-    return <h2 className="mdc-typography--title error">
-      { collectionError.detail }
-    </h2>;
-  };
-
   render() {
-    const { collection, collectionError } = this.props;
+    const { collection } = this.props;
 
     if (!collection) return null;
 
-    const detailBody = collectionError
-      ? this.renderError(collectionError)
-      : this.renderBody(collection);
+    const detailBody = this.renderBody(collection);
 
     return <WithDrawer>
       <div className="collection-detail-content">

--- a/static/js/flow/collectionTypes.js
+++ b/static/js/flow/collectionTypes.js
@@ -28,9 +28,16 @@ export type CollectionFormState = {
   adminLists: ?string,
 };
 
+export type CollectionValidation = {
+  title?:  string,
+  view_lists?: string,
+  admin_lists?: string
+}
+
 export type CollectionUiState = {
   newCollectionForm: CollectionFormState,
   editCollectionForm: CollectionFormState,
   isNew: boolean,
-  selectedVideoKey: ?string
+  selectedVideoKey: ?string,
+  errors?: CollectionValidation
 };

--- a/static/js/lib/sanctuary.js
+++ b/static/js/lib/sanctuary.js
@@ -1,0 +1,72 @@
+// @flow
+import R from "ramda";
+import { create, env } from "sanctuary";
+
+export const S = create({ checkTypes: false, env: env });
+
+/*
+ * returns Just(items) if all items are Just, else Nothing
+ */
+export const allJust = R.curry(
+  (items: S.Maybe[]) => (R.all(S.isJust)(items) ? S.Just(items) : S.Nothing)
+);
+
+/*
+ * converts a Maybe<String> to a string
+ */
+export const mstr = S.maybe("", String);
+
+/*
+ * returns Nothing if the input is undefined|null,
+ * else passes the input through a provided function
+ * (the third argument to R.ifElse)
+ */
+export const ifNil = R.ifElse(R.isNil, () => S.Nothing);
+
+/*
+ * wraps a function in a guard, which will return Nothing
+ * if any of the arguments are null || undefined,
+ * and otherwise will return Just(fn(...args))
+ *
+ * Similar to S.toMaybe
+ *
+ * guard :: (a -> b) -> (a -> Maybe b)
+ */
+export const guard = (func: Function) => (...args: any) => {
+  if (R.any(R.isNil, args)) {
+    return S.Nothing;
+  } else {
+    return S.Just(func(...args));
+  }
+};
+
+// getm :: String -> Object -> Maybe a
+export const getm = R.curry((prop, obj) => S.toMaybe(R.prop(prop, obj)));
+
+// parseJSON :: String -> Either Object Object
+// A Right value indicates the JSON parsed successfully,
+// a Left value indicates the JSON was malformed (a Left contains
+// an empty object)
+export const parseJSON = S.encaseEither(() => ({}), JSON.parse);
+
+// filterE :: (Either -> Boolean) -> Either -> Either
+// filterE takes a function f and an either E(v).
+// if the Either is a Left, it returns it.
+// if the f(v) === true, it returns, E. Else,
+// if returns Left(v).
+export const filterE = R.curry((predicate, either) =>
+  S.either(
+    S.Left,
+    right => (predicate(right) ? S.Right(right) : S.Left(right)),
+    either
+  )
+);
+
+// reduceM :: forall a b. b -> (a -> b) -> Maybe a -> b
+// this is how I think Sanctuary's `reduce` should handle a maybe
+// pass a default value, a function, and a maybe
+// if Nothing, return the function called with the default value
+// if Just, return the function called with the value in the Just
+export const reduceM = R.curry((def, fn, maybe) =>
+  S.maybe_(() => fn(def), fn, maybe)
+);

--- a/static/js/lib/sanctuary_test.js
+++ b/static/js/lib/sanctuary_test.js
@@ -1,0 +1,171 @@
+// @flow
+import { assert } from "chai";
+import R from "ramda";
+
+import {
+  S,
+  allJust,
+  mstr,
+  ifNil,
+  guard,
+  getm,
+  parseJSON,
+  filterE,
+  reduceM
+} from "./sanctuary";
+const { Just, Nothing } = S;
+import {
+  assertMaybeEquality,
+  assertIsNothing,
+  assertIsJust
+} from "./test_utils";
+
+const assertIsLeft = (e, val) => {
+  assert(e.isLeft, "should be left");
+  assert.deepEqual(e.value, val);
+};
+
+const assertIsRight = (e, val) => {
+  assert(e.isRight, "should be right");
+  assert.deepEqual(e.value, val);
+};
+
+describe("sanctuary util functions", () => {
+  describe("allJust", () => {
+    const maybes = [Just(2), Just("maybe?")];
+
+    it("should return Just(values) if passed an array of Just values", () => {
+      const checked = allJust(maybes);
+      assert(S.isJust(checked));
+      checked.value.forEach((m, i) => assertMaybeEquality(m, maybes[i]));
+    });
+
+    it("should return Nothing if passed an array with a Nothing in it", () => {
+      assertIsNothing(allJust(maybes.concat(Nothing)));
+    });
+  });
+
+  describe("mstr", () => {
+    it("should print an empty string if called on Nothing", () => {
+      assert.equal("", mstr(Nothing));
+    });
+
+    it("should print the value wrapped with Just", () => {
+      assert.equal("4", mstr(Just(4)));
+      assert.equal("some text", mstr(Just("some text")));
+    });
+  });
+
+  describe("ifNil", () => {
+    it("returns Nothing if the input is undefined", () => {
+      assertIsNothing(ifNil(x => x)(undefined));
+    });
+
+    it("returns Nothing if the input is null", () => {
+      assertIsNothing(ifNil(x => x)(null));
+    });
+
+    it("return func(input) if the input is not nil", () => {
+      const result = ifNil(x => x)("test input");
+      assert.equal("test input", result);
+    });
+  });
+
+  describe("guard", () => {
+    const wrappedFunc = guard(x => x + 2);
+    const wrappedRestFunc = guard((x, y, z) => [x, y, z]);
+
+    it("takes a function and returns a function", () => {
+      assert.isFunction(wrappedFunc);
+      assert.isFunction(wrappedRestFunc);
+    });
+
+    it("returns a function that returns Nothing if any arguments are nil", () => {
+      assertIsNothing(wrappedFunc(null));
+      assertIsNothing(wrappedFunc(undefined));
+    });
+
+    it("returns a function that returns the Just(fn(args)) if no args are undefined", () => {
+      assertIsJust(wrappedFunc(2), 4);
+    });
+
+    it("accepts rest parameters", () => {
+      assertIsJust(wrappedRestFunc(1, 2, 3), [1, 2, 3]);
+    });
+
+    it("returns Nothing if any rest parameter arg is undefined", () => {
+      const args = [1, 2, 3];
+      [null, undefined].forEach(nilVal => {
+        for (let i = 0; i < 3; i++) {
+          assertIsNothing(wrappedRestFunc(...R.update(i, nilVal, args)));
+        }
+      });
+    });
+  });
+
+  describe("getm", () => {
+    it("returns Nothing if a prop is not present", () => {
+      assertIsNothing(getm("prop", {}));
+    });
+    [null, undefined].forEach(nil => {
+      // $FlowFixMe
+      it(`returns Nothing if a prop is ${nil}`, () => {
+        assertIsNothing(getm("prop", { prop: nil }));
+      });
+    });
+
+    it("returns Just(val) if a prop is present", () => {
+      assertIsJust(getm("prop", { prop: "HI" }), "HI");
+    });
+  });
+
+  describe("parseJSON", () => {
+    it("returns Left({}) if handed bad JSON", () => {
+      assertIsLeft(parseJSON(""), {});
+      assertIsLeft(parseJSON("[[[["), {});
+      assertIsLeft(parseJSON("@#R@#FASDF"), {});
+    });
+
+    it("returns Right(Object) if handed good JSON", () => {
+      const testObj = {
+        foo: ["bar", "baz"]
+      };
+      assertIsRight(parseJSON(JSON.stringify(testObj)), testObj);
+    });
+  });
+
+  describe("filterE", () => {
+    const left = S.Left(2);
+    const right = S.Right(4);
+    it("returns a Left if passed one, regardless of predicate", () => {
+      assertIsLeft(filterE(x => x === 2, left), 2);
+      assertIsLeft(filterE(x => x !== 2, left), 2);
+    });
+
+    it("returns a Left if predicate(right.value) === false", () => {
+      assertIsLeft(filterE(x => x === 2, right), 4);
+      assertIsLeft(filterE(R.isNil, right), 4);
+    });
+
+    it("returns a Right if predicate(right.value) === true", () => {
+      assertIsRight(filterE(x => x === 4, right), 4);
+      assertIsRight(filterE(x => x % 2 === 0, right), 4);
+    });
+  });
+
+  describe("reduceM", () => {
+    it("returns fn(val) where maybe is Just(val)", () => {
+      assert.equal(
+        reduceM("default", str => `${str} value`, S.Just("maybe")),
+        "maybe value"
+      );
+    });
+
+    it("returns fn(default) where maybe is Nothing", () => {
+      assert.equal(
+        reduceM("default", str => `${str} value`, S.Nothing),
+        "default value"
+      );
+    });
+  });
+});

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -1,0 +1,22 @@
+// @flow
+import { assert } from "chai";
+
+import { S } from "./sanctuary";
+const { Maybe } = S;
+
+export const assertMaybeEquality = (m1: Maybe, m2: Maybe) => {
+  assert(S.equals(m1, m2), `expected ${m1.value} to equal ${m2.value}`);
+};
+
+export const assertIsNothing = (m: Maybe) => {
+  assert(m.isNothing, `should be nothing, is ${m}`);
+};
+
+export const assertIsJust = (m: Maybe, val: any) => {
+  assert(m.isJust, `should be Just(${val}), is ${m}`);
+  assert.deepEqual(m.value, val);
+};
+
+export const assertIsJustNoVal = (m: Maybe) => {
+  assert(m.isJust, "should be a Just");
+};

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -1,0 +1,33 @@
+// @flow
+import R from "ramda";
+
+import { S } from "./sanctuary";
+
+// this function checks that a given object passes or fails validation.
+// if it fails, it returns a setter (R.set) which which set the appropirate
+// validation message in an object. Else, it returns nothing.
+//
+// The use pattern is to bind the first three arguments, so that the
+// validate function (below) can call that bound function with the object
+// to validate.
+export const validation = R.curry(
+  (validator: Function, lens: Function, message: string, toValidate: Object) =>
+    validator(R.view(lens, toValidate))
+      ? S.Just(R.set(lens, message))
+      : S.Nothing
+);
+
+// validate takes an array of validations and an object to validate.  A
+// validation is a validation function, e.g. as defined above with its first
+// three arguments bound (so a validator function, a lens, and a message).
+//
+// however, any function that takes `toValidate` and returns a setter function
+// wrapped in a Just will do.
+export const validate = R.curry((validations, toValidate) =>
+  R.converge(
+    R.compose(R.reduce((acc, setter) => setter(acc), {}), S.justs, Array),
+    validations
+  )(toValidate)
+);
+
+export const emptyOrNil = R.either(R.isEmpty, R.isNil);

--- a/static/js/reducers/collectionUi.js
+++ b/static/js/reducers/collectionUi.js
@@ -12,6 +12,7 @@ import {
   SET_SELECTED_VIDEO_KEY,
   SET_IS_NEW,
   CLEAR_COLLECTION_FORM,
+  VALIDATE_FORM
 } from '../actions/collectionUi';
 import { PERM_CHOICE_NONE } from '../lib/dialog';
 import { getFormKey } from '../lib/collection';
@@ -71,6 +72,11 @@ const reducer = (state: CollectionUiState = INITIAL_UI_STATE, action: Action<any
     return { ...state, isNew: action.payload };
   case CLEAR_COLLECTION_FORM:
     return INITIAL_UI_STATE;
+  case VALIDATE_FORM:
+    return {
+      ...state,
+      errors: action.payload.errors
+    };
   default:
     return state;
   }

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -13,3 +13,5 @@ $darkgray-bg: #1e1e1e;
 $darkgray-bg-link: #54a4e4;
 $fontblack: rgba(0,0,0,.87);
 $icons-grey-bg: rgba(0, 0, 0, .26);
+$validation-bg: #ffe8ec;
+$validation-text: #f07183;

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -137,3 +137,14 @@ a.button-link {
     color: #fff;
   }
 }
+
+.validation-message {
+  background-color: $validation-bg;
+  color: $validation-text;
+  font-size: 14px;
+  padding: 5px;
+}
+
+.mdc-textfield__input__invalid {
+  border: 1px solid #d50000 !important;
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #233

#### What's this PR do?
- Copies over some front-end validation code from open-discussions to OVS (at some point common functions should be in their own repo).
- Adds front-end validation upon form submission to verify that any moira-lists entered by the user exist and are mailing lists.  Displays error if not.
- Also validates that the collection title is not blank.
- Prevents dialog from closing on form submission if errors exist.

#### How should this be manually tested?
 - Test from two pages:  the collections page ('Create collection') and an existing collection ('Edit collection'):
  - Make title blank.
  - Enter at least one invalid moira list in view/admin lists text fields.
  - Click 'SAVE'.  There will be a delay as the moira API is called to check on the lists, then an error message should appear under title, and under each moira list text field in which contains invalid lists (with the invalid ones listed in the error message).
  - Fix the invalid fields and click 'SAVE' again.  The collection should be saved with the new info, and the form dialog should close.
