### PR TITLE
Split CSS into separate file

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-react": "^7.1.0",
     "express": "^4.15.3",
+    "extract-text-webpack-plugin": "2",
     "fetch-mock": "^5.12.1",
     "flow-bin": "^0.50.0",
     "iflow-lodash": "^1.1.27",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var path = require("path");
 var R = require('ramda');
 var BundleTracker = require('webpack-bundle-tracker');
+const glob = require('glob');
 const { config, babelSharedLoader } = require(path.resolve("./webpack.config.shared.js"));
 
 const hotEntry = (host, port) => (
@@ -37,7 +38,26 @@ const devConfig = Object.assign({}, config, {
 });
 
 devConfig.module.rules = [
-  babelSharedLoader, ...config.module.rules
+  babelSharedLoader,
+  ...config.module.rules,
+  {
+    test: /\.css$|\.scss$/,
+    use: [
+      {loader: 'style-loader'},
+      {loader: 'css-loader'},
+      {loader: 'postcss-loader'},
+      {
+        loader: 'sass-loader',
+        options: {
+          sourceMap: true,
+          includePaths: ['node_modules', 'node_modules/@material/*']
+            .map(dir => path.join(__dirname, dir))
+            .map(fullPath => glob.sync(fullPath))
+            .reduce((acc, matches) => acc.concat(matches), []),
+        }
+      },
+    ]
+  },
 ];
 
 const makeDevConfig = (host, port) => (

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,6 +1,8 @@
 var webpack = require('webpack');
 var path = require("path");
 var BundleTracker = require('webpack-bundle-tracker');
+const glob = require('glob');
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const { config, babelSharedLoader } = require(path.resolve("./webpack.config.shared.js"));
 
 const prodBabelConfig = Object.assign({}, babelSharedLoader);
@@ -11,7 +13,30 @@ prodBabelConfig.query.plugins.push(
 );
 
 const prodConfig = Object.assign({}, config);
-prodConfig.module.rules = [prodBabelConfig, ...config.module.rules];
+prodConfig.module.rules = [
+  prodBabelConfig,
+  ...config.module.rules,
+  {
+    test: /\.css$|\.scss$/,
+    use: ExtractTextPlugin.extract({
+      fallback: 'style-loader',
+      use: [
+        'css-loader',
+        'postcss-loader',
+        {
+          loader: 'sass-loader',
+          options: {
+            sourceMap: true,
+            includePaths: ['node_modules', 'node_modules/@material/*']
+              .map(dir => path.join(__dirname, dir))
+              .map(fullPath => glob.sync(fullPath))
+              .reduce((acc, matches) => acc.concat(matches), []),
+          }
+        },
+      ],
+    })
+  }
+];
 
 module.exports = Object.assign(prodConfig, {
   context: __dirname,
@@ -50,6 +75,11 @@ module.exports = Object.assign(prodConfig, {
       minimize: true
     }),
     new webpack.optimize.AggressiveMergingPlugin(),
+    new ExtractTextPlugin({
+      filename: "[name]-[contenthash].css",
+      allChunks: true,
+      ignoreOrder: false,
+    })
   ],
   devtool: 'source-map'
 });

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -17,47 +17,6 @@ module.exports = {
           test: /\.(png|svg|ttf|woff|woff2|eot|gif)$/,
           use: 'url-loader'
         },
-        {
-          test: /\.scss$/,
-          use: [
-            {
-              loader: 'style-loader',
-              options: {
-                sourceMap: true
-              }
-            },
-            {
-              loader: 'css-loader',
-              options: {
-                sourceMap: true
-              }
-            },
-            {
-              loader: 'postcss-loader',
-              options: {
-                sourceMap: true
-              }
-            },
-            {
-              loader: 'sass-loader',
-              options: {
-                sourceMap: true,
-                includePaths: ['node_modules', 'node_modules/@material/*']
-                  .map(dir => path.join(__dirname, dir))
-                  .map(fullPath => glob.sync(fullPath))
-                  .reduce((acc, matches) => acc.concat(matches), []),
-              }
-            },
-          ]
-        },
-        {
-          test: /\.css$/,
-          exclude: /node_modules/,
-          use: [
-            { loader: 'style-loader' },
-            { loader: 'css-loader' }
-          ]
-        },
       ]
     },
     resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2417,6 +2417,15 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extract-text-webpack-plugin@2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz#756ef4efa8155c3681833fbc34da53b941746d6c"
+  dependencies:
+    async "^2.1.2"
+    loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
+    webpack-sources "^1.0.1"
+
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/micromasters/pull/3637

#### What's this PR do?
Split CSS into separate file for production. This should 

#### How should this be manually tested?
 - Run `docker-compose run -e NODE_ENV=prod watch ./webpack_if_prod.sh`
 - Edit `DEBUG` and `ODL_VIDEO_SERVICE_USE_WEBPACK_DEV_SERVER` to be `False` and remove the watch container (and its link from the nginx container)
 - `docker-compose up`

View the site locally and open your network tab. You should see a CSS file being loaded. There should be no change to the user experience of the site.
