### PR TITLE
fix psycopg error

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ faker
 html5lib==0.999999999
 ipython
 newrelic
-psycopg2==2.6
+psycopg2==2.7
 pytz
 raven
 redis==2.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@
 -e git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
 amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via zeep
-appnope==0.1.0            # via ipython
 asn1crypto==0.22.0        # via cryptography
 billiard==3.5.0.3         # via celery
 boto3==1.4.4
@@ -48,7 +47,7 @@ packaging==16.8           # via cryptography
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 prompt-toolkit==1.0.14    # via ipython
-psycopg2==2.6
+psycopg2==2.7
 ptyprocess==0.5.2         # via pexpect
 pycountry==17.5.14
 pycparser==2.18           # via cffi


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

This upgrades psycopg to version 2.7 - I ran into an issue in MM (see https://github.com/mitodl/micromasters/pull/3666) where I couldn't rebuild the web container, and, lo and behold, I ran into the same issue over here. Upgrading the package version fixes the issue.

#### How should this be manually tested?

Check out this branch and make sure that you can run `docker-compose build --no-cache web` without any errors, and that everything runs as usual. Maybe confirm that you see errors from psycopg on `master` if you run the same command.