### PR TITLE
This fixes button style and layout bug

### DIFF
--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -158,7 +158,7 @@ class VideoDetailPage extends React.Component {
                   className="share mdc-button--raised"
                   onClick={showDialog.bind(this, DIALOGS.SHARE_VIDEO)}
                 >
-                  <span className="material-icons ">share</span> Share
+                  Share
                 </Button>
                 {
                   editable &&
@@ -167,13 +167,13 @@ class VideoDetailPage extends React.Component {
                       className="edit mdc-button--raised"
                       onClick={showDialog.bind(this, DIALOGS.EDIT_VIDEO)}
                     >
-                      <span className="material-icons">edit</span> Edit
+                      Edit
                     </Button>
                     <Button
                       className="dropbox mdc-button--raised"
                       onClick={saveToDropbox.bind(this, video)}
                     >
-                      <span className="material-icons ">file_download</span> Save To Dropbox
+                      Save To Dropbox
                     </Button>
                     <Button
                       className="delete mdc-button--raised"

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -179,7 +179,7 @@ class VideoDetailPage extends React.Component {
                       className="delete mdc-button--raised"
                       onClick={showDialog.bind(this, DIALOGS.DELETE_VIDEO)}
                     >
-                      <span className="material-icons">delete</span> Delete
+                      Delete
                     </Button>
                   </span>
                 }

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -45,6 +45,8 @@ button {
 
 .mdc-button--raised {
   background: $lightgray-bg;
+  box-shadow: none;
+  font-size: 13px;
 }
 
 .hidden {

--- a/static/scss/videoDetail.scss
+++ b/static/scss/videoDetail.scss
@@ -42,7 +42,9 @@
   margin-top: 20px;
 
   button.mdc-button {
-    margin-right: 12px;
+    margin-right: 9px;
+    margin-bottom: 10px;
+    min-width: 0;
 
     .material-icons {
       color: #555;


### PR DESCRIPTION
#### What are the relevant tickets?
#336 

#### What's this PR do?
Changes the style of the action buttons on the video details page. The spacing needed to be tightened up as we are adding more buttons. So I decreased the font size, got rid of the min-width, got rid of the icons, got rid of the drop-shadow. I also added some bottom margins that will fix the stacking bug in #336. 

#### How should this be manually tested?
![image](https://user-images.githubusercontent.com/20047260/32233056-e602d72c-be2f-11e7-92b0-a453eb748cd0.png)

![image](https://user-images.githubusercontent.com/20047260/32233080-f3781b10-be2f-11e7-949a-34de5c968814.png)


