### PR TITLE
add faq page

### DIFF
--- a/static/js/actions/commonUi.js
+++ b/static/js/actions/commonUi.js
@@ -1,28 +1,31 @@
 // @flow
-import { createAction } from 'redux-actions';
+import { createAction } from "redux-actions";
 
 export const qualifiedName = (name: string) => `UI_${name}`;
 
-export const SET_DRAWER_OPEN = qualifiedName('SET_DRAWER_OPEN');
+export const SET_DRAWER_OPEN = qualifiedName("SET_DRAWER_OPEN");
 export const setDrawerOpen = createAction(SET_DRAWER_OPEN);
 
-export const SHOW_DIALOG = qualifiedName('SHOW_DIALOG');
+export const SHOW_DIALOG = qualifiedName("SHOW_DIALOG");
 export const showDialog = createAction(SHOW_DIALOG);
 
-export const HIDE_DIALOG = qualifiedName('HIDE_DIALOG');
+export const HIDE_DIALOG = qualifiedName("HIDE_DIALOG");
 export const hideDialog = createAction(HIDE_DIALOG);
 
-export const INIT_EDIT_VIDEO_FORM = qualifiedName('INIT_EDIT_VIDEO_FORM');
+export const INIT_EDIT_VIDEO_FORM = qualifiedName("INIT_EDIT_VIDEO_FORM");
 export const initEditVideoForm = createAction(INIT_EDIT_VIDEO_FORM);
 
-export const SET_EDIT_VIDEO_TITLE = qualifiedName('SET_EDIT_VIDEO_TITLE');
+export const SET_EDIT_VIDEO_TITLE = qualifiedName("SET_EDIT_VIDEO_TITLE");
 export const setEditVideoTitle = createAction(SET_EDIT_VIDEO_TITLE);
 
-export const SET_EDIT_VIDEO_DESC = qualifiedName('SET_EDIT_VIDEO_DESC');
+export const SET_EDIT_VIDEO_DESC = qualifiedName("SET_EDIT_VIDEO_DESC");
 export const setEditVideoDesc = createAction(SET_EDIT_VIDEO_DESC);
 
-export const SHOW_MENU = qualifiedName('SHOW_MENU');
+export const SHOW_MENU = qualifiedName("SHOW_MENU");
 export const showMenu = createAction(SHOW_MENU);
 
-export const HIDE_MENU = qualifiedName('HIDE_MENU');
+export const HIDE_MENU = qualifiedName("HIDE_MENU");
 export const hideMenu = createAction(HIDE_MENU);
+
+export const TOGGLE_FAQ_VISIBILITY = qualifiedName("TOGGLE_FAQ_VISIBILITY");
+export const toggleFAQVisibility = createAction(TOGGLE_FAQ_VISIBILITY);

--- a/static/js/components/FAQ.js
+++ b/static/js/components/FAQ.js
@@ -1,0 +1,47 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react";
+
+import { adminFAQs, viewerFAQs } from "../data/faqs";
+
+export default class FAQ extends React.Component {
+  props: {
+    FAQVisibility: Map<string, boolean>,
+    toggleFAQVisibility:  Function,
+  }
+
+  renderFAQ = ([question, answer]: [string, any]) => {
+    const { FAQVisibility, toggleFAQVisibility } = this.props;
+
+    return (
+      <div className="question" key={question}>
+        <div className="show-hide-question" onClick={toggleFAQVisibility(question)}>
+          <i className="material-icons">
+            {FAQVisibility.get(question) ? "expand_more" : "chevron_right"}
+          </i>
+          <div>
+            {question}
+          </div>
+        </div>
+        {FAQVisibility.get(question)
+          ? <div className="answer">
+            {answer}
+          </div>
+          : null}
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="collection-list-content">
+        <div className="card centered-content">
+          <h2 className="mdc-typography--title">Frequently Asked Questions</h2>
+          <div className="frequently-asked-questions">
+            {Object.entries(SETTINGS.is_admin ? adminFAQs : viewerFAQs).map(this.renderFAQ)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/static/js/components/FAQ_test.js
+++ b/static/js/components/FAQ_test.js
@@ -1,0 +1,56 @@
+// @flow
+/* global SETTINGS:false */
+import React from "react";
+import sinon from "sinon";
+import { shallow } from "enzyme";
+import { assert } from "chai";
+
+import FAQ from "./FAQ";
+
+import { adminFAQs, viewerFAQs } from "../data/faqs";
+
+describe("FAQ Component", () => {
+  let FAQVisibility, toggleFAQVisibility;
+  beforeEach(() => {
+    FAQVisibility = new Map();
+    toggleFAQVisibility = sinon.stub();
+  });
+
+  const renderFAQs = () => shallow(<FAQ FAQVisibility={FAQVisibility} toggleFAQVisibility={toggleFAQVisibility} />);
+
+  it("shows the appropriate FAQs to the user", () => {
+    [true, false].forEach(isAdmin => {
+      SETTINGS.is_admin = isAdmin;
+      const wrapper = renderFAQs();
+      const questions = wrapper
+        .find(".show-hide-question")
+        .map(wrapper =>
+          wrapper
+            .find("div")
+            .at(1)
+            .text()
+        );
+      assert.deepEqual(questions, Object.keys(isAdmin ? adminFAQs : viewerFAQs));
+    });
+  });
+
+  it("calls the toggleFAQVisibility callback when a question title is clicked", () => {
+    const wrapper = renderFAQs();
+    wrapper.find(".show-hide-question").at(0).simulate("click");
+    assert(toggleFAQVisibility.called);
+  });
+
+  it("checks FAQVisibility to see if a question should be open", () => {
+    Object.entries(viewerFAQs).forEach(([question, answer]) => {
+      [true, false].forEach(visibility => {
+        FAQVisibility.set(question, visibility);
+        const wrapper = renderFAQs();
+        if (visibility) {
+          assert.equal(wrapper.find(".answer").text(), answer);
+        } else {
+          assert.lengthOf(wrapper.find(".answer"), 0);
+        }
+      });
+    });
+  });
+});

--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -108,6 +108,10 @@ class Drawer extends React.Component {
           }
         </nav>
         <nav id="icon-with-text-demo" className="mdc-temporary-drawer__content mdc-list">
+          <a className="mdc-list-item mdc-link" href="/help/">
+            <i className="material-icons mdc-list-item__start-detail" aria-hidden="true">help_outline</i>
+            Help
+          </a>
           <a className="mdc-list-item mdc-link" href="/logout/">
             <i className="material-icons mdc-list-item__start-detail" aria-hidden="true">input</i>
             Log out

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -76,7 +76,7 @@ describe("Drawer", () => {
 
   it('drawer element is rendered with collections', async () => {
     let wrapper = await renderDrawer();
-    let drawerNode = wrapper.find('.mdc-list-item .mdc-link').at(1);
+    let drawerNode = wrapper.find('.mdc-list-item .mdc-link').at(2);
     assert.equal(drawerNode.props().href, '/logout/');
     assert.isTrue(drawerNode.text().endsWith('Log out'));
   });
@@ -90,9 +90,16 @@ describe("Drawer", () => {
     });
   });
 
-  it('drawer element is rendered with a logout link', async () => {
+  it('drawer element is rendered with a help link', async () => {
     let wrapper = await renderDrawer();
     let drawerNode = wrapper.find('.mdc-list-item .mdc-link').at(1);
+    assert.equal(drawerNode.props().href, '/help/');
+    assert.isTrue(drawerNode.text().endsWith('Help'));
+  });
+
+  it('drawer element is rendered with a logout link', async () => {
+    let wrapper = await renderDrawer();
+    let drawerNode = wrapper.find('.mdc-list-item .mdc-link').at(2);
     assert.equal(drawerNode.props().href, '/logout/');
     assert.isTrue(drawerNode.text().endsWith('Log out'));
   });

--- a/static/js/containers/HelpPage.js
+++ b/static/js/containers/HelpPage.js
@@ -1,0 +1,33 @@
+// @flow
+import React from "react";
+import { connect } from "react-redux";
+import R from "ramda";
+
+import WithDrawer from "./WithDrawer";
+import FAQ from "../components/FAQ";
+import { toggleFAQVisibility } from '../actions/commonUi';
+
+class HelpPage extends React.Component {
+  toggleShowFAQ = R.curry((questionName, e) => {
+    const { dispatch } = this.props;
+
+    e.preventDefault();
+    dispatch(toggleFAQVisibility(questionName));
+  })
+
+  render() {
+    const { FAQVisibility } = this.props;
+
+    return (
+      <WithDrawer>
+        <FAQ FAQVisibility={FAQVisibility} toggleFAQVisibility={this.toggleShowFAQ} />
+      </WithDrawer>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  FAQVisibility: state.commonUi.FAQVisibility
+});
+
+export default connect(mapStateToProps)(HelpPage);

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -16,6 +16,8 @@ import EditVideoFormDialog from '../components/dialogs/EditVideoFormDialog';
 import ShareVideoDialog from '../components/dialogs/ShareVideoDialog';
 import DeleteVideoDialog from '../components/dialogs/DeleteVideoDialog';
 import { withDialogs } from '../components/dialogs/hoc';
+import VideoSubtitleCard from "../components/VideoSubtitleCard";
+import VideoSaverScript from "../components/VideoSaverScript";
 
 import { actions } from '../actions';
 import * as videoSubtitleActions from '../actions/videoUi';
@@ -24,14 +26,12 @@ import { makeCollectionUrl } from '../lib/urls';
 import { saveToDropbox } from '../lib/video';
 import { videoIsProcessing, videoHasError } from '../lib/video';
 import { DIALOGS, MM_DD_YYYY } from '../constants';
+import { updateVideoJsSync } from "../actions/videoUi";
+import { initGA, sendGAPageView } from "../util/google_analytics";
 
 import type { Video } from "../flow/videoTypes";
 import type { CommonUiState } from "../reducers/commonUi";
 import type { VideoUiState } from "../reducers/videoUi";
-import VideoSubtitleCard from "../components/VideoSubtitleCard";
-import { updateVideoJsSync } from "../actions/videoUi";
-import { initGA, sendGAPageView } from "../util/google_analytics";
-import VideoSaverScript from "../components/VideoSaverScript";
 
 class VideoDetailPage extends React.Component {
   props: {

--- a/static/js/data/faqs.js
+++ b/static/js/data/faqs.js
@@ -1,0 +1,44 @@
+// @flow
+/* eslint-disable max-len */
+export const adminFAQs = {
+  "I only see My Collections, but don't see any collections.":
+    "Once logged into the site, you should see your course collection on the list under My Collections.  Click the course folder to access the videos.",
+  "Where is my video?": `Videos recorded by the lecture capture systems in the classroom are automatically uploaded to the course collection overnight.  If a video has been uploaded, you should receive an email with a link to the video.  You can also go to your collection and view the videos.
+	If you uploaded from Dropbox, you video will be made available as soon as it has finished processing.  If you do not see your video after a reasonable amount of time, please contact odl-video-support@mit.edu for assistance.`,
+  "How do I share a video?":
+    "In your collection, click on the Share icon in the bottom right hand of your video.  You will have the option to copy the Video URL or embed the video into a webpage using HTML embed code.  Select which option you would like to use and paste it on your course website.",
+  "Sharing a collection":
+    "Once you are at the collection level, you can copy the URL and use it in your course website by pasting the link in Stellar. Please remember that any videos added to this collection will be available to anyone you have given access to the videos.",
+  "Delay posting a video link for your course.":
+    "If you wish to delay a video for viewing, you can post the embed code into your course site.  Students viewings the video will only be able to see the links that you share in this fashion.  Do not share the collection if you wish to delay viewing of videos for your course.",
+  "I see 0 videos in my collection. Where is my video?": `Your video might not be finished uploading.  Once it has uploaded, you should see a message in your collection that your vidoe is processing.  The video should be viewable once the transcoding process has finished.
+	If you still do not see a video in the collection, clear your cache and log in again (or try another browser).`,
+  "How do I rename my video?":
+    "Use the pencil icon to change the title name.  You can also add a description of your video as well. Click Save Changes when finished.",
+  "How do I add captions?":
+    "Click on the video icon that you wish to add captions or subtitles.  You will be redirected to the video page and will have the option to upload a WebVTT file for your captions.  Once uploaded, you should see the captions when you play your video and turn on the CC on the toolbar.",
+  "How do I create a new collection?":
+    "Log into video.odl.mit.edu and click the +Create New Collection icon.  You will then be able to name your collection, add in a description and add Moira access lists for viewing.",
+  "How do I edit my collection name and description?":
+    "Click on the gear icon in the top right hand side of the collection page.  A window will pop up that will allow you to change the title and add a description.  You will also be able to control access to the collection via Moira lists (see web.mit.edu/Moira for more information about creating a list.)  You can add lists for viewing, or for administrative access.  Once you have added the lists, click Save.",
+  "I don't see a popup window":
+    "Check your browser settings to make sure that you can access popup windows from video.odl.mit.edu",
+  "How do I get to my collections?":
+    "You can select the sandwich button on the upper left hand side of the screen to navigate you any of your collections.  You can also click the ODL Video Services title at the top of the page to get back to your list of collecitons that you have access for viewing.",
+  "I have a question that isn't on the FAQ": "Please contact odl-video-support@mit.edu",
+  "How do I log out of my collection?":
+    "Click the sandwich button on the upper left hand side of your screen and go to Logout at the bottom, or go to video.odl.mit.edu/logout"
+};
+
+export const viewerFAQs = {
+  "How can I access my course video?":
+    "Make sure you are logged into video.odl.mit.edu.  Once logged in, you can click on the link on your course site to play a video.",
+  "I only see My Collections, but don't see any collections.":
+    "Check with you faculty member as to whether you are on the video access list for your course.  OVS uses the Stellar course lists, so make sure you are registered for the course so you can access the videos.",
+  "I see 0 videos in my collection. Where is my video?":
+    "Check with your professor to make sure you have access to the course collection so you cna se ethe videos.",
+  "How can I play back the video at a faster speed?":
+    "On the lecture capture videos, click the gear icon on the toolbar. Select Speed, and then pick the speed you would like to use.",
+  "Multi camera lecture viewing.  How do I switch between cameras?":
+    "Once you have pressed the play button, you can select which source you would like to view using the four choices on the right hand side of your screen.  You cna also click the icon with the 4 images on the toolbar which will create a popup of the four sources that you can move off to the side and switch between sources.  If you have two monitors, this will allow you to watch the main video full screen and use the pop up window to control the camera source you would like to view."
+};

--- a/static/js/entry/help_page.js
+++ b/static/js/entry/help_page.js
@@ -1,0 +1,28 @@
+// @flow
+/* global SETTINGS:false */
+__webpack_public_path__ = SETTINGS.public_path;  // eslint-disable-line no-undef, camelcase
+import 'react-hot-loader/patch';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+import HelpPage from '../containers/HelpPage';
+
+import configureStore from '../store/configureStore';
+
+// Object.entries polyfill
+import entries from 'object.entries';
+if (!Object.entries) {
+  entries.shim();
+}
+
+const store = configureStore();
+
+const rootEl = document.getElementById("container");
+
+ReactDOM.render(
+  <Provider store={store}>
+    <HelpPage />
+  </Provider>,
+  rootEl
+);

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -14,7 +14,8 @@ declare var SETTINGS: {
   email: ?string,
   dropbox_key: string,
   support_email_address: string,
-  status_code?: number
+  status_code?: number,
+  is_admin: boolean
 };
 
 // mocha

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -10,7 +10,8 @@ const _createSettings = () => ({
   user: '',
   dropbox_key: 'dropbox_key',
   thumbnail_base_url: 'http://fake/',
-  support_email_address: 'support@example.com'
+  support_email_address: 'support@example.com',
+  is_admin: false,
 });
 
 global.SETTINGS = _createSettings();

--- a/static/js/reducers/commonUi.js
+++ b/static/js/reducers/commonUi.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Action } from '../flow/reduxTypes';
+import type { Action } from "../flow/reduxTypes";
 import {
   SHOW_DIALOG,
   HIDE_DIALOG,
@@ -8,12 +8,13 @@ import {
   SET_EDIT_VIDEO_TITLE,
   SET_EDIT_VIDEO_DESC,
   SHOW_MENU,
-  HIDE_MENU
-} from '../actions/commonUi';
-import { DIALOGS } from '../constants';
-import { showDialog, hideDialog } from '../lib/dialog';
+  HIDE_MENU,
+  TOGGLE_FAQ_VISIBILITY
+} from "../actions/commonUi";
+import { DIALOGS } from "../constants";
+import { showDialog, hideDialog } from "../lib/dialog";
 
-import type { DialogVisibilityState } from '../lib/dialog';
+import type { DialogVisibilityState } from "../lib/dialog";
 
 export type CommonUiState = DialogVisibilityState & {
   drawerOpen: boolean,
@@ -24,13 +25,14 @@ export type CommonUiState = DialogVisibilityState & {
   },
   menuVisibility: {
     [string]: boolean
-  }
-};
+  },
+  FAQVisibility: Map<string, boolean>
+}
 
 export const INITIAL_EDIT_VIDEO_FORM_STATE = {
   key: null,
-  title: '',
-  description: ''
+  title: "",
+  description: ""
 };
 
 export const INITIAL_UI_STATE = {
@@ -41,13 +43,14 @@ export const INITIAL_UI_STATE = {
   },
   drawerOpen: false,
   menuVisibility: {},
-  editVideoForm: INITIAL_EDIT_VIDEO_FORM_STATE
+  editVideoForm: INITIAL_EDIT_VIDEO_FORM_STATE,
+  FAQVisibility: new Map()
 };
 
 const reducer = (state: CommonUiState = INITIAL_UI_STATE, action: Action<any, null>) => {
   switch (action.type) {
   case SET_DRAWER_OPEN:
-    return {...state, drawerOpen: action.payload };
+    return { ...state, drawerOpen: action.payload };
   case SHOW_DIALOG:
     return showDialog(state, action.payload);
   case HIDE_DIALOG:
@@ -61,9 +64,9 @@ const reducer = (state: CommonUiState = INITIAL_UI_STATE, action: Action<any, nu
       }
     };
   case SET_EDIT_VIDEO_TITLE:
-    return {...state, editVideoForm: { ...state.editVideoForm, title: action.payload }};
+    return { ...state, editVideoForm: { ...state.editVideoForm, title: action.payload } };
   case SET_EDIT_VIDEO_DESC:
-    return {...state, editVideoForm: { ...state.editVideoForm, description: action.payload }};
+    return { ...state, editVideoForm: { ...state.editVideoForm, description: action.payload } };
   case SHOW_MENU:
     return {
       ...state,
@@ -79,6 +82,13 @@ const reducer = (state: CommonUiState = INITIAL_UI_STATE, action: Action<any, nu
         ...state.menuVisibility,
         [action.payload]: false
       }
+    };
+  case TOGGLE_FAQ_VISIBILITY: // eslint-disable-line no-case-declarations
+    let update = new Map(state.FAQVisibility);
+    update.set(action.payload, !update.get(action.payload));
+    return {
+      ...state,
+      FAQVisibility: update
     };
   default:
     return state;

--- a/static/js/reducers/commonUi_test.js
+++ b/static/js/reducers/commonUi_test.js
@@ -1,10 +1,10 @@
 // @flow
-import sinon from 'sinon';
+import sinon from "sinon";
 import configureTestStore from "redux-asserts";
-import { assert } from 'chai';
-import _ from 'lodash';
+import { assert } from "chai";
+import _ from "lodash";
 
-import rootReducer from '../reducers';
+import rootReducer from "../reducers";
 import {
   setDrawerOpen,
   setEditVideoTitle,
@@ -13,13 +13,14 @@ import {
   showDialog,
   hideDialog,
   showMenu,
-  hideMenu
-} from '../actions/commonUi';
+  hideMenu,
+  toggleFAQVisibility
+} from "../actions/commonUi";
 import { INITIAL_UI_STATE, INITIAL_EDIT_VIDEO_FORM_STATE } from "./commonUi";
 import { createAssertReducerResultState } from "../util/test_utils";
 import { DIALOGS } from "../constants";
 
-describe('CommonUi', () => {
+describe("CommonUi", () => {
   let sandbox, assertReducerResultState, store;
 
   beforeEach(() => {
@@ -32,36 +33,36 @@ describe('CommonUi', () => {
     sandbox.restore();
   });
 
-  it('should open the drawer in the UI', () => {
+  it("should open the drawer in the UI", () => {
     store.dispatch(setDrawerOpen(true));
-    assert.include(store.getState().commonUi, {drawerOpen: true});
+    assert.include(store.getState().commonUi, { drawerOpen: true });
   });
 
-  it('should close the drawer in the UI', () => {
+  it("should close the drawer in the UI", () => {
     store.dispatch(setDrawerOpen(false));
     assert.deepEqual(store.getState().commonUi, INITIAL_UI_STATE);
   });
 
-  it('setting the drawer visibility changes state', () => {
+  it("setting the drawer visibility changes state", () => {
     assertReducerResultState(setDrawerOpen, ui => ui.drawerOpen, false);
   });
 
-  it('has actions that set video title and description', () => {
+  it("has actions that set video title and description", () => {
     assert.deepEqual(store.getState().commonUi.editVideoForm, INITIAL_EDIT_VIDEO_FORM_STATE);
-    store.dispatch(setEditVideoTitle('title'));
-    store.dispatch(setEditVideoDesc('description'));
-    assert.equal(store.getState().commonUi.editVideoForm.title, 'title');
-    assert.equal(store.getState().commonUi.editVideoForm.description, 'description');
+    store.dispatch(setEditVideoTitle("title"));
+    store.dispatch(setEditVideoDesc("description"));
+    assert.equal(store.getState().commonUi.editVideoForm.title, "title");
+    assert.equal(store.getState().commonUi.editVideoForm.description, "description");
   });
 
-  it('has an action that initializes the edit video form,', () => {
-    let formObj = {key: 'key', title: 'title', description: 'description'};
+  it("has an action that initializes the edit video form,", () => {
+    let formObj = { key: "key", title: "title", description: "description" };
     store.dispatch(initEditVideoForm(formObj));
     assert.deepEqual(store.getState().commonUi.editVideoForm, formObj);
   });
 
-  it('has actions that open and close dialogs', () => {
-    _.mapKeys(DIALOGS, (dialogKey) => {
+  it("has actions that open and close dialogs", () => {
+    _.mapKeys(DIALOGS, dialogKey => {
       store.dispatch(showDialog(dialogKey));
       assert.deepEqual(store.getState().commonUi.dialogVisibility[dialogKey], true);
       store.dispatch(hideDialog(dialogKey));
@@ -69,11 +70,23 @@ describe('CommonUi', () => {
     });
   });
 
-  it('has actions that open and close menus', () => {
-    let formObj = {key: 'key', title: 'title', description: 'description'};
+  it("has actions that open and close menus", () => {
+    let formObj = { key: "key", title: "title", description: "description" };
     store.dispatch(showMenu(formObj));
     assert.deepEqual(store.getState().commonUi.menuVisibility[formObj], true);
     store.dispatch(hideMenu(formObj));
     assert.deepEqual(store.getState().commonUi.menuVisibility[formObj], false);
+  });
+
+  it("should have initial state for FAQ visibility", () => {
+    assert.deepEqual(store.getState().commonUi.FAQVisibility, new Map());
+  });
+
+  it("should let you toggle whether an FAQ is shown or not", () => {
+    assert.equal(store.getState().commonUi.FAQVisibility.get("my faq"), undefined);
+    store.dispatch(toggleFAQVisibility("my faq"));
+    assert.equal(store.getState().commonUi.FAQVisibility.get("my faq"), true);
+    store.dispatch(toggleFAQVisibility("my faq"));
+    assert.equal(store.getState().commonUi.FAQVisibility.get("my faq"), false);
   });
 });

--- a/static/scss/help-page.scss
+++ b/static/scss/help-page.scss
@@ -1,0 +1,24 @@
+.frequently-asked-questions {
+  .question {
+    margin-bottom: 20px;
+
+    .show-hide-question {
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      font-weight: 600;
+
+      i {
+        color: black;
+      }
+    }
+
+    .answer {
+      margin: 20px 22px;
+
+      @include breakpoint(phone) {
+        margin: 20px 0px;
+      }
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -25,3 +25,4 @@
 @import 'collection';
 @import 'sideDrawer';
 @import 'errorPage';
+@import 'help-page';

--- a/ui/templates/ui/help.html
+++ b/ui/templates/ui/help.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block title %}OVS | Help{% endblock %}
+{% block pagetitle %}OVS: Help{% endblock %}
+{% block content %}
+  <div id="container"></div>
+{% load render_bundle %}
+{% render_bundle 'help_page' %}
+{% endblock %}

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -16,6 +16,8 @@ urlpatterns = [
 
     url(r'^collections/', views.CollectionReactView.as_view(), name='collection-react-view'),
 
+    url(r'^help/', views.HelpPageView.as_view(), name='help-react-view'),
+
     url(r'^videos/(?P<video_key>[0-9a-f]+)/$', views.VideoDetail.as_view(), name='video-detail'),
     url(r'^videos/(?P<video_key>[0-9a-f]+)/embed/$', views.VideoEmbed.as_view(), name='video-embed'),
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -108,6 +108,22 @@ class VideoEmbed(TemplateView):
         return context
 
 
+@method_decorator(login_required, name='dispatch')
+class HelpPageView(TemplateView):
+    """View for the help page"""
+    template_name = "ui/help.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        has_admin = Collection.objects.all_admin(self.request.user).exists()
+        is_staff_or_superuser = ui_permissions.is_staff_or_superuser(self.request.user)
+        context["js_settings_json"] = json.dumps({
+            **default_js_settings(self.request),
+            'is_admin': has_admin or is_staff_or_superuser
+        })
+        return context
+
+
 class ModelDetailViewset(
         mixins.RetrieveModelMixin,
         mixins.UpdateModelMixin,

--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -9,6 +9,7 @@ module.exports = {
       'error': ['babel-polyfill', './static/js/entry/error'],
       'video_detail': ['babel-polyfill', './static/js/entry/video_detail'],
       'video_embed': ['babel-polyfill', './static/js/entry/video_embed'],
+      'help_page': ['babel-polyfill', './static/js/entry/help_page'],
       'style': './static/js/entry/style',
     },
     module: {


### PR DESCRIPTION
#### What are the relevant tickets?

closes #274 

#### What's this PR do?

This adds an FAQ / help page with expandable questions.

#### How should this be manually tested?

If you go to `/help` you should see the page. If you are an admin you should see the admin specific questions, if not you should see the viewer specific ones. You can change the value of `SETTINGS.is_admin` to test out both views.