### PR TITLE
404 for invalid collection/video keys

### DIFF
--- a/ui/urls.py
+++ b/ui/urls.py
@@ -14,12 +14,13 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^logout/$', django_logout_view, {'next_page': settings.LOGIN_URL}),
 
-    url(r'^collections/', views.CollectionReactView.as_view(), name='collection-react-view'),
+    url(r'^collections/(?P<collection_key>[0-9a-f]{32})?/?$', views.CollectionReactView.as_view(),
+        name='collection-react-view'),
 
     url(r'^help/', views.HelpPageView.as_view(), name='help-react-view'),
 
-    url(r'^videos/(?P<video_key>[0-9a-f]+)/$', views.VideoDetail.as_view(), name='video-detail'),
-    url(r'^videos/(?P<video_key>[0-9a-f]+)/embed/$', views.VideoEmbed.as_view(), name='video-embed'),
+    url(r'^videos/(?P<video_key>[0-9a-f]{32})/$', views.VideoDetail.as_view(), name='video-detail'),
+    url(r'^videos/(?P<video_key>[0-9a-f]{32})/embed/$', views.VideoEmbed.as_view(), name='video-embed'),
 
     url(r'^transcode/', include('dj_elastictranscoder.urls')),
     url(r'^api/v0/upload_videos/$', views.UploadVideosFromDropbox.as_view(), name='upload-videos'),

--- a/ui/views.py
+++ b/ui/views.py
@@ -59,8 +59,10 @@ class CollectionReactView(TemplateView):
     """List of collections"""
     template_name = "ui/collections.html"
 
-    def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
+    def get_context_data(self, collection_key=None, **kwargs):  # pylint: disable=arguments-differ
         context = super().get_context_data(**kwargs)
+        if collection_key:
+            get_object_or_404(Collection, key=collection_key)
         context["js_settings_json"] = json.dumps({
             **default_js_settings(self.request),
             'editable': ui_permissions.is_staff_or_superuser(self.request.user),

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -475,8 +475,20 @@ def test_upload_subtitles_authentication(mock_moira_client, logged_in_apiclient,
     assert client.post(url, input_data, format='multipart').status_code == status.HTTP_202_ACCEPTED
 
 
-@pytest.mark.parametrize("logged_in", [True, False])
-def test_page_not_found(logged_in, logged_in_apiclient, settings):
+@pytest.mark.parametrize("url", [
+    "/fake_page/",
+    "/collections/baduuid/",
+    "/collections/41ee85f9dbe141f5b8fa59dcf8c3063e/",
+    "/collections/01234567890123456789012345678901/",
+    "/collections/012345678901234567890123456789012/",
+    "/videos/baduuid/",
+    "/videos/01234567890123456789012345678902/",
+    "/videos/012345678901234567890123456789012/",
+    "/videos/baduuid/embed/"
+    "/videos/01234567890123456789012345678901/embed/",
+    "/videos/012345678901234567890123456789012/embed/",
+])
+def test_page_not_found(url, logged_in_apiclient, settings):
     """
     We should show the React container for our 404 page
     """
@@ -485,9 +497,7 @@ def test_page_not_found(logged_in, logged_in_apiclient, settings):
     settings.EMAIL_SUPPORT = 'support'
 
     client, user = logged_in_apiclient
-    if not logged_in:
-        client.logout()
-    resp = client.get("/definitely_not_a_real_page/")
+    resp = client.get(url)
     assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert json.loads(resp.context[0]['js_settings_json']) == {
         'cloudfront_base_url': settings.VIDEO_CLOUDFRONT_BASE_URL,
@@ -495,6 +505,6 @@ def test_page_not_found(logged_in, logged_in_apiclient, settings):
         'public_path': '/static/bundles/',
         'status_code': status.HTTP_404_NOT_FOUND,
         'support_email_address': settings.EMAIL_SUPPORT,
-        'email': user.email if logged_in else None,
-        'user': user.username if logged_in else None,
+        'email': user.email,
+        'user': user.username,
     }


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #350 
Closes #351 

#### What's this PR do?
Adjusts `ui/urls.py` file to accept only 32-character keys for collections & videos

#### How should this be manually tested?
- Create a collection and video if necessary
- The following URL's should still work:
  - /
  - /collections
  - /collections/<collection_key>
  - /videos/<video_key>
- The following should result in a 404 and not a 50x error:
  - /collections/1234
  - /videos/1234