### PR TITLE
Remove default mit email address

### DIFF
--- a/app.json
+++ b/app.json
@@ -70,7 +70,7 @@
       "description": "The execution environment that the app is in (e.g. dev, staging, prod)"
     },
     "ODL_VIDEO_FROM_EMAIL": {
-      "description": "default return address for email sent from the application"
+      "description": "default return address for email sent from the application",
       "value": "MIT ODL Video Service <webmaster@localhost>"
     },
     "ODL_VIDEO_BASE_URL": {

--- a/app.json
+++ b/app.json
@@ -70,7 +70,8 @@
       "description": "The execution environment that the app is in (e.g. dev, staging, prod)"
     },
     "ODL_VIDEO_FROM_EMAIL": {
-      "value": "MIT ODL Video Service <micromasters-support@mit.edu>"
+      "description": "default return address for email sent from the application"
+      "value": "MIT ODL Video Service <webmaster@localhost>"
     },
     "ODL_VIDEO_BASE_URL": {
       "description": "Application base URL",


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #181 

#### What's this PR do?

replaces default mit.edu address with webmaster@localhost

#### How should this be manually tested?

If the app deploys without upsetting CI settings, then everything is OK. 

#### Any background context you want to provide?

We really shouldn't leak mit.edu email addresses. Especially when they're not the right address anyway. 
