### PR TITLE
Sync settings with cookiecutter

### DIFF
--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -27,6 +27,7 @@ services:
       BOOTCAMP_DB_DISABLE_SSL: 'True'
       REDIS_URL: redis://redis:6379/0
       XDG_CACHE_HOME: /src/.cache
+      SECRET_KEY: travis_secret
     env_file: .env
 
   web:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       PORT: 8087
       COVERAGE_DIR: htmlcov
       DATABASE_URL: postgres://postgres@db:5432/postgres
-      ODL_VIDEO_SERVICE_USE_WEBPACK_DEV_SERVER: 'True'
+      ODL_VIDEO_USE_WEBPACK_DEV_SERVER: 'True'
       ODL_VIDEO_SECURE_SSL_REDIRECT: 'False'
       ODL_VIDEO_DB_DISABLE_SSL: 'True'
       CELERY_TASK_ALWAYS_EAGER: 'False'

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -468,6 +468,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'cloudsync.tasks.update_video_statuses',
         'schedule': get_int('VIDEO_STATUS_UPDATE_FREQUENCY', 60)
     },
+    'update-youtube-statuses': {
+        'task': 'cloudsync.tasks.update_youtube_statuses',
+        'schedule': get_int('VIDEO_STATUS_UPDATE_FREQUENCY', 60)
+    },
     'watch-bucket': {
         'task': 'cloudsync.tasks.monitor_watch_bucket',
         'schedule': get_int('VIDEO_WATCH_BUCKET_FREQUENCY', 900)

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ passenv =
     CI
     REDIS*
 setenv =
+    SECRET_KEY=secret
     DEBUG=False
     CELERY_TASK_ALWAYS_EAGER=True
     SENTRY_DSN=


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
- Uses `SECRET_KEY` environment variable instead of `DJANGO_SECRET_KEY`
 - Rename `ODL_VIDEO_SERVICE_USE_WEBPACK_DEV_SERVER` to `ODL_VIDEO_USE_WEBPACK_DEV_SERVER` for consistency with cookiecutter
 - Adds `SECURE_SSL_REDIRECT` from cookiecutter. This is necessary to force SSL use for end users
 - Move various settings around to make future comparisons with cookiecutter easier
 - Add OS X syslog settings from cookiecutter
 - Remove password validators which are unused

#### How should this be manually tested?
Nothing should be different
