### PR TITLE
bump psycopg to 2.7.3.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ faker
 html5lib==0.999999999
 ipython
 newrelic
-psycopg2==2.7
+psycopg2==2.7.3.2
 pytz
 raven
 redis==2.10.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ packaging==16.8           # via cryptography
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 prompt-toolkit==1.0.14    # via ipython
-psycopg2==2.7
+psycopg2==2.7.3.2
 ptyprocess==0.5.2         # via pexpect
 pyasn1-modules==0.1.5     # via google-auth, google-auth-httplib2, oauth2client
 pyasn1==0.3.7             # via google-auth, google-auth-httplib2, oauth2client, pyasn1-modules, rsa


### PR DESCRIPTION
#### What are the relevant tickets?

None, but we're avoiding issues like https://github.com/mitodl/micromasters/issues/3709

#### What's this PR do?

bumps the version of psycopg

#### How should this be manually tested?

do tests pass?

