### PR TITLE
Fix Moira-related issues

### DIFF
--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -18,5 +18,5 @@ export const wait = (millis: number): Promise<void> =>
 export const calculateListPermissionValue = (choice: string, listsInput: ?string): Array<string> => (
   choice !== PERM_CHOICE_LISTS || !listsInput || listsInput.trim().length === 0
     ? []
-    : R.map(R.trim, R.split(',', listsInput))
+    : R.reject(R.isEmpty, R.map(R.trim, R.split(',', listsInput)))
 );

--- a/static/js/util/util_test.js
+++ b/static/js/util/util_test.js
@@ -1,7 +1,7 @@
 // @flow
 import { assert } from 'chai';
 
-import { wait } from './util';
+import {calculateListPermissionValue, wait} from './util';
 
 describe('util functions', () => {
   it("waits some milliseconds", done => {
@@ -19,5 +19,10 @@ describe('util functions', () => {
         done();
       }, 20);
     }, 20);
+  });
+  it('test moira list values', () => {
+    let moiraString = ',foo,,,bar,rab,oof,';
+    let expectedLists = ['foo', 'bar', 'rab', 'oof'];
+    assert.deepEqual(expectedLists, calculateListPermissionValue('lists', moiraString));
   });
 });

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -19,3 +19,5 @@ requests-mock
 semantic-version
 tox
 moto
+# Fixes problem with pytest on travis
+astroid==1.5.3

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -71,6 +71,9 @@ def user_moira_lists(user):
     try:
         return moira.user_lists(moira_user.username, moira_user.type)
     except Exception as exc:  # pylint: disable=broad-except
+        if 'java.lang.NullPointerException' in str(exc):
+            # User is not a member of any moira lists, so ignore exception and return empty list
+            return []
         raise MoiraException('Something went wrong with getting moira-lists for %s' % user.username) from exc
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #370 
Fixes #391

#### What's this PR do?
- Ignores the exception thrown by Moira when retrieving moira lists for a user that isn't on any lists
- Prevents moira lists with blank names from being processed (dangling or multiple commas on front-end form).

#### How should this be manually tested?
- From a collection edit dialog, enter 1 or more real moira list names with extra commas at the beginning, end, and/or between the names.  Click the save button.  The dialog should close.  Open it again, and you should see the moira list names without the extra commas.
- From the command line:
   ```python
   from django.contrib.auth.models import User
   from ui.utils import user_moira_lists
   user, _ = User.objects.get_or_create(email='<listless_email>', defaults={'username': '<listless_email>'})
   user_moira_lists(user)
   ```
   This should return an empty list and not throw an exception.  A list of emails that currently throw exceptions can be found in the comments at https://sentry.io/mit-office-of-digital-learning/odl-video-service/issues/380406074/activity/
 