### PR TITLE
Fix embedded videos

### DIFF
--- a/ui/views.py
+++ b/ui/views.py
@@ -10,6 +10,7 @@ from django.shortcuts import (
     render,
 )
 from django.utils.decorators import method_decorator
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import TemplateView
 from rest_framework import (
     authentication,
@@ -95,6 +96,7 @@ class VideoDetail(TemplateView):
         return context
 
 
+@method_decorator(xframe_options_exempt, name='dispatch')
 class VideoEmbed(TemplateView):
     """Display embedded video"""
     template_name = 'ui/video_embed.html'


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #302 
- Does NOT solve Touchstone authentication bypassing (issue #344)

#### What's this PR do?
- Allows video embed pages to load in an external iframe (assuming no Touchstone or already logged in via Touchstone).

#### How should this be manually tested?
Create a simple HTML page with a video embed URL in an iframe, and then serve it locally via `python3 -m http.server <port>`.  The video should load inside the iframe.
