### PR TITLE
Use unique s3 key for each subtitle upload to avoid Cloudfront caching issue

### DIFF
--- a/static/js/components/VideoSubtitleCard.js
+++ b/static/js/components/VideoSubtitleCard.js
@@ -27,7 +27,7 @@ export default class VideoSubtitleCard extends React.Component {
             {video.videosubtitle_set.map((subtitle: VideoSubtitle, key) => (
               <div className="mdc-list-item" key={key}>
                 <span className="video-subtitle-filename">
-                  { subtitle.s3_object_key.split('/').slice(-1)}
+                  {subtitle.s3_object_key.split('/').slice(-1)[0].slice(0,10)}..._{subtitle.language}.vtt
                 </span>
                 <span className="video-subtitle-language">({subtitle.language_name})</span>
                 <span className="video-subtitle-button">

--- a/static/js/components/material/Filefield.js
+++ b/static/js/components/material/Filefield.js
@@ -22,7 +22,7 @@ export default class Filefield extends React.Component {
 
     let acceptedTypes = accept ? accept : "*";
 
-    return <a onClick={this.handleClick} href="#"
+    return <button onClick={this.handleClick} href="#"
       className={className ? `${className} button-link upload-link` : "button-link upload-link"}>
       <input
         type="file"
@@ -31,6 +31,6 @@ export default class Filefield extends React.Component {
         accept={acceptedTypes}
         {...otherProps} />
       {label}
-    </a>;
+    </button>;
   }
 }

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -123,7 +123,7 @@ textarea {
   height: 110px;
 }
 
-a.button-link {
+.button-link {
   background: $blue-button;
   font-size: 14px;
   color: rgba(255,255,255,.95);

--- a/ui/factories.py
+++ b/ui/factories.py
@@ -1,4 +1,7 @@
 """Factories for UI app"""
+from datetime import datetime
+
+import pytz
 from dj_elastictranscoder.models import EncodeJob
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -121,7 +124,7 @@ class VideoSubtitleFactory(DjangoModelFactory):
     """
     video = SubFactory(VideoFactory)
     language = 'en'
-    s3_object_key = LazyAttribute(lambda obj: obj.video.subtitle_key(language=obj.language))
+    s3_object_key = LazyAttribute(lambda obj: obj.video.subtitle_key(datetime.now(tz=pytz.UTC), language=obj.language))
     bucket_name = settings.VIDEO_S3_SUBTITLE_BUCKET
     filename = FuzzyText()
 

--- a/ui/models.py
+++ b/ui/models.py
@@ -210,16 +210,21 @@ class Video(models.Model):
         basename, _ = os.path.splitext(original_s3_key)
         return output_template.format(prefix=TRANSCODE_PREFIX, s3key=basename, preset=preset)
 
-    def subtitle_key(self, language='en'):
+    def subtitle_key(self, dttm, language='en'):
         """
         Returns an S3 object key to be used for a subtitle file
         Args:
             language(str): 2-letter language code
+            dttm(DateTime): a DateTime object
 
         Returns:
             str: S3 object key
         """
-        return 'subtitles/{}/subtitle_{}.vtt'.format(self.hexkey, language)
+        return 'subtitles/{key}/subtitles_{key}_{dt}_{lang}.vtt'.format(
+            key=self.hexkey,
+            dt=dttm.strftime('%Y%m%d%H%M%S'),
+            lang=language
+        )
 
     def update_status(self, status):
         """

--- a/ui/models_test.py
+++ b/ui/models_test.py
@@ -2,10 +2,14 @@
 Tests for the UI models
 """
 import os
+import re
 import uuid
+from datetime import datetime
 
 import boto3
 import pytest
+
+import pytz
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
@@ -177,3 +181,15 @@ def test_moira_members(mocker, moiralist):
 def test_video_subtitle_language():
     """ Tests that the correct language name for a code is returned"""
     assert VideoSubtitleFactory(language='en').language_name == 'English'
+
+
+def test_video_subtitle_key():
+    """ Tests that the correct subtitle key is returned for a language"""
+    video = VideoFactory(key='8494dafc-3665-4960-8e00-9790574ec93a')
+    now = datetime.now(tz=pytz.UTC)
+    assert re.fullmatch(
+        'subtitles/8494dafc366549608e009790574ec93a/subtitles_8494dafc366549608e009790574ec93a_{}_en.vtt'.format(
+            now.strftime('%Y%m%d%H%M%S')
+        ),
+        video.subtitle_key(now, 'en')
+    ) is not None

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -431,6 +431,8 @@ def test_upload_subtitles(logged_in_apiclient, mocker, enable_video_permissions,
     Tests for UploadVideoSubtitle
     """
     mocker.patch('ui.views.cloudapi.boto3')
+    expected_subtitle_key = 'subtitles/test/20171227121212_en.vtt'
+    mocker.patch('ui.models.Video.subtitle_key', return_value=expected_subtitle_key)
     settings.ENABLE_VIDEO_PERMISSIONS = enable_video_permissions
     client, user = logged_in_apiclient
     video = VideoFactory(collection=CollectionFactory(owner=user))
@@ -449,7 +451,7 @@ def test_upload_subtitles(logged_in_apiclient, mocker, enable_video_permissions,
     expected_data = {
         'language': 'en',
         'filename': filename,
-        's3_object_key': 'subtitles/{}/subtitle_en.vtt'.format(video.hexkey),
+        's3_object_key': expected_subtitle_key,
         'language_name': 'English'
     }
     for key in expected_data:


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #303 

#### What's this PR do?
Gives a unique S3 key (and consequently Cloudfront URL) based on datetime for each uploaded subtitle, to avoid caching issues which cause an old subtitle file to still be used for awhile after is is replaced by another.

#### How should this be manually tested?
Upload a subtitles file and display the subtitles.  Delete it, upload a different subtitle file, and turn subtitles on again.  The new subtitles should be displayed, not the old ones.
