### PR TITLE
Fixed issue with long video titles that do not break

### DIFF
--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -270,6 +270,7 @@ $video-card-width: 15.6%;
           line-height: 1.3;
           font-weight: 400;
           font-size: .9rem;
+          word-wrap: break-word;
 
           a {
             color: rgba(0,0,0,.87);


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
This fixes an issue where long video titles do not break when there is no space in the title.

#### How should this be manually tested?
See that it works. This is a one-line change.

BEFORE:
![image](https://user-images.githubusercontent.com/20047260/34733568-d1450b14-f536-11e7-947e-de708a6b3ef3.png)

AFTER:
![image](https://user-images.githubusercontent.com/20047260/34733550-c4e30394-f536-11e7-9996-c36f6a8e4a57.png)
