### PR TITLE
Add support for playing MP4 videos in multiple resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "url-loader": "^0.5.9",
     "video.js": "^5.20.1",
     "videojs-contrib-hls": "^5.8.3",
+    "videojs-resolution-switcher": "^0.4.2",
     "webpack": "^3.2.0",
     "webpack-bundle-tracker": "^0.2.0",
     "webpack-dev-middleware": "^1.11.0",

--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -4,7 +4,7 @@
 import React from "react"
 
 import { makeVideoSubtitleUrl } from "../lib/urls"
-import { getHLSEncodedUrl, videojs } from "../lib/video"
+import { videojs } from "../lib/video"
 import type { Video, VideoSubtitle } from "../flow/videoTypes"
 import { FULLSCREEN_API } from "../util/fullscreen_api"
 import { CANVASES } from "../constants"
@@ -29,12 +29,13 @@ const makeConfigForVideo = (video: Video): Object => ({
     nativeTextTracks: false
   },
   playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 4.0],
-  sources:       [
-    {
-      src:  getHLSEncodedUrl(video),
-      type: "application/x-mpegURL"
+  sources:       video.sources,
+  plugins:       {
+    videoJsResolutionSwitcher: {
+      default:      "high",
+      dynamicLabel: true
     }
-  ]
+  }
 })
 
 const drawCanvasImage = function(canvas, videoNode, shiftX, shiftY) {

--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -88,10 +88,17 @@ describe("VideoPlayer", () => {
           nativeTextTracks: false
         },
         playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 4.0],
-        sources:       [
+        plugins:       {
+          videoJsResolutionSwitcher: {
+            default:      "high",
+            dynamicLabel: true
+          }
+        },
+        sources: [
           {
-            type: "application/x-mpegURL",
-            src:  libVideo.getHLSEncodedUrl(video)
+            src:   libVideo.getHLSEncodedUrl(video),
+            type:  "application/x-mpegURL",
+            label: "HLS"
           }
         ]
       })

--- a/static/js/factories/video.js
+++ b/static/js/factories/video.js
@@ -64,6 +64,15 @@ export const makeVideoSubtitle = (
   language_name:  "English"
 })
 
+export const makeVideoSource = (
+  videoKey: string = casual.uuid,
+  encoding: string = ENCODING_HLS
+) => ({
+  src:   `https://fake.cloudfront.fake/${makeObjectKey(videoKey, encoding)}`,
+  type:  "application/x-mpegURL",
+  label: "HLS"
+})
+
 export const makeVideo = (
   videoKey: string = casual.uuid,
   collectionKey: string = casual.uuid
@@ -85,7 +94,8 @@ export const makeVideo = (
   status:             VIDEO_STATUS_COMPLETE,
   is_private:         false,
   is_public:          false,
-  view_lists:         []
+  view_lists:         [],
+  sources:            [makeVideoSource(videoKey, ENCODING_HLS)]
 })
 
 export const makeVideos = (

--- a/static/js/flow/videoTypes.js
+++ b/static/js/flow/videoTypes.js
@@ -27,6 +27,12 @@ export type VideoThumbnail = {
   bucket_name:   string,
 };
 
+export type VideoSource = {
+  src:           string,
+  label:         string,
+  type:          string,
+};
+
 export type Video = {
   key:                    string,
   created_at:             string,
@@ -42,7 +48,8 @@ export type Video = {
   view_lists:             Array<string>,
   collection_view_lists:   Array<string>,
   is_public:              boolean,
-  is_private:             boolean
+  is_private:             boolean,
+  sources:                Array<VideoSource>
 };
 
 export type VideoFormState = {

--- a/static/js/lib/video.js
+++ b/static/js/lib/video.js
@@ -19,6 +19,7 @@ import { makeVideoFileName, makeVideoFileUrl } from "./urls"
 // For this to work properly videojs must be available as a global
 global.videojs = _videojs
 require("videojs-contrib-hls")
+require("videojs-resolution-switcher")
 // export here to allow mocking of videojs function
 export const videojs = _videojs
 

--- a/static/scss/videoPlayer.scss
+++ b/static/scss/videoPlayer.scss
@@ -59,8 +59,13 @@
   bottom: 0;
 }
 
-//Uswitch styles
-.uswitch-odl-medium {
-  width: 80%;
-  height: calc(100vh - 200px);
+.vjs-resolution-button {
+  line-height: 3.0em;
+  position: absolute;
+  margin-top: 0.5em;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  text-align: center;
 }

--- a/ui/encodings.py
+++ b/ui/encodings.py
@@ -7,3 +7,9 @@ class EncodingNames:
     """Simple class to hold encoding names"""
     ORIGINAL = 'original'
     HLS = 'HLS'
+    SMALL = 'small'
+    BASIC = 'basic'
+    MEDIUM = 'medium'
+    LARGE = 'large'
+    HD = 'HD'
+    MP4 = [HD, LARGE, MEDIUM, BASIC, SMALL]

--- a/ui/models.py
+++ b/ui/models.py
@@ -178,6 +178,24 @@ class Video(models.Model):
         except YouTubeVideo.DoesNotExist:
             return None
 
+    @property
+    def sources(self):
+        """
+        Generate a sources dict for VideoJS
+
+        Returns:
+            dict: Dict of video sources for VideoJS
+        """
+        sources = [
+            {
+                "src": file.cloudfront_url,
+                "label": file.encoding,
+                "type":  "application/x-mpegURL" if file.encoding == EncodingNames.HLS else "video/mp4"
+            } for file in self.videofile_set.exclude(encoding__exact=EncodingNames.ORIGINAL)
+        ]
+        sources.sort(key=lambda x: EncodingNames.MP4.index(x['label']) if x['label'] in EncodingNames.MP4 else 0)
+        return sources
+
     def get_s3_key(self):
         """
         Avoid duplicate S3 keys/filenames when transferring videos from Dropbox

--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -156,7 +156,8 @@ class VideoSerializer(serializers.ModelSerializer):
             'view_lists',
             'collection_view_lists',
             'is_public',
-            'is_private'
+            'is_private',
+            'sources'
         )
         read_only_fields = (
             'key',
@@ -167,6 +168,7 @@ class VideoSerializer(serializers.ModelSerializer):
             'videothumbnail_set',
             'videosubtitle_set',
             'collection_view_lists',
+            'sources'
         )
 
 

--- a/ui/serializers_test.py
+++ b/ui/serializers_test.py
@@ -146,6 +146,7 @@ def test_video_serializer():
         'status': video.status,
         'collection_view_lists': [],
         'view_lists': [],
+        'sources': [],
         'is_private': False,
         'is_public': False
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,13 +245,13 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
-
-acorn@^5.2.1:
+acorn@^5.0.0, acorn@^5.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
+acorn@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
 
 aes-decrypter@1.0.3:
   version "1.0.3"
@@ -274,16 +274,7 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.5, ajv@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    json-schema-traverse "^0.3.0"
-    json-stable-stringify "^1.0.1"
-
-ajv@^5.3.0:
+ajv@^5.0.0, ajv@^5.1.5, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -291,6 +282,15 @@ ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    json-schema-traverse "^0.3.0"
+    json-stable-stringify "^1.0.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1126,19 +1126,19 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.9.2:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
-babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-runtime@^6.22.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.7.0:
   version "6.25.0"
@@ -1440,7 +1440,7 @@ chai@^4.1.0:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chalk@2.3.0, chalk@^2.1.0:
+chalk@2.3.0, chalk@^2.0.0, chalk@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
@@ -1458,7 +1458,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1:
+chalk@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
@@ -2448,18 +2448,18 @@ eslint@^4.2.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.1.6, espree@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
-  dependencies:
-    acorn "^5.1.1"
-    acorn-jsx "^3.0.0"
-
-espree@^3.5.2:
+espree@^3.1.6, espree@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
   dependencies:
     acorn "^5.2.1"
+    acorn-jsx "^3.0.0"
+
+espree@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
+  dependencies:
+    acorn "^5.1.1"
     acorn-jsx "^3.0.0"
 
 esprima@^2.6.0, esprima@^2.7.1:
@@ -3214,13 +3214,9 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
-ignore@^3.1.2, ignore@^3.3.3:
+ignore@^3.1.2, ignore@^3.2.7, ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
-
-ignore@^3.2.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -6514,6 +6510,10 @@ videojs-ie8@1.1.2:
   resolved "https://registry.yarnpkg.com/videojs-ie8/-/videojs-ie8-1.1.2.tgz#a23d3d8608ad7192b69c6077fc4eb848998d35d9"
   dependencies:
     es5-shim "^4.5.1"
+
+videojs-resolution-switcher@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/videojs-resolution-switcher/-/videojs-resolution-switcher-0.4.2.tgz#53ef38c58e95b90a61a7452de8177ee838a26405"
 
 videojs-swf@5.4.1:
   version "5.4.1"


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #413 

#### What's this PR do?
- Adds an `EncodingName` for each TechTV resolution
- Adds a `sources` property to `Video` model that returns a compatible configuration for VideoJS
- Installs and enables the `videojs-resolution-switcher` plugin for VideoJS, and configures it to play the highest available resolution by default (only with MP4 videos).

#### How should this be manually tested?
All existing videos and newly uploaded videos should work as before with no obvious changes.

Testing MP4 support will require some manual setup, since there's no code yet to import TechTV videos.  
  - Download the sample files available at https://www.dropbox.com/sh/8e4ndstrobxl300/AAAuYvvr7z6_btXoLSUyP4Bla?dl=0
  - Create a new Video object (shell or admin) and copy its UUID key.
  - In a django shell, do the following:
    - Upload the `original.m4v` file to the VIDEO_S3_BUCKET folder with key '`<videokey>`/original.m4v'. Example:
      ```python
      from ui.utils import get_bucket
      bucket = get_bucket(settings.VIDEO_S3_BUCKET)
      bucket.upload_file('original.m4v', '6097c15a226bfbb478b0bfade55ec0d2/original.m4v')
      ```
    - Create a new `VideoFile` object with encoding `ORIGINAL` and the above s3 key & bucket.
    - Upload the MP4 files to the VIDEO_S3_TRANSCODE_BUCKET with key 'transcoded/`<videokey>`/`<filename>`'
      ```python
      bucket = get_bucket(settings.VIDEO_S3_TRANSCODE_BUCKET)
      bucket.upload_file('hd.mp4', 'transcoded/6097c15a226bfbb478b0bfade55ec0d2/hd.mp4')
      ```
    - Create a new `VideoFile` object with the correct s3 key, bucket, and encoding ('small', 'medium', etc) for each upload.
    - Upload the JPEG image to the VIDEO_S3_THUMBNAIL_BUCKET with key '/thumbnails/`<videokey>`/`<filename>`'
      ```python
      bucket = get_bucket(settings.VIDEO_S3_THUMBNAIL_BUCKET)
      bucket.upload_file('001.jpg', 'thumbnails/6097c15a226bfbb478b0bfade55ec0d2/001.jpg')
      ```
    - Create a new `VideoThumbnail` object with the above s3 key and bucket.
 - Go to the detail page for the video.  The video should play, and there should be a quality selector button that defaults to `HD`.