### PR TITLE
TechTV URL's in OVS

### DIFF
--- a/ui/urls.py
+++ b/ui/urls.py
@@ -23,6 +23,10 @@ urlpatterns = [
     url(r'^videos/(?P<video_key>[0-9a-f]{32})/$', views.VideoDetail.as_view(), name='video-detail'),
     url(r'^videos/(?P<video_key>[0-9a-f]{32})/embed/$', views.VideoEmbed.as_view(), name='video-embed'),
 
+    url(r'^videos/(?P<video_key>\d+)-.+/?$', views.TechTVDetail.as_view(), name='techtv-detail'),
+    url(r'^videos/(?P<video_key>.+)/private/?$', views.TechTVPrivateDetail.as_view(), name='techtv-private'),
+    url(r'^embeds/(?P<video_key>\d+)/?$', views.TechTVEmbed.as_view(), name='techtv-embed'),
+
     url(r'^transcode/', include('dj_elastictranscoder.urls')),
     url(r'^api/v0/upload_videos/$', views.UploadVideosFromDropbox.as_view(), name='upload-videos'),
     url(r'^api/v0/upload_subtitles/$', views.UploadVideoSubtitle.as_view(),

--- a/ui/views.py
+++ b/ui/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import (
     get_object_or_404,
     redirect,
     render,
-)
+    get_list_or_404)
 from django.utils.decorators import method_decorator
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import TemplateView
@@ -25,6 +25,7 @@ from rest_framework.views import APIView
 
 from cloudsync import api as cloudapi
 from cloudsync.tasks import upload_youtube_caption
+from techtv2ovs.models import TechTVVideo
 from ui.serializers import VideoSerializer
 from ui.templatetags.render_bundle import public_path
 from ui import (
@@ -113,6 +114,39 @@ class VideoEmbed(TemplateView):
             'video': VideoSerializer(video).data,
         })
         return context
+
+
+class TechTVDetail(VideoDetail):
+    """
+    Video detail page for a TechTV-based URL
+    """
+    def get_context_data(self, video_key, **kwargs):
+        # There might be more than one imported TechTV video with this id
+        ttv_videos = get_list_or_404(TechTVVideo.objects.filter(ttv_id=video_key))
+        video = ttv_videos[0].video
+        return super().get_context_data(video.hexkey, **kwargs)
+
+
+class TechTVPrivateDetail(VideoDetail):
+    """
+    Video detail page for a TechTV-based private URL
+    """
+    def get_context_data(self, video_key, **kwargs):
+        # There might be more than one imported TechTV video with this private token
+        ttv_videos = get_list_or_404(TechTVVideo.objects.filter(private_token=video_key))
+        video = ttv_videos[0].video
+        return super().get_context_data(video.hexkey, **kwargs)
+
+
+class TechTVEmbed(VideoEmbed):
+    """
+    Video embed page for a TechTV-based URL
+    """
+    def get_context_data(self, video_key, **kwargs):
+        # There might be more than one imported TechTV video with this id
+        ttv_videos = get_list_or_404(TechTVVideo.objects.filter(ttv_id=video_key))
+        video = ttv_videos[0].video
+        return super().get_context_data(video.hexkey, **kwargs)
 
 
 @method_decorator(login_required, name='dispatch')


### PR DESCRIPTION
#### What are the relevant tickets?
- Partially addresses #418 (redirect from TechTV to OVS still required)
- closes #436 

#### What's this PR do?
- Reproduces TechTV URL's in OVS:
  - http://<domain>/videos/<techtv_video_id>-<techtv_title_slug>
  - http://<domain>/embeds/<techtv_video_id>
  - http://<domain>/videos/<techtv_private_token>/private

#### How should this be manually tested?
- Install/start MySQL and import the TechTV database dump located at https://www.dropbox.com/home/ODL-Video/TechTV/SQL
   ```
    mysql -u <username> -p techtv <dump_file.sql>
    ```

- Run the django command:
  ```
  docker-compose run web python manage.py techtvimport --user <mysql_user>  --db techtv --host 10.0.2.2 --aws --collection 3106
  ```
- This should import one protected collection with 1 video, which is marked as private.

- Login with an admin account, and verify that the following URL's all load a video titled `Special Seminar: Kenneth Tsa - Cutaneous Squamous Cell Carcinoma...`:
  - `http://<docker_ip>:8089/videos/29538-special-seminar-kenneth-tsa-cutaneous-squamous-cell-carcinoma-lessons-from-braf-inhibitors-and-insigh` (as video detail page)
  -  http://<docker_ip>:8089/embeds/29538 (as video embed page)
  - http://<docker_ip>:8089/videos/<private_token>/private (as video detail page, where `private_token` can be found in the related `TechTVVideo` object for the `Video`
  - http://<docker_ip>:8089/videos/<video_uuid_hexkey>, the typical URL for videos, should also work and be the default URL when navigating to this video from its collection page.
- URL's for non-TechTV videos should also continue to work as before.