### PR TITLE
Handle nested moira permissions on individual video/collection pages

### DIFF
--- a/ui/models.py
+++ b/ui/models.py
@@ -16,7 +16,6 @@ from mail import tasks
 from ui import utils
 from ui.constants import VideoStatus, YouTubeStatus
 from ui.encodings import EncodingNames
-from ui.exceptions import MoiraException
 from ui.tasks import delete_s3_objects
 
 TRANSCODE_PREFIX = 'transcoded'
@@ -27,19 +26,6 @@ class MoiraList(models.Model):
     Model for Moira
     """
     name = models.CharField(max_length=250, unique=True)
-
-    def members(self):
-        """
-        Retrieve the members of a moira list
-
-        Returns: (set) a unique set of moira list members.
-
-        """
-        moira = utils.get_moira_client()
-        try:
-            return set(moira.list_members(self.name, type=''))
-        except Exception as exc:
-            raise MoiraException('Something went wrong with getting moira-list members') from exc
 
     def __str__(self):
         return self.name

--- a/ui/models_test.py
+++ b/ui/models_test.py
@@ -168,17 +168,6 @@ def test_collection_for_for_owner():
     assert extra_collection not in qset
 
 
-def test_moira_members(mocker, moiralist):
-    """
-    Tests the MoiraList.members method
-    """
-    member_list = ['joe', 'nancy', 'nancy', 'foo', 'bar', 'bar@mit.edu']
-    mock_client = mocker.patch('ui.models.utils.get_moira_client')
-    mock_client().list_members.return_value = member_list
-    assert mock_client().list_members.called_once_with(moiralist.name)
-    assert moiralist.members() == set(member_list)
-
-
 def test_video_subtitle_language():
     """ Tests that the correct language name for a code is returned"""
     assert VideoSubtitleFactory(language='en').language_name == 'English'

--- a/ui/permissions.py
+++ b/ui/permissions.py
@@ -95,10 +95,7 @@ def has_admin_permission(obj, request):
     """
     if request.user == obj.owner or request.user.is_superuser:
         return True
-    lists = list(obj.admin_lists.values_list('name', flat=True))
-    if has_common_lists(request.user, lists):
-        return True
-    return False
+    return has_common_lists(request.user, list(obj.admin_lists.values_list('name', flat=True)))
 
 
 class HasCollectionPermissions(IsAuthenticated):

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -79,14 +79,23 @@ def user_moira_lists(user):
 
 def has_common_lists(user, list_names):
     """
-    Return true if the user's moira lists overlap with the collection's
+    Return true if the user is a member of any of the supplied moira list names
 
     Returns:
         bool: True if there is any name in list_names which is in the user's moira lists
     """
     if user.is_anonymous():
         return False
-    return len(set(user_moira_lists(user)).intersection(list_names)) > 0
+    moira_user = get_moira_user(user)
+    client = get_moira_client()
+    for moiralist in list_names:
+        try:
+            members = set(client.list_members(moiralist, type=''))
+            if moira_user.username in members:
+                return True
+        except Exception as exc:
+            raise MoiraException('Something went wrong with getting moira-list members: %s', moiralist) from exc
+    return False
 
 
 def get_et_job(job_id):


### PR DESCRIPTION
#### What are the relevant tickets?
- Closes #422 

#### What's this PR do?
Modifies permission methods to check the members of each view/admin moira list associated with a collection or video, one by one, but immediately return True if a match is found for the request user.  

#### How should this be manually tested?
- Create a collection with 1+ videos, with view permissions set to the`odl-engineering` moira list (and optionally 1 or 2 more lists).
- Create a user with username/email of someone who is in the `odl-engineering-platform` moira list, and make it a staff user.
- Log in as that user.  The above collection will still not show up in the list of available collections, but if you go directly to that collection's URL, you should be allowed to view the collection and its video.
- Repeat the above but remove `odl-engineering` from view permissions and add it to admin permissions instead.  You should be able to view and edit the collection and video.
- Repeat the above but remove `odl-engineering` from the collection admin permissions and add it to the video-specific permissions instead (you will need to set `ENABLE_VIDEO_PERMISSIONS=True`).

