### PR TITLE
Remove requirement that moira list must also be a mailing list

### DIFF
--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -25,12 +25,8 @@ def validate_moira_lists(lists):
     for mlist in lists:
         if not moira_client.list_exists(mlist.name):
             bad_lists.append(mlist.name)
-        else:
-            attributes = moira_client.client.service.getListAttributes(mlist.name, moira_client.proxy_id)
-            if not (attributes and attributes[0]['mailList']):
-                bad_lists.append(mlist.name)
     if bad_lists:
-        raise serializers.ValidationError("Not found or not mailing list: {}".format(','.join(bad_lists)))
+        raise serializers.ValidationError("Moira list does not exist: {}".format(','.join(bad_lists)))
     return lists
 
 

--- a/ui/serializers_test.py
+++ b/ui/serializers_test.py
@@ -46,21 +46,7 @@ def test_collection_serializer_validation_fake_admin_lists(mocker):
     serialized_data = serializers.CollectionSerializer(collection).data
     with pytest.raises(ValidationError) as exc:
         serializers.CollectionSerializer(data=serialized_data).is_valid(raise_exception=True)
-    assert exc.match('Not found or not mailing list: {}'.format(collection.admin_lists.first().name))
-
-
-def test_collection_serializer_validation_nonmail_admin_lists(mocker):
-    """
-    Test for CollectionSerializer's admin moira lists validation, for lists that aren't mailing lists
-    """
-    mock_client = mocker.patch('ui.serializers.get_moira_client')
-    mock_client().list_exists.return_value = True
-    mock_client().client.service.getListAttributes.return_value = [{'mailList': False}]
-    collection = factories.CollectionFactory(admin_lists=[factories.MoiraListFactory()])
-    serialized_data = serializers.CollectionSerializer(collection).data
-    with pytest.raises(ValidationError) as exc:
-        serializers.CollectionSerializer(data=serialized_data).is_valid(raise_exception=True)
-    assert exc.match('Not found or not mailing list: {}'.format(collection.admin_lists.first().name))
+    assert exc.match('Moira list does not exist: {}'.format(collection.admin_lists.first().name))
 
 
 def test_collection_serializer_validation_fake_view_lists(mocker):
@@ -73,21 +59,7 @@ def test_collection_serializer_validation_fake_view_lists(mocker):
     serialized_data = serializers.CollectionSerializer(collection).data
     with pytest.raises(ValidationError) as exc:
         serializers.CollectionSerializer(data=serialized_data).is_valid(raise_exception=True)
-    assert exc.match('Not found or not mailing list: {}'.format(collection.view_lists.first().name))
-
-
-def test_collection_serializer_validation_nonmail_view_lists(mocker):
-    """
-    Test for CollectionSerializer's viewable moira lists validation, for lists that aren't mailing lists
-    """
-    mock_client = mocker.patch('ui.serializers.get_moira_client')
-    mock_client().list_exists.return_value = True
-    mock_client().client.service.getListAttributes.return_value = [{'mailList': False}]
-    collection = factories.CollectionFactory(view_lists=[factories.MoiraListFactory()])
-    serialized_data = serializers.CollectionSerializer(collection).data
-    with pytest.raises(ValidationError) as exc:
-        serializers.CollectionSerializer(data=serialized_data).is_valid(raise_exception=True)
-    assert exc.match('Not found or not mailing list: {}'.format(collection.view_lists.first().name))
+    assert exc.match('Moira list does not exist: {}'.format(collection.view_lists.first().name))
 
 
 @pytest.mark.parametrize("has_permission", [True, False])


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #430

#### What's this PR do?
 - Removes the requirement that moira lists also be mailing lists.
 - Checks that an admin moira list is a mailing list before trying to send an email notification to it.

#### How should this be manually tested?
- Edit a collection and add `ovs-mvp-access` to either view or admin moira lists.  Save the change, it should be accepted and you should not get an error message.
