### PR TITLE
Updated cryptography requirement to fix incompatibility with OpenSSL

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 Django==1.10.5
 boto3==1.4.4
 celery==4.0.2
-cryptography==1.8.1
+cryptography
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@
 -e git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
 amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via fs, zeep
-appnope==0.1.0            # via ipython
 asn1crypto==0.22.0        # via cryptography
 billiard==3.5.0.3         # via celery
 bonobo==0.6.1
@@ -23,7 +22,7 @@ cffi==1.10.0              # via cryptography
 chardet==3.0.4            # via requests
 colorama==0.3.9           # via mondrian
 contextlib2==0.5.5        # via raven
-cryptography==1.8.1
+cryptography==2.1.4
 decorator==4.1.1          # via ipython, traitlets
 defusedxml==0.5.0         # via zeep
 dj-database-url==0.3.0
@@ -61,7 +60,7 @@ mysqlclient==1.3.12
 newrelic==2.88.1.73
 oauth2client==3.0.0
 oauthlib==2.0.6           # via requests-oauthlib
-packaging==16.8           # via bonobo, cryptography
+packaging==16.8           # via bonobo
 pbr==3.1.1                # via stevedore
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Upgrades the version of `cryptography` specified in the rquirements file so that it can be installed on Debian 9 with OpenSSL 1.0.1f

#### How should this be manually tested?
Rebuild the app container and ensure that tests are still passing and the app still runs without errors.

#### Where should the reviewer start?
`requirements.in` and `requirements.txt`

#### Any background context you want to provide?
While attempting to deploy the application on a Debian 9 host the dependency installation fails due to an incompatibility between OpenSSL 1.0.1f from the package repository, and cryptography 1.8.x. Compatibility with the 1.0.1f version of openssl was introduced in the 1.9.x release of cryptography.

#### What GIF best describes this PR or how it makes you feel?
![](https://i.imgur.com/t0XHtgJ.gif)
