### PR TITLE
TechTV caption import

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,6 +24,16 @@
       "default": "['*']",
       "description": "Array of allowed hostnames"
     },
+    "DROPBOX_KEY": {
+      "default": "",
+      "description": "Dropbox app key for uploads/downloads",
+      "required": true
+    },
+    "GA_TRACKING_ID": {
+      "default": "",
+      "description": "Google Analytics Tracking ID",
+      "required": false
+    },
     "GA_TRACKING_ID": {
       "default": "",
       "description": "Google Analytics Tracking ID",

--- a/requirements.in
+++ b/requirements.in
@@ -42,3 +42,5 @@ google-api-python-client
 mysqlclient
 dropbox
 bonobo
+-e git+https://github.com/mitodl/pycaption.git#egg=pycaption
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,12 @@
 git+https://github.com/mitodl/django-elastic-transcoder.git#egg=django-elastic-transcoder
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
 git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
+git+https://github.com/mitodl/pycaption.git#egg=pycaption
 amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via fs, zeep
+appnope==0.1.0            # via ipython
 asn1crypto==0.22.0        # via cryptography
+beautifulsoup4==4.6.0
 billiard==3.5.0.3         # via celery
 bonobo==0.6.1
 boto3==1.4.4
@@ -25,6 +28,7 @@ chardet==3.0.4            # via requests
 colorama==0.3.9           # via mondrian
 contextlib2==0.5.5        # via raven
 cryptography==2.1.4
+cssutils==1.0.2
 decorator==4.1.1          # via ipython, traitlets
 defusedxml==0.5.0         # via zeep
 dj-database-url==0.3.0
@@ -37,9 +41,11 @@ djangorestframework==3.6.3
 docutils==0.13.1          # via botocore
 dropbox==8.6.0
 elasticsearch==5.4.0      # via django-server-status
+enum34==1.1.6
 factory-boy==2.8.1
 faker==0.7.17
 fs==2.0.18                # via bonobo
+future==0.16.0
 google-api-python-client==1.6.4
 google-auth-httplib2==0.0.2
 google-auth-oauthlib==0.1.1

--- a/techtv2ovs/management/commands/techtvimport.py
+++ b/techtv2ovs/management/commands/techtvimport.py
@@ -1,6 +1,7 @@
 """ techtv2ovs command """
 import os
 from bonobo.contrib.django import ETLCommand
+from django.core.management import CommandError
 
 from techtv2ovs.utils import TechTVImporter
 
@@ -60,7 +61,9 @@ class Command(ETLCommand):
         """
         Run the command
         """
-
+        for env in ('DROPBOX_FOLDER', 'DROPBOX_TOKEN'):
+            if os.getenv(env) is None:
+                raise CommandError('`{}` environment variable must be set'.format(env))
         importer = TechTVImporter(
             db_user=options['user'],
             db_pw=os.getenv('MYSQL_PASSWORD', default=''),


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #416

#### What's this PR do?
Imports captions from a TechTV video into OVS

#### How should this be manually tested?
- Get a token for your dropbox app at https://www.dropbox.com/developers/apps
    - Click the 'Generate token' button
    - The dropbox account must have access to the folder `ODL-Video/TechTV/Captions` for this to work properly: the account owner should be on the 'ODL-Video' dropbox team, and the app should have 'Full Dropbox' access.
    - In your `.env` file, set `DROPBOX_TOKEN` to your token value.

- Install/start MySQL and import the TechTV database dump located at https://www.dropbox.com/home/ODL-Video/TechTV/SQL
   ```
    mysql -u <username> -p techtv <dump_file.sql>
    ```

- Run the django command:
    ```
     docker-compose run web python manage.py techtvimport --aws --user <mysql_user> --db techtv --host 10.0.2.2 --collection 3549 --protected 0
    ```

Three videos should be imported with working caption files in the collection "MIT Diversity Summits"