### PR TITLE
VideoJS YouTube Player

### DIFF
--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -53,7 +53,7 @@ def videofile():
     return VideoFileFactory()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def user():
     """Fixture to create a user"""
     return UserFactory()

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "video.js": "^5.20.1",
     "videojs-contrib-hls": "^5.8.3",
     "videojs-resolution-switcher": "^0.4.2",
+    "videojs-youtube": "^2.4.1",
     "webpack": "^3.2.0",
     "webpack-bundle-tracker": "^0.2.0",
     "webpack-dev-middleware": "^1.11.0",

--- a/static/js/factories/video.js
+++ b/static/js/factories/video.js
@@ -95,7 +95,8 @@ export const makeVideo = (
   is_private:         false,
   is_public:          false,
   view_lists:         [],
-  sources:            [makeVideoSource(videoKey, ENCODING_HLS)]
+  sources:            [makeVideoSource(videoKey, ENCODING_HLS)],
+  youtube_id:         null
 })
 
 export const makeVideos = (

--- a/static/js/flow/videoTypes.js
+++ b/static/js/flow/videoTypes.js
@@ -49,7 +49,8 @@ export type Video = {
   collection_view_lists:   Array<string>,
   is_public:              boolean,
   is_private:             boolean,
-  sources:                Array<VideoSource>
+  sources:                Array<VideoSource>,
+  youtube_id:            ?string
 };
 
 export type VideoFormState = {

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -60,3 +60,6 @@ afterEach(function() {
 import chai from "chai"
 import chaiAsPromised from "chai-as-promised"
 chai.use(chaiAsPromised)
+// create fake script tag to appease videojs-youtube
+const script = document.createElement("script")
+document.body.appendChild(script)

--- a/static/js/lib/video.js
+++ b/static/js/lib/video.js
@@ -20,6 +20,8 @@ import { makeVideoFileName, makeVideoFileUrl } from "./urls"
 global.videojs = _videojs
 require("videojs-contrib-hls")
 require("videojs-resolution-switcher")
+require("videojs-youtube")
+
 // export here to allow mocking of videojs function
 export const videojs = _videojs
 

--- a/static/scss/videoPlayer.scss
+++ b/static/scss/videoPlayer.scss
@@ -33,19 +33,21 @@
 
 .video-js {
   &:not(.vjs-fullscreen) {
-    position: relative !important;
-    width: inherit !important;
-    height: inherit !important;
-    overflow: hidden;
-
-    .vjs-tech {
+    &:not(.vjs-youtube) {
       position: relative !important;
       width: inherit !important;
       height: inherit !important;
-      max-height: calc(100vh - 200px);
+      overflow: hidden;
 
-      @include breakpoint(mobile) {
-        max-height: calc(100vh - 60px);
+      .vjs-tech {
+        position: relative !important;
+        width: inherit !important;
+        height: inherit !important;
+        max-height: calc(100vh - 200px);
+
+        @include breakpoint(mobile) {
+          max-height: calc(100vh - 60px);
+        }
       }
     }
   }

--- a/ui/models.py
+++ b/ui/models.py
@@ -185,6 +185,8 @@ class Video(models.Model):
         Returns:
             dict: Dict of video sources for VideoJS
         """
+        if self.collection.stream_source == StreamSource.YOUTUBE:
+            return []
         sources = [
             {
                 "src": file.cloudfront_url,

--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -153,7 +153,8 @@ class VideoSerializer(serializers.ModelSerializer):
             'collection_view_lists',
             'is_public',
             'is_private',
-            'sources'
+            'sources',
+            'youtube_id'
         )
         read_only_fields = (
             'key',
@@ -164,7 +165,8 @@ class VideoSerializer(serializers.ModelSerializer):
             'videothumbnail_set',
             'videosubtitle_set',
             'collection_view_lists',
-            'sources'
+            'sources',
+            'youtube_id'
         )
 
 

--- a/ui/serializers_test.py
+++ b/ui/serializers_test.py
@@ -96,13 +96,18 @@ def test_collection_list_serializer():
     assert serializers.CollectionListSerializer(collection).data == expected
 
 
-def test_video_serializer():
+@pytest.mark.parametrize('youtube', [True, False])
+@pytest.mark.parametrize('public', [True, False])
+def test_video_serializer(youtube, public):
     """
     Test for VideoSerializer
     """
     video = factories.VideoFactory()
     video_files = [factories.VideoFileFactory(video=video)]
     video_thumbnails = [factories.VideoThumbnailFactory(video=video)]
+    video.is_public = public
+    if youtube and public:
+        factories.YouTubeVideoFactory(video=video)
 
     expected = {
         'key': video.hexkey,
@@ -120,7 +125,8 @@ def test_video_serializer():
         'view_lists': [],
         'sources': [],
         'is_private': False,
-        'is_public': False
+        'is_public': public,
+        'youtube_id': (video.youtube_id if youtube and public else None)
     }
     assert serializers.VideoSerializer(video).data == expected
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,14 +2975,7 @@ glob@~7.0.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.3.0.tgz#ef7ec4beead579b454f5ebd5e7f303db54f42a2b"
-  dependencies:
-    min-document "^2.6.1"
-    process "~0.5.1"
-
-global@^4.3.0, global@^4.3.1, global@^4.3.2, global@~4.3.0:
+global@4.3.2, global@^4.3.0, global@^4.3.1, global@^4.3.2, global@~4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
   dependencies:
@@ -4144,7 +4137,7 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-min-document@^2.19.0, min-document@^2.6.1:
+min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
   dependencies:
@@ -6465,7 +6458,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-video.js@^5.17.0, "video.js@^5.19.1 || ^6.2.0", video.js@^5.20.1:
+video.js@^5.17.0, "video.js@^5.19.1 || ^6.2.0", video.js@^5.20.1, "video.js@^5.6.0 || ^6.2.8":
   version "5.20.2"
   resolved "https://registry.yarnpkg.com/video.js/-/video.js-5.20.2.tgz#9f0b6121a2f841fc4b1c473d8983ef4d10c663ba"
   dependencies:
@@ -6501,9 +6494,9 @@ videojs-contrib-media-sources@4.4.8:
     video.js "^5.17.0"
     webworkify "1.0.2"
 
-videojs-font@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/videojs-font/-/videojs-font-2.0.0.tgz#af7461ef9d4b95e0334bffb78b2f2ff0364a9034"
+videojs-font@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/videojs-font/-/videojs-font-2.1.0.tgz#a25930a67f6c9cfbf2bb88dacb8c6b451f093379"
 
 videojs-ie8@1.1.2:
   version "1.1.2"
@@ -6519,11 +6512,17 @@ videojs-swf@5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/videojs-swf/-/videojs-swf-5.4.1.tgz#2077ef71c749f2c7823ef49babae4dd2acb08f87"
 
-videojs-vtt.js@0.12.4:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/videojs-vtt.js/-/videojs-vtt.js-0.12.4.tgz#38f2499e31efb3fa93590ddad4cb663275a4b161"
+videojs-vtt.js@0.12.6:
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/videojs-vtt.js/-/videojs-vtt.js-0.12.6.tgz#e078600bda899eaa6f9c3307134cd0c811947b8e"
   dependencies:
     global "^4.3.1"
+
+videojs-youtube@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/videojs-youtube/-/videojs-youtube-2.4.1.tgz#4ebd6736a09c636f79fcc324befd9db230780bfc"
+  dependencies:
+    video.js "^5.6.0 || ^6.2.8"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -6697,9 +6696,9 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-xhr@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.2.2.tgz#2ee72571869f8686d41559a9ea286c18971435ff"
+xhr@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/xhr/-/xhr-2.4.0.tgz#e16e66a45f869861eeefab416d5eff722dc40993"
   dependencies:
     global "~4.3.0"
     is-function "^1.0.1"


### PR DESCRIPTION
#### What are the relevant tickets?
- Closes #452 

#### What's this PR do?
- Videos with a collection `stream_source` of `None` will play from YouTube if available, Cloudfront otherwise.
- Videos with a collection `stream_source` of `Youtube` will only play from YouTube, available or not.
- Videos with a collection `stream_source` of `Cloudfront` will never play from YouTube, only Cloudfront.

#### How should this be manually tested?
- Assign working values for `.env` variables `YT_CLIENT_ID`, `YT_PROJECT_ID`, `YT_CLIENT_SECRET`, `YT_ACCESS_TOKEN`, `YT_REFRESH_TOKEN` (I can send them to you)
- You can run the import command 3x as explained in PR #454.  Or just change the `stream_source` value of an existing collection.
- After each run/stream_source change, wait a few minutes if necessary for videos to upload to Youtube, then try to play a video.  The video should play from the expected source based on the rules above.
- Block off youtube by modifying your `/etc/hosts` file (or ad blocker list).  Then try playing a video.  The video should still play from Cloudfront if its collection `stream_source` is `None` or `Cloudfront`.  It should not be playable if the `stream_source` is `Youtube`.
    - This is done in the front-end on page load by trying to create an `Image` with a src url equal to the first thumbnail for a Youtube video, the assumption being that if that cannot be loaded then the video can't be either.  


Note: I had to manually edit yarn.lock because it was creating duplicate dependencies for video.js that broke the youtube plugin, I think it may be related [to this bug](https://github.com/yarnpkg/yarn/issues/3967).