### PR TITLE
Force login on protected video URL's but not public video URL's

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -110,7 +110,7 @@ if get_bool('USE_SHIBBOLETH', False):
     AUTHENTICATION_BACKENDS = [
         'shibboleth.backends.ShibbolethRemoteUserBackend',
     ]
-    LOGIN_URL = "/collections"
+    LOGIN_URL = "/collections/"
 else:
     LOGIN_URL = "/admin/login/"
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #461

#### What's this PR do?
- If a video is not public and the user is not logged in, redirect to a login-required version of the URL; once logged in that URL should then redirect back to the standard video URL.  If the user is logged in but does not have permission, show the 'You do not have permission' message.  
- Checks for a next parameter on the collections view since that's what the production login URL is set to with Touchstone enabled.

#### How should this be manually tested?
- Try to access a video URL without being logged in.  You should be redirected to the login page.  After login you should be redirected back to the original video URL.
- Login as a non-superuser and navigate to a private video URL.  You should get a no permission message.
- Set `ENABLE_VIDEO_PERMISSIONS` to True and make a video public (it will need subtitles).  Log out and go to the video detail page, it should load.
- Repeat for video embed URL, and TechTV URL's.
- Try the URL `/collections/?next=/videos/<your_video_key>`.  You should be redirected to that video page.