### PR TITLE
Upgrade to Django 1.11

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,29 @@
+"""
+Pytest configuration file for the entire application
+"""
+# pylint: disable=redefined-outer-name
+import warnings
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def warnings_as_errors():
+    """
+    Convert warnings to errors. This should only affect unit tests, letting pylint and other plugins
+    raise DeprecationWarnings without erroring.
+    """
+    try:
+        warnings.resetwarnings()
+        warnings.simplefilter('error')
+        # For celery
+        warnings.simplefilter('ignore', category=ImportWarning)
+        warnings.filterwarnings(
+            "ignore",
+            message="'async' and 'await' will become reserved keywords in Python 3.7",
+            category=DeprecationWarning,
+        )
+
+        yield
+    finally:
+        warnings.resetwarnings()

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -75,7 +75,7 @@ DISABLE_WEBPACK_LOADER_STATS = get_bool("DISABLE_WEBPACK_LOADER_STATS", False)
 if not DISABLE_WEBPACK_LOADER_STATS:
     INSTALLED_APPS += ('webpack_loader',)
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -91,7 +91,7 @@ if DEBUG:
     INSTALLED_APPS += (
         'nplusone.ext.django',
     )
-    MIDDLEWARE_CLASSES += (
+    MIDDLEWARE += (
         'nplusone.ext.django.NPlusOneMiddleware',
     )
 
@@ -100,7 +100,7 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 LOGIN_REDIRECT_URL = "/"
 if get_bool('USE_SHIBBOLETH', False):
     # TOUCHSTONE
-    MIDDLEWARE_CLASSES.append('shibboleth.middleware.ShibbolethRemoteUserMiddleware')
+    MIDDLEWARE.append('shibboleth.middleware.ShibbolethRemoteUserMiddleware')
     SHIBBOLETH_ATTRIBUTE_MAP = {
         "EPPN": (True, "username"),
         "MAIL": (True, "email"),
@@ -518,7 +518,7 @@ MIDDLEWARE_FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS = get_int(
     'MIDDLEWARE_FEATURE_FLAG_COOKIE_MAX_AGE_SECONDS', 60 * 60)
 
 if MIDDLEWARE_FEATURE_FLAG_QS_PREFIX:
-    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + (
+    MIDDLEWARE = MIDDLEWARE + (
         'odl_video.middleware.QueryStringFeatureFlagMiddleware',
         'odl_video.middleware.CookieFeatureFlagMiddleware',
     )

--- a/pylintrc
+++ b/pylintrc
@@ -19,4 +19,4 @@ ignored-modules=
 	six.moves,
 
 [MESSAGES CONTROL]
-disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use
+disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use, no-else-return

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,10 +4,3 @@ norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.e
 pep8ignore =
    */migrations/* ALL
 pep8maxlinelength = 119
-filterwarnings =
-    error
-    ignore::DeprecationWarning
-    ignore::django.utils.deprecation.RemovedInDjango20Warning
-    ignore::ImportWarning
-    ignore::PendingDeprecationWarning
-    ignore:Failed to load HostKeys

--- a/requirements.in
+++ b/requirements.in
@@ -1,13 +1,13 @@
-Django==1.10.5
+Django==1.11.10
 boto3==1.4.4
 celery==4.0.2
 cryptography
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0
-djangorestframework==3.6.3
+djangorestframework==3.7.7
 django-server-status==0.5.0
-django-webpack-loader==0.4.1
+django-webpack-loader==0.5.0
 factory_boy
 faker
 html5lib==0.999999999

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,12 @@
 #
 --no-binary psycopg2
 
-git+https://github.com/mitodl/django-elastic-transcoder.git#egg=django-elastic-transcoder
-git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
-git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
-git+https://github.com/mitodl/pycaption.git#egg=pycaption
+-e git+https://github.com/mitodl/django-elastic-transcoder.git#egg=django-elastic-transcoder
+-e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
+-e git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
+-e git+https://github.com/mitodl/pycaption.git#egg=pycaption
 amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via fs, zeep
-appnope==0.1.0            # via ipython
 asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.6.0
 billiard==3.5.0.3         # via celery
@@ -35,9 +34,9 @@ dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0
 django-server-status==0.5.0
-django-webpack-loader==0.4.1
-django==1.10.5
-djangorestframework==3.6.3
+django-webpack-loader==0.5.0
+django==1.11.10
+djangorestframework==3.7.7
 docutils==0.13.1          # via botocore
 dropbox==8.6.0
 elasticsearch==5.4.0      # via django-server-status

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@
 #
 --no-binary psycopg2
 
--e git+https://github.com/mitodl/django-elastic-transcoder.git#egg=django-elastic-transcoder
--e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
--e git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
--e git+https://github.com/mitodl/pycaption.git#egg=pycaption
+git+https://github.com/mitodl/django-elastic-transcoder.git#egg=django-elastic-transcoder
+git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
+git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
+git+https://github.com/mitodl/pycaption.git#egg=pycaption
 amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via fs, zeep
 asn1crypto==0.22.0        # via cryptography

--- a/techtv2ovs/utils.py
+++ b/techtv2ovs/utils.py
@@ -334,8 +334,8 @@ class TechTVImporter:
                 description=remove_tags(description),
                 owner=get_owner(email),
             )
-            ovs_collection.admin_lists = [admin_list]
-            ovs_collection.view_lists = [view_list]
+            ovs_collection.admin_lists.set([admin_list])
+            ovs_collection.view_lists.set([view_list])
             ovs_collection.save()
             ttvcollection.collection = ovs_collection
             ttvcollection.save()

--- a/ui/api_test.py
+++ b/ui/api_test.py
@@ -3,6 +3,7 @@ Tests for ui/api.py
 """
 from uuid import uuid4
 
+from django.core.exceptions import ValidationError
 from django.http import Http404
 import pytest
 
@@ -74,9 +75,9 @@ def test_process_dropbox_data_empty_link_list(mocker):
 
 def test_process_dropbox_data_wrong_collection():
     """
-    Tests that the process_dropbox_data in case the collection does not exist
+    Tests that process_dropbox_data errors in case the collection does not exist
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         api.process_dropbox_data(
             {
                 'collection': 'fooooooooo',

--- a/ui/permissions_test.py
+++ b/ui/permissions_test.py
@@ -221,7 +221,7 @@ def test_is_collection_user_not_matching_admin_lists(mock_moira_client,
     Test for HasCollectionPermissions.has_object_permission to verify
     that user who does not match a collection moira admin list does not have permission
     """
-    collection.admin_lists = [moira_list]
+    collection.admin_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(collection.owner).username]
     assert collection_permission.has_object_permission(request_data.request,
                                                        request_data.view,
@@ -238,7 +238,7 @@ def test_is_collection_user_matching_admin_lists(mock_moira_client,
     Test for HasCollectionPermissions.has_object_permission to verify
     that user who is in one of the collection's admin lists has permission
     """
-    collection.admin_lists = [moira_list]
+    collection.admin_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert collection_permission.has_object_permission(request_data.request,
                                                        request_data.view,
@@ -254,7 +254,7 @@ def test_is_collection_user_not_matching_view_lists(mock_moira_client,
     Test for HasCollectionPermissions.has_object_permission to verify
     that user who does not match a collection moira view list does not have permission
     """
-    collection.view_lists = [moira_list]
+    collection.view_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = ['someone_else']
     assert collection_permission.has_object_permission(request_data.request,
                                                        request_data.view,
@@ -270,7 +270,7 @@ def test_is_collection_user_matching_view_lists(mock_moira_client,
     Test for HasCollectionPermissions.has_object_permission to verify
     that user who is in one of the collection's view lists has permission
     """
-    collection.view_lists = [moira_list]
+    collection.view_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert collection_permission.has_object_permission(request_data.request,
                                                        request_data.view,
@@ -393,7 +393,7 @@ def test_video_view_permission_no_matching_lists(mock_moira_client, moira_list, 
     Test for HasVideoPermissions.has_object_permission to verify
     that user who is not in the video collection's view-only moira lists cannot see it.
     """
-    video.collection.view_lists = [moira_list]
+    video.collection.view_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = ['someone_else']
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is False
 
@@ -403,7 +403,7 @@ def test_video_view_permission_matching_lists(mock_moira_client, moira_list, vid
     Test for HasVideoPermissions.has_object_permission to verify
     that a user in one of the video collection's view-only moira lists can see it.
     """
-    video.collection.view_lists = [moira_list]
+    video.collection.view_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is True
 
@@ -417,7 +417,7 @@ def test_video_view_permission_matching_lists_post(mock_moira_client,
     Test for HasVideoPermissions.has_object_permission to verify
     that a user in one of the video collection's view-only moira lists cannot use unsafe methods.
     """
-    video.collection.view_lists = [moira_list]
+    video.collection.view_lists.set([moira_list])
     request_data.request.method = 'POST'
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is False
@@ -432,7 +432,7 @@ def test_video_view_permission_matching_admin_lists(mock_moira_client,
     Test for HasVideoPermissions.has_object_permission to verify
     that a user in one of the video collection's admin-only moira lists can see it.
     """
-    video.collection.admin_lists = [moira_list]
+    video.collection.admin_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is True
 
@@ -451,7 +451,7 @@ def test_video_admin_permission_other_user(mock_moira_client, moira_list, video_
     Test for HasAdminPermissionsForVideo.has_object_permission to verify
     that user who does not own the video's collection does not have permission
     """
-    video.collection.view_lists = [moira_list]
+    video.collection.view_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     request_data.request.method = 'POST'
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is False
@@ -483,7 +483,7 @@ def test_video_admin_permission_no_matching_lists(mock_moira_client, moira_list,
     Test for HasAdminPermissionsForVideo.has_object_permission to verify
     that user who is not in the video collection's admin moira lists cannot edit it.
     """
-    video.collection.admin_lists = [moira_list]
+    video.collection.admin_lists.set([moira_list])
     request_data.request.method = 'POST'
     mock_moira_client.return_value.list_members.return_value = ['someone_else']
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is False
@@ -498,7 +498,7 @@ def test_video_admin_permission_matching_view_lists(mock_moira_client,
     Test for HasAdminPermissionsForVideo.has_object_permission to verify
     that a user in one of the video collection's view-only moira lists cannot edit it.
     """
-    video.collection.view_lists = [moira_list]
+    video.collection.view_lists.set([moira_list])
     request_data.request.method = 'POST'
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is False
@@ -513,7 +513,7 @@ def test_video_admin_permission_matching_admin_lists(mock_moira_client,
     Test for HasAdminPermissionsForVideo.has_object_permission to verify
     that a user in one of the video collection's admin moira lists can edit it.
     """
-    video.collection.admin_lists = [moira_list]
+    video.collection.admin_lists.set([moira_list])
     request_data.request.method = 'POST'
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is True
@@ -528,7 +528,7 @@ def test_video_admin_permission_matching_lists_post(mock_moira_client,
     Test for HasAdminPermissionsForVideo.has_object_permission to verify
     that a user in one of the video collection's admin moira lists can use unsafe methods.
     """
-    video.collection.admin_lists = [moira_list]
+    video.collection.admin_lists.set([moira_list])
     request_data.request.method = 'POST'
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is True
@@ -562,7 +562,7 @@ def test_override_video_public_collection_view_lists(video_permissons_setting,
     """
     settings.ENABLE_VIDEO_PERMISSIONS = video_permissons_setting
     video.is_public = True
-    video.collection.view_lists = [moira_list]
+    video.collection.view_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = ['someone_else']
     assert video_permission.has_object_permission(
         request_data_anon.request, request_data_anon.view, video) is video_permissons_setting
@@ -581,7 +581,7 @@ def test_override_video_private_collection_view_lists(video_permissons_setting,
     """
     settings.ENABLE_VIDEO_PERMISSIONS = video_permissons_setting
     video.is_private = True
-    video.collection.view_lists = [moira_list]
+    video.collection.view_lists.set([moira_list])
     video.save()
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert video_permission.has_object_permission(
@@ -601,7 +601,7 @@ def test_override_video_private_collection_admin_lists(video_permissons_setting,
     """
     settings.ENABLE_VIDEO_PERMISSIONS = video_permissons_setting
     video.is_private = True
-    video.collection.admin_lists = [moira_list]
+    video.collection.admin_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is True
 
@@ -624,8 +624,8 @@ def test_override_video_view_lists_collection_view_lists(video_permissons_settin
     settings.ENABLE_VIDEO_PERMISSIONS = video_permissons_setting
     video_list = MoiraListFactory()
     collection_list = MoiraListFactory()
-    video.view_lists = [video_list]
-    video.collection.view_lists = [collection_list]
+    video.view_lists.set([video_list])
+    video.collection.view_lists.set([collection_list])
     mock_moira_client.return_value.list_members.side_effect = mock_list_members
     assert video_permission.has_object_permission(
         request_data.request, request_data.view, video) is video_permissons_setting
@@ -650,8 +650,8 @@ def test_override_video_view_lists_collection_admin_lists(video_permissons_setti
         return [get_moira_user(request_data.request.user).username] if name == collection_list.name else ['other']
 
     mock_moira_client.return_value.list_members.side_effect = mock_list_members
-    video.view_lists = [video_list]
-    video.collection.admin_lists = [collection_list]
+    video.view_lists.set([video_list])
+    video.collection.admin_lists.set([collection_list])
     assert video_permission.has_object_permission(request_data.request, request_data.view, video) is True
 
 
@@ -659,8 +659,8 @@ def test_collections_view(mock_moira_client, moira_list, collection, alt_moira_d
     """
     Test that CollectionManager.all_viewable returns the lists that the user has view access to.
     """
-    collection.view_lists = [moira_list]
-    alt_moira_data.collection.view_lists = [alt_moira_data.moira_list]
+    collection.view_lists.set([moira_list])
+    alt_moira_data.collection.view_lists.set([alt_moira_data.moira_list])
     mock_moira_client.return_value.user_lists.return_value = [moira_list.name]
     assert collection in Collection.objects.all_viewable(alt_moira_data.user)
     assert alt_moira_data.collection not in Collection.objects.all_viewable(alt_moira_data.user)
@@ -670,9 +670,9 @@ def test_collections_view_admin_user(mock_moira_client, moira_list, collection, 
     """
     Test that CollectionManager.all_viewable returns the lists that the user has view access to.
     """
-    collection.admin_lists = [moira_list]
-    alt_moira_data.collection.admin_lists = [alt_moira_data.moira_list]
-    alt_moira_data.collection.view_lists = [moira_list]
+    collection.admin_lists.set([moira_list])
+    alt_moira_data.collection.admin_lists.set([alt_moira_data.moira_list])
+    alt_moira_data.collection.view_lists.set([moira_list])
     mock_moira_client.return_value.user_lists.return_value = [moira_list.name]
     for col in (collection, alt_moira_data.collection):
         assert col in Collection.objects.all_viewable(alt_moira_data.user)
@@ -682,8 +682,8 @@ def test_collections_admin(mock_moira_client, collection, moira_list, alt_moira_
     """
     Test that CollectionManager.all_admin returns the lists that the user has admin access to.
     """
-    collection.admin_lists = [moira_list]
-    alt_moira_data.collection.view_lists = [moira_list]
+    collection.admin_lists.set([moira_list])
+    alt_moira_data.collection.view_lists.set([moira_list])
     mock_moira_client.return_value.user_lists.return_value = [moira_list.name]
     assert collection in Collection.objects.all_admin(alt_moira_data.user)
     assert alt_moira_data.collection not in Collection.objects.all_admin(alt_moira_data.user)
@@ -698,7 +698,7 @@ def test_subtitle_view_permission_no_matching_lists(mock_moira_client,
     Test for HasVideoSubtitlePermissions.has_object_permission to verify
     that user who is not in the subtitle collection's view-only moira lists cannot see it.
     """
-    subtitle.video.collection.view_lists = [moira_list]
+    subtitle.video.collection.view_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = ['someone_else']
     assert subtitle_permission.has_object_permission(request_data.request, request_data.view, subtitle) is False
 
@@ -712,7 +712,7 @@ def test_subtitle_view_permission_matching_lists(mock_moira_client,
     Test for HasVideoSubtitlePermissions.has_object_permission to verify
     that a user in one of the subtitle collection's view-only moira lists can see it.
     """
-    subtitle.video.collection.view_lists = [moira_list]
+    subtitle.video.collection.view_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     assert subtitle_permission.has_object_permission(request_data.request, request_data.view, subtitle) is True
 
@@ -725,7 +725,7 @@ def test_subtitle_admin_permission_no_matching_lists(mock_moira_client, moira_li
     Test for HasVideoSubtitlePermissions.has_object_permission to verify
     that user who is not in the subtitle collection's admin moira lists cannot edit it.
     """
-    subtitle.video.collection.admin_lists = [moira_list]
+    subtitle.video.collection.admin_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = ['someone_else']
     request_data.request.method = 'POST'
     assert subtitle_permission.has_object_permission(request_data.request, request_data.view, subtitle) is False
@@ -740,7 +740,7 @@ def test_subtitle_admin_permission_matching_lists(mock_moira_client,
     Test for HasVideoSubtitlePermissions.has_object_permission to verify
     that a user in one of the subtitle collection's admin moira lists can use unsafe methods.
     """
-    subtitle.video.collection.admin_lists = [moira_list]
+    subtitle.video.collection.admin_lists.set([moira_list])
     mock_moira_client.return_value.list_members.return_value = [get_moira_user(request_data.user).username]
     request_data.request.method = 'POST'
     assert subtitle_permission.has_object_permission(request_data.request, request_data.view, subtitle) is True

--- a/ui/templatetags/render_bundle.py
+++ b/ui/templatetags/render_bundle.py
@@ -3,8 +3,8 @@
 from django import template
 from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.utils.safestring import mark_safe
 
-from webpack_loader.templatetags.webpack_loader import render_as_tags
 from webpack_loader.utils import get_loader
 
 from odl_video.utils import webpack_dev_server_url
@@ -24,12 +24,22 @@ def public_path(request):
     """
     if settings.USE_WEBPACK_DEV_SERVER:
         return ensure_trailing_slash(webpack_dev_server_url(request))
-    return ensure_trailing_slash(static("bundles/"))
+    else:
+        return ensure_trailing_slash(static("bundles/"))
 
 
 def _get_bundle(request, bundle_name):
     """
     Update bundle URLs to handle webpack hot reloading correctly if DEBUG=True
+
+    Args:
+        request (django.http.request.HttpRequest): A request
+        bundle_name (str): The name of the webpack bundle
+
+    Returns:
+        iterable of dict:
+            The chunks of the bundle. Usually there's only one but I suppose you could have
+            CSS and JS chunks for one bundle for example
     """
     if not settings.DISABLE_WEBPACK_LOADER_STATS:
         for chunk in get_loader('DEFAULT').get_bundle(bundle_name):
@@ -45,9 +55,46 @@ def _get_bundle(request, bundle_name):
 def render_bundle(context, bundle_name):
     """
     Render the script tags for a Webpack bundle
+
+    We use this instead of webpack_loader.templatetags.webpack_loader.render_bundle because we want to substitute
+    a dynamic URL for webpack dev environments. Maybe in the future we should refactor to use publicPath
+    instead for this.
+
+    Args:
+        context (dict): The context for rendering the template (includes request)
+        bundle_name (str): The name of the bundle to render
+
+    Returns:
+        django.utils.safestring.SafeText: The tags for JS and CSS
     """
     try:
-        return render_as_tags(_get_bundle(context['request'], bundle_name), '')
+        bundle = _get_bundle(context['request'], bundle_name)
+        return _render_tags(bundle)
     except OSError:
         # webpack-stats.json doesn't exist
-        return ''
+        return mark_safe('')
+
+
+def _render_tags(bundle):
+    """
+    Outputs tags for template rendering.
+    Adapted from webpack_loader.utils.get_as_tags and webpack_loader.templatetags.webpack_loader.
+
+    Args:
+        bundle (iterable of dict): The information about a webpack bundle
+
+    Returns:
+        django.utils.safestring.SafeText: HTML for rendering bundles
+    """
+
+    tags = []
+    for chunk in bundle:
+        if chunk['name'].endswith(('.js', '.js.gz')):
+            tags.append((
+                '<script type="text/javascript" src="{}" ></script>'
+            ).format(chunk['url']))
+        elif chunk['name'].endswith(('.css', '.css.gz')):
+            tags.append((
+                '<link type="text/css" href="{}" rel="stylesheet" />'
+            ).format(chunk['url']))
+    return mark_safe('\n'.join(tags))

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -31,5 +31,5 @@ urlpatterns = [
     url(r'^api/v0/upload_videos/$', views.UploadVideosFromDropbox.as_view(), name='upload-videos'),
     url(r'^api/v0/upload_subtitles/$', views.UploadVideoSubtitle.as_view(),
         name='upload-subtitles'),
-    url(r'^api/v0/', include(router.urls, namespace='models-api')),
+    url(r'^api/v0/', include((router.urls, 'models-api'))),
 ]

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -84,7 +84,7 @@ def has_common_lists(user, list_names):
     Returns:
         bool: True if there is any name in list_names which is in the user's moira lists
     """
-    if user.is_anonymous():
+    if user.is_anonymous:
         return False
     moira_user = get_moira_user(user)
     client = get_moira_client()

--- a/ui/views.py
+++ b/ui/views.py
@@ -338,21 +338,21 @@ def _handle_error_view(request, status_code):
     })
 
 
-def permission_denied_403_view(request):
+def permission_denied_403_view(request, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Handles a 403 response
     """
     return _handle_error_view(request, status.HTTP_403_FORBIDDEN)
 
 
-def page_not_found_404_view(request):
+def page_not_found_404_view(request, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Handles a 404 response
     """
     return _handle_error_view(request, status.HTTP_404_NOT_FOUND)
 
 
-def error_500_view(request):
+def error_500_view(request, *args, **kwargs):  # pylint: disable=unused-argument
     """
     Handles a 500 response
     """

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -59,7 +59,7 @@ def user_view_list_data():
     video = VideoFactory()
     collection = video.collection
     moira_list = factories.MoiraListFactory()
-    collection.view_lists = [moira_list]
+    collection.view_lists.set([moira_list])
     return SimpleNamespace(video=video, moira_list=moira_list, collection=collection)
 
 
@@ -71,7 +71,7 @@ def user_admin_list_data():
     video = VideoFactory()
     collection = video.collection
     moira_list = factories.MoiraListFactory()
-    collection.admin_lists = [moira_list]
+    collection.admin_lists.set([moira_list])
     return SimpleNamespace(video=video, moira_list=moira_list, collection=collection)
 
 
@@ -162,7 +162,7 @@ def test_upload_dropbox_videos_authentication(mock_moira_client, logged_in_apicl
     url = reverse('upload-videos')
     collection = CollectionFactory(owner=user)
     moira_list = factories.MoiraListFactory()
-    collection.admin_lists = [moira_list]
+    collection.admin_lists.set([moira_list])
     collection.save()
     other_user = UserFactory()
     input_data = {


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
 - Upgrades to Django 1.11
 - Fixes deprecation warnings in preparation for Django 2.0
 - Updates pytest warning filtering
 - Update django-webpack-loader and related templatetags

#### How should this be manually tested?
Nothing should break