### PR TITLE
Added a check to verify that file has not already been synced

### DIFF
--- a/s3_sync/s3_sync.py
+++ b/s3_sync/s3_sync.py
@@ -126,13 +126,13 @@ def check_if_file_already_synced(local_video_records_done_folder,
         video files that appeared in both done and synced folders
         simultaneously.
     """
-    for file in os.listdir(local_video_records_done_folder):
-        if os.path.isfile(local_video_records_synced_folder + '/' + file):
-            os.replace(f"{local_video_records_done_folder}/{file}",
-                       f"{local_video_records_conflict_folder}/{file}")
+    for file_name in os.listdir(local_video_records_done_folder):
+        if os.path.isfile(local_video_records_synced_folder + '/' + file_name):
+            os.replace(f"{local_video_records_done_folder}/{file_name}",
+                       f"{local_video_records_conflict_folder}/{file_name}")
             notify_slack_channel(f"*Failed* to copy file from `{local_video_records_done_folder}`"
                                  f"to `{local_video_records_synced_folder}`."
-                                 f"Moved following file(s) to conflict folder: {file}")
+                                 f"Moved following file(s) to conflict folder: {file_name}")
 
 
 def notify_slack_channel(slack_message):
@@ -203,13 +203,13 @@ def move_files_to_synced_folder(local_video_records_done_folder,
         logger.warning("Could not find S3 sync results file",
                        s3_sync_result_file)
         sys.exit("[-] Could not find S3 sync results file")
-    with open(s3_sync_result_file) as file:
-        s3_sync_result_data = file.read()
-    for file in re.findall(r"upload:\s(?:.*\\)(.*)to", s3_sync_result_data):
+    with open(s3_sync_result_file) as file_name:
+        s3_sync_result_data = file_name.read()
+    for file_name in re.findall(r"upload:\s(?:.*\\)(.*)to", s3_sync_result_data):
         try:
-            os.rename(f"{local_video_records_done_folder}/{file}",
-                      f"{local_video_records_synced_folder}/{file}")
-            notify_slack_channel(f"Sync succeeded on: *{computer_name}* \n `{file}`")
+            os.rename(f"{local_video_records_done_folder}/{file_name}",
+                      f"{local_video_records_synced_folder}/{file_name}")
+            notify_slack_channel(f"Sync succeeded on: *{computer_name}* \n `{file_name}`")
         except OSError as err:
             logger.exception("Failed to copy or remove local file", err)
 

--- a/s3_sync/s3_sync_settings.ini
+++ b/s3_sync/s3_sync_settings.ini
@@ -3,6 +3,7 @@ home_dir: your_home_dir
 aws_cli_binary: C:/Program Files/Amazon/AWSCLI/aws.exe
 local_video_records_done_folder: ${home_dir}/your_videos
 local_video_records_synced_folder: ${home_dir}/your_synced_videos
+local_video_records_conflict_folder: ${home_dir}/conflict_videos
 
 [AWS]
 AWS_ACCESS_KEY_ID: your_aws_access_key


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket but part of some recent issues we came across.

#### What's this PR do?
Made the following changes:
- Added a check to verify that file has not already been synced and if it has, move it to a "conflict" folder and notify slack. 
- Made some changes to the slack notifications to provide filenames of the synced files on the m

#### How should this be manually tested?
I tested this on a Windows 10 VM and ran a few scenarios that appeared to be functional.

#### Any background context you want to provide?
At times when the machines are being tested, a tech might already synced files into the "done" folder and forget to delete them from there. The issue is that when the script runs, it would sync the files in the "done" folder which have already been processed and then try to move them to the "synced" folder. That fails since the files already exist in that folder and the script uses `os.rename` instead of `os.replace`. Hence the file ends up staying in the "done" folder and we have an endless loop.
