### PR TITLE
Show the encode job associated with each video in Admin

### DIFF
--- a/ui/admin.py
+++ b/ui/admin.py
@@ -2,7 +2,9 @@
 Admin for UI app
 """
 from django.contrib import admin
+from django.contrib.contenttypes.admin import GenericTabularInline
 
+from dj_elastictranscoder.models import EncodeJob
 from ui import models
 
 
@@ -52,10 +54,27 @@ class VideoThumbnailsInline(admin.TabularInline):
     readonly_fields = ['created_at']
 
 
+class VideoEncodeJobsInline(GenericTabularInline):
+    """
+    Inline model for video encode job
+    """
+    model = EncodeJob
+    extra = 0
+    list_display = ('id', 'state', 'message')
+    readonly_fields = ('id', 'state', 'message')
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 class VideoAdmin(admin.ModelAdmin):
     """Customized Video admin model"""
     model = models.Video
     inlines = [
+        VideoEncodeJobsInline,
         VideoFilesInline,
         VideoSubtitlesInline,
         VideoThumbnailsInline
@@ -64,6 +83,7 @@ class VideoAdmin(admin.ModelAdmin):
         'title',
         'created_at'
     )
+    list_filter = ['status']
     date_hierarchy = 'created_at'
     readonly_fields = ['created_at']
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #442 

#### What's this PR do?
- Shows the `EncodeJob` associated with each `Video` on that video's admin page.
- Allows filtering of `Video` objects by status.

#### How should this be manually tested?
- Go to `/admin/ui/video/`, there should be a working status filter
- Go to the admin page for any video that was uploaded from Dropbox (not migrated from TechTV), there should be an `Encode Jobs` section with one item, showing 3 fields: `id`, `state`, `message`.  It should not be editable and you shouldn't be able to delete it or add a new one.
