### PR TITLE
Switch from celery.get_task_logger() to logging.getLogger() for tasks

### DIFF
--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -1,6 +1,7 @@
 """
 Tasks for cloudsync app
 """
+import logging
 import os
 import re
 from urllib.parse import unquote
@@ -10,7 +11,6 @@ import boto3
 from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import ClientError
 from celery import shared_task, states, Task
-from celery.utils.log import get_task_logger
 from dj_elastictranscoder.models import EncodeJob
 from django.conf import settings
 from googleapiclient.errors import HttpError
@@ -21,7 +21,7 @@ from ui.models import Video, YouTubeVideo, VideoSubtitle
 from ui.constants import VideoStatus, YouTubeStatus
 from ui.utils import get_bucket
 
-log = get_task_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 CONTENT_DISPOSITION_RE = re.compile(

--- a/cloudsync/youtube.py
+++ b/cloudsync/youtube.py
@@ -255,5 +255,4 @@ class YouTubeApi:
         Returns:
             int: 204 status code if successful
         """
-        log.exception("Deleting YT video id %s", video_id)
         return self.client.videos().delete(id=video_id).execute()

--- a/techtv2ovs/tasks.py
+++ b/techtv2ovs/tasks.py
@@ -1,17 +1,16 @@
 """ Celery tasks for techtv2ovs """
-
+import logging
 from os.path import splitext
 
 import boto3
 from celery import shared_task
-from celery.utils.log import get_task_logger
 from django.conf import settings
 
 from techtv2ovs.constants import TTV_VIDEO_BUCKET, ImportStatus
 from techtv2ovs.models import TechTVVideo
 from ui.models import VideoFile
 
-log = get_task_logger(__name__)
+log = logging.getLogger(__name__)
 
 # pylint: disable=unused-argument,broad-except
 


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #462 
- Removes a stray `log.exception()` line

#### What's this PR do?
Replaces `celery.get_task_logger` with `logging.getLogger`

#### How should this be manually tested?
Nothing should break.
To test that logged exceptions make it to sentry:
- Set `SENTRY_DSN` in your `.env` file to the correct value
- Modify `cloudsync.tasks.monitor_watch_bucket` to always log an exception:
   `log.exception("This is a test")`)
- In a shell, run `monitor_watch_bucket.delay()`
- Check Sentry for your error
