### PR TITLE
Don't try to save EncodeJobs on the video admin page

### DIFF
--- a/ui/admin.py
+++ b/ui/admin.py
@@ -66,6 +66,9 @@ class VideoEncodeJobsInline(GenericTabularInline):
     def has_add_permission(self, request):
         return False
 
+    def has_change_permission(self, request, obj=None):
+        return request.method != 'POST'
+
     def has_delete_permission(self, request, obj=None):
         return False
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #480 

#### What's this PR do?
Prevents an error when saving changes on a `Video` admin page

#### How should this be manually tested?
Go to the admin page for an uploaded video with an encode job.  Make a change to title or description and click one of the Save buttons.  It should not cause an error.
