### PR TITLE
Correctly assign attributes to VideoSubtitles imported from TechTV

### DIFF
--- a/ui/models.py
+++ b/ui/models.py
@@ -229,17 +229,19 @@ class Video(models.Model):
         basename, _ = os.path.splitext(original_s3_key)
         return output_template.format(prefix=TRANSCODE_PREFIX, s3key=basename, preset=preset)
 
-    def subtitle_key(self, dttm, language='en'):
+    def subtitle_key(self, dttm, language='en', prefix='subtitles'):
         """
         Returns an S3 object key to be used for a subtitle file
         Args:
             language(str): 2-letter language code
             dttm(DateTime): a DateTime object
+            prefix(str): beginning of S3 key
 
         Returns:
             str: S3 object key
         """
-        return 'subtitles/{key}/subtitles_{key}_{dt}_{lang}.vtt'.format(
+        return '{prefix}/{key}/subtitles_{key}_{dt}_{lang}.vtt'.format(
+            prefix=prefix,
             key=self.hexkey,
             dt=dttm.strftime('%Y%m%d%H%M%S'),
             lang=language


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #484 

#### What's this PR do?
- Assigns `filename`, `language`, and `bucket_name` attributes for `VideoSubtitle` objects imported from TechTV
- Uses the `Video.subtitle_key` method to assign the `VideoSubtitle` S3 key

#### How should this be manually tested?
- Follow the steps to import a TechTV collection with subtitles described in #446 
- In the OVS admin, check that the subtitles for the imported videos have values for `filename`, `language`, and `bucket_name`, and that the S3 key takes the form `subtitles/techtv/<video_key>/subtitles_<video_key>_<datetime_digits>_en.vtt`
