### PR TITLE
Add UserMetadata section w/environment id in transcode jobs

### DIFF
--- a/cloudsync/api.py
+++ b/cloudsync/api.py
@@ -152,8 +152,11 @@ def transcode_video(video, video_file):
         settings.AWS_ACCESS_KEY_ID,
         settings.AWS_SECRET_ACCESS_KEY
     )
+
+    user_meta = {'pipeline': 'odl-video-service-{}'.format(settings.ENVIRONMENT).lower()}
+
     try:
-        transcoder.encode(video_input, outputs, Playlists=playlists)
+        transcoder.encode(video_input, outputs, Playlists=playlists, UserMetadata=user_meta)
     except ClientError as exc:
         log.error('Transcode job creation failed for video %s', video.id)
         video.update_status(VideoStatus.TRANSCODE_FAILED_INTERNAL)

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -269,7 +269,7 @@ def test_monitor_watch(mocker, user):
     """Test the Watch bucket monitor task"""
     UserFactory(username='admin')
     mocker.patch.multiple('cloudsync.tasks.settings',
-                          ET_PRESET_IDS=('1351620000001-000061',),
+                          ET_PRESET_IDS=('1351620000001-000061',), ENVIRONMENT='test',
                           AWS_REGION='us-east-1', ET_PIPELINE_ID='foo')
     mock_encoder = mocker.patch('cloudsync.api.VideoTranscoder.encode')
     s3 = boto3.resource('s3')
@@ -291,11 +291,16 @@ def test_monitor_watch(mocker, user):
             "PresetId": "1351620000001-000061",
             "SegmentDuration": "10.0",
             "ThumbnailPattern": "thumbnails/" + new_video.hexkey + "/video_thumbnail_{count}"
-        }], Playlists=[{
+        }],
+        Playlists=[{
             "Format": "HLSv3",
             "Name": "transcoded/" + new_video.hexkey + "/video__index",
             "OutputKeys": ["transcoded/" + new_video.hexkey + "/video_1351620000001-000061"]
-        }])
+        }],
+        UserMetadata={
+            'pipeline': 'odl-video-service-test'
+        }
+    )
     assert new_videofile.bucket_name == settings.VIDEO_S3_BUCKET
     with pytest.raises(ClientError):
         s3c.get_object(Bucket=bucket.name, Key=filename)


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #483 

#### What's this PR do?
Adds the following to each encode job:
```python
UserMetadata: {
    'pipeline': 'odl-video-service-<settings.ENVIRONMENT>'
}
```

#### How should this be manually tested?
- Upload a video
- Go to the admin page for the video and look at the encode job message.  It should include the `UserMetadata` section.