### PR TITLE
add pytest_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 .hypothesis/
 coverage/
 .nyc_output/
+.pytest_cache/
 
 # Translations
 *.mo


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

add the `.pytest_cache` dir to `.gitignore`

#### How should this be manually tested?

check this out and run the tests, `.gitignore` should do it's job