### PR TITLE
Stream videofiles from S3 to Youtube

### DIFF
--- a/cloudsync/conftest.py
+++ b/cloudsync/conftest.py
@@ -1,6 +1,8 @@
 """
 conftest for pytest in this module
 """
+from io import BytesIO
+
 import pytest
 import requests_mock
 import botocore.session
@@ -62,7 +64,7 @@ def youtube_mock(mocker):
     mocker.patch('cloudsync.youtube.boto3')
     mocker.patch('cloudsync.youtube.oauth2client')
     mocker.patch('cloudsync.youtube.build')
-    mocker.patch('cloudsync.youtube.MediaFileUpload', return_value=b'')
+    mocker.patch('cloudsync.youtube.SeekableBufferedInputBase', return_value=BytesIO(b'123'))
 
 
 class MockClientET:

--- a/requirements.in
+++ b/requirements.in
@@ -43,4 +43,4 @@ mysqlclient
 dropbox
 bonobo
 -e git+https://github.com/mitodl/pycaption.git#egg=pycaption
-
+smart_open==1.5.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,12 +12,15 @@ git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
 git+https://github.com/mitodl/pycaption.git#egg=pycaption
 amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via fs, zeep
+appnope==0.1.0            # via ipython
 asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.6.0
 billiard==3.5.0.3         # via celery
 bonobo==0.6.1
 boto3==1.4.4
+boto==2.48.0              # via smart-open
 botocore==1.5.84          # via boto3, s3transfer
+bz2file==0.98             # via smart-open
 cached-property==1.3.0    # via zeep
 cachetools==2.0.1         # via google-auth
 celery==4.0.2
@@ -93,6 +96,7 @@ rsa==3.4.2                # via google-auth, google-auth-httplib2, oauth2client
 s3transfer==0.1.10        # via boto3
 simplegeneric==0.8.1      # via ipython
 six==1.10.0               # via cryptography, django-server-status, dropbox, faker, fs, google-api-python-client, google-auth, google-auth-httplib2, html5lib, oauth2client, packaging, prompt-toolkit, python-dateutil, stevedore, traitlets, zeep
+smart_open==1.5.7
 static3==0.7.0            # via dj-static
 stevedore==1.28.0         # via bonobo
 traitlets==4.3.2          # via ipython


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #358

#### What's this PR do?
Uses the `smart_open` library to stream video files from S3 to Youtube instead of downloading in full from S3 before uploading to Youtube.

#### How should this be manually tested?
- Set `YT_ACCESS_TOKEN`, `YT_REFRESH_TOKEN` to working values (I can provide them).
- In a shell, run:
  ```python
  from cloudsync.youtube import YouTubeApi
  from ui.models import Video
  video = Video.objects.get(id=<id_of_video_to_upload>)
  yt = YouTubeApi()
  yt.upload_video(video)
  ````
- When it is done, some JSON should be returned that includes an id.
- Go to the URL `https://www.youtube.com/watch?v=<id>`
- The video should be playable, if not at first then after a few minutes.

