### PR TITLE
Truncate long titles and descriptions when uploading to YouTube

### DIFF
--- a/cloudsync/youtube.py
+++ b/cloudsync/youtube.py
@@ -227,8 +227,8 @@ class YouTubeApi:
 
         request_body = dict(
             snippet=dict(
-                title=video.title,
-                description=video.description
+                title=video.title[:100],
+                description=video.description[:5000]
             ),
             status=dict(
                 privacyStatus=privacy

--- a/techtv2ovs/utils.py
+++ b/techtv2ovs/utils.py
@@ -325,7 +325,7 @@ class TechTVImporter:
             if not ttvvideo.video:
                 ttvvideo.video = Video.objects.create(
                     collection=ttvcollection.collection,
-                    title=v_title,
+                    title=remove_tags(v_title),
                     description=remove_tags(v_description),
                     source_url="http://techtv.mit.edu/videos/",
                     is_private=ttvvideo.private,

--- a/techtv2ovs/utils_test.py
+++ b/techtv2ovs/utils_test.py
@@ -1,5 +1,6 @@
 """ Tests for techtv2ovs.utils """
 import os
+
 import pytest
 from bonobo.structs import Graph
 from dropbox.exceptions import ApiError
@@ -121,7 +122,9 @@ def test_process_collection_again(mocker, importer):
 def test_process_videos(mocker, s3files, importer):
     """ Assert that correct video objects are created by TechTVImporter.process_videos"""
     ttvcollection = TechTVCollectionFactory()
-    video_data = (('456', 'My Video', 'My Description', '123asda23', 0, None),)
+    title = 'My Title'
+    description = 'My Description'
+    video_data = (('456', '<i>{}</i>'.format(title), '<i>{}</i>'.format(description), '123asda23', 0, None),)
     s3_videos = mocker.patch('techtv2ovs.utils.get_s3_videos', return_value=s3files)
     mocker.patch('techtv2ovs.utils.mysql_query', return_value=video_data)
     mocker.patch('techtv2ovs.utils.TechTVImporter.process_files')
@@ -132,8 +135,8 @@ def test_process_videos(mocker, s3files, importer):
     assert ttv_video.status == (ImportStatus.CREATED if s3files else ImportStatus.MISSING)
     if s3files:
         assert ttv_video.video.status == VideoStatus.CREATED
-        assert ttv_video.video.title == video_data[0][1]
-        assert ttv_video.video.description == video_data[0][2]
+        assert ttv_video.video.title == title
+        assert ttv_video.video.description == description
     else:
         assert ttv_video.video is None
     assert s3_videos.call_count == 1


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #506 

#### What's this PR do?
- Truncates title to 100 characters, description to 5000, when uploading to YouTube
- Strips any HTML tags from video title when importing from TechTV (same as for  #description).

#### How should this be manually tested?
- Give a video a title with > 100 characters, description > 5000 characters
- In a django shell:
  ```python
  from cloudsync.youtube import YouTubeApi
  from ui.models import Video
  video = Video.objects.get(id=<video_id>)
  youtube = YouTubeApi()
  youtube.upload_video(video)
  ```
- The response should contain the Youtube id and truncated title.  If you go to `https://www.youtube.com/watch?v=<youtube_id>` the title and description should be truncated.