### PR TITLE
Return a Youtube ID only if the status is processed

### DIFF
--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -354,9 +354,9 @@ def test_upload_youtube_videos(mocker, max_uploads):
     upload_youtube_videos()
     assert mock_uploader.call_count == min(3, max_uploads)
     for video in Video.objects.filter(is_public=True).order_by('-created_at')[:settings.YT_DAILY_UPLOAD_LIMIT]:
-        assert video.youtube_id is not None
+        assert YouTubeVideo.objects.filter(video=video).first() is not None
     for video in private_videos:
-        assert video.youtube_id is None
+        assert YouTubeVideo.objects.filter(video=video).first() is None
 
 
 def test_upload_youtube_videos_error(mocker):

--- a/ui/models.py
+++ b/ui/models.py
@@ -166,7 +166,10 @@ class Video(models.Model):
         Return YouTube video id if any
         """
         try:
-            return self.youtubevideo.id
+            youtube_video = self.youtubevideo
+            if youtube_video.status == YouTubeStatus.PROCESSED:
+                return youtube_video.id
+            return None
         except YouTubeVideo.DoesNotExist:
             return None
 
@@ -196,7 +199,7 @@ class Video(models.Model):
         Returns:
             dict: Dict of video sources for VideoJS
         """
-        if self.collection.stream_source == StreamSource.YOUTUBE:
+        if self.is_public and self.collection.stream_source == StreamSource.YOUTUBE and self.youtube_id is not None:
             return []
         sources = [
             {

--- a/ui/signals.py
+++ b/ui/signals.py
@@ -33,7 +33,7 @@ def update_video_permissions(sender, **kwargs):
         if video.techtvvideo_set.first() is None and len(video.videosubtitle_set.all()) <= 1:
             video.is_public = False
             video.save()
-        elif video.youtube_id:
+        elif YouTubeVideo.objects.filter(video=video).first() is not None:
             remove_youtube_caption.delay(video.id, kwargs['instance'].language)
 
 

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -4,7 +4,6 @@ import pytest
 from ui.constants import StreamSource, YouTubeStatus
 from ui.encodings import EncodingNames
 from ui.factories import VideoFactory, YouTubeVideoFactory, VideoSubtitleFactory, VideoFileFactory
-from ui.models import YouTubeVideo
 
 pytestmark = pytest.mark.django_db
 
@@ -24,10 +23,10 @@ def test_youtube_video_delete_signal(mocker):
     mock_task = mocker.patch('ui.signals.remove_youtube_video.delay')
     video = VideoFactory(is_public=True)
     yt_video = YouTubeVideoFactory(video=video)
-    assert YouTubeVideo.objects.filter(id=yt_video.id).first() == yt_video
+    youtube_id = yt_video.id
     video.is_public = False
     video.save()
-    mock_task.assert_called_once_with(video.youtube_id)
+    mock_task.assert_called_once_with(youtube_id)
 
 
 def test_youtube_video_permissions_signal(mocker):

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -12,6 +12,7 @@ from rest_framework.reverse import reverse
 
 from techtv2ovs.factories import TechTVVideoFactory
 from ui import factories
+from ui.constants import YouTubeStatus
 from ui.factories import (
     UserFactory,
     CollectionFactory,
@@ -519,7 +520,7 @@ def test_upload_subtitles(logged_in_apiclient, mocker):
     mocker.patch('ui.models.Video.subtitle_key', return_value=expected_subtitle_key)
     client, user = logged_in_apiclient
     video = VideoFactory(collection=CollectionFactory(owner=user))
-    yt_video = YouTubeVideoFactory(video=video)
+    yt_video = YouTubeVideoFactory(video=video, status=YouTubeStatus.PROCESSED)
     filename = 'subtitles.vtt'
     youtube_task = mocker.patch('ui.views.upload_youtube_caption.delay')
     input_data = {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #505 

#### What's this PR do?
Plays a video from YouTube only if YouTube has finished processing the video.

#### How should this be manually tested?
- In django admin, set a video to `is_public=True`
- Set the video's collection to `stream_source=Youtube`
- Go to the video detail page.  It should play the video from Cloudfront even though the collection's stream_source is `Youtube`, because no Youtube video exists yet.
- In a shell:
  ```python
  from cloudsync.youtube import YouTubeApi
  from ui.models import Video
  video = Video.objects.get(id=<video_id>)
  youtube = YouTubeApi()
  youtube.upload_video(video)
  ```
- Go to the video detail page and play the video.  Assuming that Youtube is still processing, the video should still stream from cloudfront and not Youtube.
- Check the status of the `YouTubeVideo` on the admin page.  When it changes to `processed`, go back to the video detail page.  This time it should play from YouTube.

