### PR TITLE
Upload a transcoded videofile to YouTube if the original is missing

### DIFF
--- a/cloudsync/youtube.py
+++ b/cloudsync/youtube.py
@@ -224,7 +224,7 @@ class YouTubeApi:
             dict: YouTube API response
 
         """
-        videofile = video.original_video
+        videofile = video.original_video or video.transcoded_videos[0]
 
         request_body = dict(
             snippet=dict(

--- a/ui/models_test.py
+++ b/ui/models_test.py
@@ -247,3 +247,29 @@ def test_original_video():
         VideoFileFactory(video=video, s3_object_key='transcoded.hls', encoding=EncodingNames.HLS),
         ]
     assert video.original_video == videofiles[0]
+
+
+def test_transcoded_mp4_video():
+    """ Tests that Video.transcoded_videos returns transcoded MP4 videos in the correct order"""
+    video = VideoFactory()
+    videofiles = [
+        VideoFileFactory(video=video, s3_object_key='original.mp4', encoding=EncodingNames.ORIGINAL),
+        VideoFileFactory(video=video, s3_object_key='small.mp4', encoding=EncodingNames.SMALL),
+        VideoFileFactory(video=video, s3_object_key='basic.mp4', encoding=EncodingNames.BASIC),
+        VideoFileFactory(video=video, s3_object_key='HD.mp4', encoding=EncodingNames.HD),
+        ]
+    assert len(video.transcoded_videos) == 3
+    assert video.transcoded_videos[0] == videofiles[3]
+    assert video.transcoded_videos[1] == videofiles[2]
+    assert video.transcoded_videos[2] == videofiles[1]
+
+
+def test_transcoded_hls_video():
+    """ Tests that Video.transcoded_videos returns transcoded HLS videofile"""
+    video = VideoFactory()
+    videofiles = [
+        VideoFileFactory(video=video, s3_object_key='original.mp4', encoding=EncodingNames.ORIGINAL),
+        VideoFileFactory(video=video, s3_object_key='video.m3u8', encoding=EncodingNames.HLS),
+        ]
+    assert len(video.transcoded_videos) == 1
+    assert video.transcoded_videos[0] == videofiles[1]


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #507 

#### What's this PR do?
- If the original file (a `Videofile` with encoding of `EncodingNames.ORIGINAL`) for a `Video` object is missing, as occasionally happens with imported TechTV videos, when uploading to Youtube use the highest available resolution transcoded video instead.

#### How should this be manually tested?
- Find a `Video` previously imported from TechTV that does not have an associated `YouTubeVideo` object, or [run the import command to create one](https://github.com/mitodl/odl-video-service/pull/446).
- In the django admin, delete the `VideoFile` associated with the `Video` that has an `encoding` of `original`.  Change the `Video` to be public (`is_public=True`).
- In a shell, run the following:
  ```python
  from cloudsync.tasks import upload_youtube_videos
  upload_youtube_videos.delay()
  ```
- After a minute or two there should be a `YouTubeVideo` object for the `Video`, and once it is done processing, the `Video` should play from Youtube on its detail page (`../videos/<video_key>`)
