### PR TITLE
fix text field regressions from mdc upgrade

### DIFF
--- a/static/js/components/material/Textarea.js
+++ b/static/js/components/material/Textarea.js
@@ -12,8 +12,8 @@ export default class Textarea extends React.Component<*, void> {
     return (
       <div className="mdc-textarea-container">
         <label htmlFor={id}>{label}</label>
-        <div className="mdc-textfield">
-          <textarea className="mdc-textfield__input" id={id} {...otherProps} />
+        <div className="mdc-text-field">
+          <textarea className="mdc-text-field__input" id={id} {...otherProps} />
         </div>
       </div>
     )

--- a/static/js/components/material/Textfield.js
+++ b/static/js/components/material/Textfield.js
@@ -15,14 +15,14 @@ export default class Textfield extends React.Component<*, void> {
     const renderedLabel = label ? <label htmlFor={id}>{label}</label> : null
 
     return (
-      <div className="mdc-textfield-container">
+      <div className="mdc-text-field-container">
         {renderedLabel}
-        <div className="mdc-textfield">
+        <div className="mdc-text-field">
           <input
             type="text"
             className={`${
-              validationMessage ? "mdc-textfield__input__invalid" : ""
-            } mdc-textfield__input `}
+              validationMessage ? "mdc-text-field__input__invalid" : ""
+            } mdc-text-field__input `}
             id={id}
             {...otherProps}
           />

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -102,20 +102,20 @@ label {
   width: 100%;
 }
 
-.mdc-textfield {
+.mdc-text-field {
   width: 100%;
 }
 
-input[type=text], input[type=password], input[type=email], textarea, .mdc-textfield__input, input[type=text].mdc-textfield__input {
+input[type=text], input[type=password], input[type=email], textarea, .mdc-text-field__input, input[type=text].mdc-text-field__input {
   display: block;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid rgba(0, 0, 0, 0.12) !important;
   box-sizing: border-box;
   padding: 10px;
   background: #fff;
   font-size: 15px;
 }
 
-.mdc-textfield-container, .mdc-textarea-container {
+.mdc-text-field-container, .mdc-textarea-container {
   margin: 0 0 14px 0;
 }
 
@@ -147,7 +147,7 @@ textarea {
   padding: 5px;
 }
 
-.mdc-textfield__input__invalid {
+.mdc-text-field__input__invalid {
   border: 1px solid #d50000 !important;
 }
 
@@ -186,11 +186,11 @@ textarea {
         padding: 0;
       }
 
-      .mdc-textfield-container {
+      .mdc-text-field-container {
         flex-grow: 1;
         margin-bottom: 0;
 
-        .mdc-textfield {
+        .mdc-text-field {
           display: inline-block;
           margin: 0 0 0 5px;
         }


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/odl-video-service/pull/519
https://github.com/mitodl/odl-video-service/pull/513

#### What's this PR do?
Fixes regression introduced in https://github.com/mitodl/odl-video-service/pull/513
Regression was text fields were no longer full width.

#### How should this be manually tested?
Visit a section of the app that has text fields. Confirm that the text fields are full width.
