### PR TITLE
Make error views CORS-compatible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - .:/src
       - django_media:/var/media
     environment:
-      DEBUG: 'True'
+      DEBUG: ${DEBUG:-True}
       DEV_ENV: 'True'
       NODE_ENV: 'development'
       PORT: 8087

--- a/ui/views.py
+++ b/ui/views.py
@@ -88,6 +88,7 @@ def index(request):  # pylint: disable=unused-argument
     return redirect('collection-react-view')
 
 
+@method_decorator(xframe_options_exempt, name='dispatch')
 @method_decorator(login_required, name='dispatch')
 class CollectionReactView(TemplateView):
     """List of collections"""
@@ -171,6 +172,7 @@ class TechTVPrivateDetail(VideoDetail):
         return conditional_response(self, ttv_videos[0].video, *args, **kwargs)
 
 
+@method_decorator(xframe_options_exempt, name='dispatch')
 class TechTVEmbed(VideoEmbed):
     """
     Video embed page for a TechTV-based URL
@@ -375,6 +377,7 @@ class VideoSubtitleViewSet(ModelDetailViewset):
     )
 
 
+@method_decorator(xframe_options_exempt, name='dispatch')
 def _handle_error_view(request, status_code):
     """
     Handles a 403, 404 or 500 response


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #517 

#### What's this PR do?
- Makes the following views CORS-compatible:
  - error pages
  - TechTV embeds (same as regular video embeds)
  - collections (because that's the login redirect on production/RC).

#### How should this be manually tested?
- Set `DEBUG=False` in your `.env` file.
- Make a test HTML page containing an iframe for a non-public video embed URL in your dev instance:
  ```html
  <html>
  <body>
  <iframe src="http://localhost:8089/videos/<video_key>" width="560" height="315" frameborder="0" allowfullscreen></iframe>
  </body>
  </html>
  ```

- Login to your OVS instance as someone who does not have permission to view the above video.
- Start a local web server: `python -m http.server`
- Open up the HTML page you created.  You should see this:

<img width="579" alt="screen shot 2018-04-09 at 11 44 47 am" src="https://user-images.githubusercontent.com/187676/38507792-7571e162-3beb-11e8-9410-ed9eb1e7d2dc.png">

- You should see an embedded 404 error page if you change the videokey in your embed HTML to one that doesn't exist.

