### PR TITLE
add frontend pagination feature flag

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -415,6 +415,7 @@ YT_DAILY_UPLOAD_LIMIT = get_int('YT_DAILY_UPLOAD_LIMIT', 400)
 LECTURE_CAPTURE_USER = get_string('LECTURE_CAPTURE_USER', '')
 
 ENABLE_VIDEO_PERMISSIONS = get_bool('ENABLE_VIDEO_PERMISSIONS', False)
+ENABLE_FRONTEND_PAGINATION = get_bool('ENABLE_FRONTEND_PAGINATION', False)
 
 # List of mandatory settings. If any of these is not set, the app will not start
 # and will raise an ImproperlyConfigured exception
@@ -446,6 +447,7 @@ MANDATORY_SETTINGS = [
     'VIDEO_S3_SUBTITLE_BUCKET',
     'VIDEO_S3_WATCH_BUCKET',
     'ENABLE_VIDEO_PERMISSIONS',
+    'ENABLE_FRONTEND_PAGINATION',
     'YT_ACCESS_TOKEN',
     'YT_REFRESH_TOKEN',
     'YT_CLIENT_ID',

--- a/ui/views.py
+++ b/ui/views.py
@@ -56,7 +56,8 @@ def default_js_settings(request):
         "support_email_address": settings.EMAIL_SUPPORT,
         "ga_dimension_camera": settings.GA_DIMENSION_CAMERA,
         "FEATURES": {
-            "ENABLE_VIDEO_PERMISSIONS": settings.ENABLE_VIDEO_PERMISSIONS
+            "ENABLE_VIDEO_PERMISSIONS": settings.ENABLE_VIDEO_PERMISSIONS,
+            "ENABLE_FRONTEND_PAGINATION": settings.ENABLE_FRONTEND_PAGINATION,
         }
     }
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -105,6 +105,7 @@ def test_video_detail(logged_in_client, settings):
     settings.GA_DIMENSION_CAMERA = 'camera1'
     settings.GA_TRACKING_ID = 'UA-xyz-1'
     settings.ENABLE_VIDEO_PERMISSIONS = False
+    settings.ENABLE_FRONTEND_PAGINATION = False
     videofileHLS = VideoFileFactory(hls=True, video__collection__owner=user)
     videofileHLS.video.status = 'Complete'
     url = reverse('video-detail', kwargs={'video_key': videofileHLS.video.hexkey})
@@ -122,7 +123,8 @@ def test_video_detail(logged_in_client, settings):
         "support_email_address": settings.EMAIL_SUPPORT,
         "dropbox_key": "foo_dropbox_key",
         "FEATURES": {
-            "ENABLE_VIDEO_PERMISSIONS": False
+            "ENABLE_VIDEO_PERMISSIONS": False,
+            "ENABLE_FRONTEND_PAGINATION": False,
         }
     }
 
@@ -133,6 +135,7 @@ def test_video_embed(logged_in_client, settings):  # pylint: disable=redefined-o
     settings.GA_DIMENSION_CAMERA = 'camera1'
     settings.GA_TRACKING_ID = 'UA-xyz-1'
     settings.ENABLE_VIDEO_PERMISSIONS = False
+    settings.ENABLE_FRONTEND_PAGINATION = False
     videofileHLS = VideoFileFactory(
         hls=True,
         video__collection__owner=user,
@@ -153,7 +156,8 @@ def test_video_embed(logged_in_client, settings):  # pylint: disable=redefined-o
         "email": user.email,
         "support_email_address": settings.EMAIL_SUPPORT,
         "FEATURES": {
-            "ENABLE_VIDEO_PERMISSIONS": False
+            "ENABLE_VIDEO_PERMISSIONS": False,
+            "ENABLE_FRONTEND_PAGINATION": False,
         }
     }
 
@@ -618,6 +622,7 @@ def test_page_not_found(url, logged_in_apiclient, settings):
     settings.GA_DIMENSION_CAMERA = 'camera1'
     settings.EMAIL_SUPPORT = 'support'
     settings.ENABLE_VIDEO_PERMISSIONS = False
+    settings.ENABLE_FRONTEND_PAGINATION = False
 
     client, user = logged_in_apiclient
     resp = client.get(url)
@@ -632,7 +637,8 @@ def test_page_not_found(url, logged_in_apiclient, settings):
         'email': user.email,
         'user': user.username,
         "FEATURES": {
-            "ENABLE_VIDEO_PERMISSIONS": False
+            "ENABLE_VIDEO_PERMISSIONS": False,
+            "ENABLE_FRONTEND_PAGINATION": False,
         }
     }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Related to TechTV migration.

#### What's this PR do?
Adds a feature flag for front-end pagination. Just the flag, no actual features yet.

#### How should this be manually tested?
1. In your `.env` file, add `ENABLE_FRONTEND_PAGINATION=True`.
2. Restart your web server (to re-read the `.env` file)
3. Go to any page, e.g. http://localhost:8089/collections/
4. View the source for the page and ensure that the `SETTINGS` object has `ENABLE_FRONTEND_PAGINATION: true` .


#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
