### PR TITLE
Pagination for Collections API

### DIFF
--- a/app.json
+++ b/app.json
@@ -122,6 +122,18 @@
       "description": "If false, disables the node_modules cache to fix yarn install",
       "value": "false"
     },
+    "PAGE_SIZE_QUERY_PARAM": {
+      "description": "Request parameter to specify paging size",
+      "required": "false"
+    },
+    "PAGE_SIZE_MAXIMUM": {
+      "description": "Maximum page size allowed",
+      "required": "false"
+    },
+    "PAGE_SIZE_COLLECTIONS": {
+      "description": "Default collection page size",
+      "required": "false"
+    },
     "PGBOUNCER_DEFAULT_POOL_SIZE": {
       "value": "50"
     },

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -531,3 +531,8 @@ if MIDDLEWARE_FEATURE_FLAG_QS_PREFIX:
         'odl_video.middleware.QueryStringFeatureFlagMiddleware',
         'odl_video.middleware.CookieFeatureFlagMiddleware',
     )
+
+# Paging parameters
+PAGE_SIZE_QUERY_PARAM = get_string('PAGE_SIZE_QUERY_PARAM', 'page_size')
+PAGE_SIZE_MAXIMUM = get_int('PAGE_SIZE_MAXIMUM', 1000)
+PAGE_SIZE_COLLECTIONS = get_int('PAGE_SIZE_COLLECTIONS', 1000)

--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -162,7 +162,7 @@ class Drawer extends React.Component<*, void> {
 
 const mapStateToProps = state => {
   const { collectionsList, commonUi } = state
-  const collections = collectionsList.loaded ? collectionsList.data : []
+  const collections = collectionsList.loaded ? collectionsList.data.results : []
   const needsUpdate = !collectionsList.processing && !collectionsList.loaded
 
   return {

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -32,7 +32,7 @@ describe("Drawer", () => {
     listenForActions = store.createListenForActions()
     getCollectionsStub = sandbox
       .stub(api, "getCollections")
-      .returns(Promise.resolve(collections))
+      .returns(Promise.resolve({results: collections}))
   })
 
   afterEach(() => {

--- a/static/js/containers/CollectionDetailPage_test.js
+++ b/static/js/containers/CollectionDetailPage_test.js
@@ -47,7 +47,7 @@ describe("CollectionDetailPage", () => {
     getCollectionStub = sandbox
       .stub(api, "getCollection")
       .returns(Promise.resolve(collection))
-    sandbox.stub(api, "getCollections").returns(Promise.resolve(collections))
+    sandbox.stub(api, "getCollections").returns(Promise.resolve({results: collections}))
   })
 
   afterEach(() => {

--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -86,7 +86,7 @@ class CollectionListPage extends React.Component<*, void> {
 
 const mapStateToProps = state => {
   const { collectionsList, commonUi } = state
-  const collections = collectionsList.loaded ? collectionsList.data : []
+  const collections = collectionsList.loaded ? (collectionsList.data.results ? collectionsList.data.results : collectionsList.data) : []
   const needsUpdate = !collectionsList.processing && !collectionsList.loaded
 
   return {

--- a/static/js/containers/CollectionListPage_test.js
+++ b/static/js/containers/CollectionListPage_test.js
@@ -27,7 +27,7 @@ describe("CollectionListPage", () => {
     listenForActions = store.createListenForActions()
     collections = [makeCollection(), makeCollection(), makeCollection()]
 
-    sandbox.stub(api, "getCollections").returns(Promise.resolve(collections))
+    sandbox.stub(api, "getCollections").returns(Promise.resolve({results: collections}))
   })
 
   afterEach(() => {
@@ -61,7 +61,7 @@ describe("CollectionListPage", () => {
 
   it("loads the collections on load", async () => {
     await renderPage()
-    assert.deepEqual(store.getState().collectionsList.data, collections)
+    assert.deepEqual(store.getState().collectionsList.data.results, collections)
   })
 
   it("doesn't show the create collection button if SETTINGS.editable is false", async () => {

--- a/static/js/containers/ErrorPage_test.js
+++ b/static/js/containers/ErrorPage_test.js
@@ -22,7 +22,7 @@ describe("ErrorPage", () => {
     listenForActions = store.createListenForActions()
     collections = [makeCollection(), makeCollection(), makeCollection()]
 
-    sandbox.stub(api, "getCollections").returns(Promise.resolve(collections))
+    sandbox.stub(api, "getCollections").returns(Promise.resolve({results: collections}))
   })
 
   afterEach(() => {

--- a/static/js/containers/VideoDetailPage_test.js
+++ b/static/js/containers/VideoDetailPage_test.js
@@ -34,7 +34,7 @@ describe("VideoDetailPage", () => {
 
     getVideoStub = sandbox.stub(api, "getVideo").returns(Promise.resolve(video))
     dropboxStub = sandbox.stub(libVideo, "saveToDropbox")
-    sandbox.stub(api, "getCollections").returns(Promise.resolve([]))
+    sandbox.stub(api, "getCollections").returns(Promise.resolve({results: []}))
 
     // silence videojs warnings
     sandbox.stub(libVideo, "videojs")

--- a/static/js/containers/WithDrawer.js
+++ b/static/js/containers/WithDrawer.js
@@ -34,7 +34,7 @@ class WithDrawer extends React.Component<*, void> {
 
 const mapStateToProps = state => {
   const { collectionsList, commonUi } = state
-  const collections = collectionsList.loaded ? collectionsList.data : []
+  const collections = collectionsList.loaded ? collectionsList.data.results  : []
   const needsUpdate = !collectionsList.processing && !collectionsList.loaded
 
   return {

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -33,11 +33,11 @@ describe("api", () => {
 
   it("gets collection list", async () => {
     const collections = _.times(2, () => makeCollection())
-    fetchStub.returns(Promise.resolve(collections))
+    fetchStub.returns(Promise.resolve({results: collections}))
 
     const result = await getCollections()
     sinon.assert.calledWith(fetchStub, `/api/v0/collections/`)
-    assert.deepEqual(result, collections)
+    assert.deepEqual(result.results, collections)
   })
 
   it("creates a new collection", async () => {

--- a/static/js/reducers/collections.js
+++ b/static/js/reducers/collections.js
@@ -10,9 +10,8 @@ export const collectionsListEndpoint = {
   initialState:       { ...INITIAL_STATE, data: [] },
   getFunc:            (): Promise<CollectionList> => api.getCollections(),
   postFunc:           (collection: Collection) => api.createCollection(collection),
-  postSuccessHandler: (payload: Collection, data: Array<Collection>) => {
-    // this should keep it sorted in reverse creation time order
-    return [payload, ...data]
+  postSuccessHandler: (payload: Collection, data: Object) => {
+    return {results: [payload, ...(data ? data.results || [] : [])]}
   }
 }
 

--- a/static/js/reducers/collections_test.js
+++ b/static/js/reducers/collections_test.js
@@ -24,13 +24,13 @@ describe("collections endpoints", () => {
   })
 
   it("adds a new collection to the beginning of the list", async () => {
-    sandbox.stub(api, "getCollections").returns(Promise.resolve(collections))
+    sandbox.stub(api, "getCollections").returns(Promise.resolve({results: collections}))
     let state = await dispatchThen(actions.collectionsList.get(), [
       actions.collectionsList.get.requestType,
       actions.collectionsList.get.successType
     ])
 
-    assert.deepEqual(state.collectionsList.data, collections)
+    assert.deepEqual(state.collectionsList.data.results, collections)
 
     const newCollection = makeCollection()
     sandbox
@@ -40,9 +40,6 @@ describe("collections endpoints", () => {
       actions.collectionsList.post.requestType,
       actions.collectionsList.post.successType
     ])
-    assert.deepEqual(state.collectionsList.data, [
-      newCollection,
-      ...collections
-    ])
+    assert.deepEqual(state.collectionsList.data.results, [newCollection, ...collections])
   })
 })

--- a/ui/pagination.py
+++ b/ui/pagination.py
@@ -1,0 +1,12 @@
+"""
+Custom pagination classes
+"""
+from django.conf import settings
+from rest_framework.pagination import PageNumberPagination
+
+
+class CollectionSetPagination(PageNumberPagination):
+    """ Custom pagination class for collections """
+    page_size = settings.PAGE_SIZE_COLLECTIONS
+    page_size_query_param = settings.PAGE_SIZE_QUERY_PARAM
+    max_page_size = settings.PAGE_SIZE_MAXIMUM

--- a/ui/views.py
+++ b/ui/views.py
@@ -22,6 +22,7 @@ from rest_framework import (
     mixins,
 )
 from rest_framework.decorators import detail_route
+from rest_framework.filters import OrderingFilter
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -29,6 +30,7 @@ from rest_framework.views import APIView
 from cloudsync import api as cloudapi
 from cloudsync.tasks import upload_youtube_caption
 from techtv2ovs.models import TechTVVideo
+from ui.pagination import CollectionSetPagination
 from ui.serializers import VideoSerializer
 from ui.templatetags.render_bundle import public_path
 from ui import (
@@ -302,6 +304,10 @@ class CollectionViewSet(viewsets.ModelViewSet):
         permissions.IsAuthenticated,
         ui_permissions.HasCollectionPermissions
     )
+
+    pagination_class = CollectionSetPagination
+    filter_backends = (OrderingFilter,)
+    ordering_fields = ('created_at', 'title')
 
     def get_queryset(self):
         """

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -22,6 +22,7 @@ from ui.factories import (
     VideoSubtitleFactory,
     YouTubeVideoFactory)
 from ui.models import VideoSubtitle
+from ui.pagination import CollectionSetPagination
 from ui.serializers import (
     DropboxUploadSerializer,
     VideoSerializer)
@@ -274,14 +275,14 @@ def test_collection_viewset_list(mock_moira_client, logged_in_apiclient):
 
     result = client.get(url)
     assert result.status_code == status.HTTP_200_OK
-    assert len(result.data) == len(expected_collection_keys)
-    for coll_data in result.data:
+    assert len(result.data['results']) == len(expected_collection_keys)
+    for coll_data in result.data['results']:
         assert coll_data['key'] in expected_collection_keys
         assert coll_data['key'] not in prohibited_collection_keys
         assert 'videos' not in coll_data
 
 
-def test_collection_viewset_list_superuser(logged_in_apiclient):
+def test_collection_viewset_list_superuser(logged_in_apiclient, settings):
     """
     Tests the list of collections for a superuser
     """
@@ -295,8 +296,8 @@ def test_collection_viewset_list_superuser(logged_in_apiclient):
 
     result = client.get(url)
     assert result.status_code == status.HTTP_200_OK
-    assert len(result.data) == 6
-    for coll_data in result.data:
+    assert len(result.data['results']) == 6
+    for coll_data in result.data['results']:
         assert coll_data['key'] in collections
 
 
@@ -700,3 +701,41 @@ def test_video_viewset_analytics_throw(mocker, logged_in_apiclient):
     url = reverse('models-api:video-analytics', kwargs={'key': video.hexkey})
     result = client.get(url, {'throw': 1})
     assert result.status_code == 500
+
+
+def test_collection_pagination(mocker, logged_in_apiclient):
+    """
+    Verify that the correct number of collections is returned per page
+    """
+    mocker.patch('ui.serializers.get_moira_client')
+    mocker.patch('ui.utils.get_moira_client')
+    page_size = 8
+    CollectionSetPagination.page_size = page_size
+    client, user = logged_in_apiclient
+    collections = CollectionFactory.create_batch(20, owner=user)
+    url = reverse('models-api:collection-list')
+    result = client.get(url)
+    assert len(result.data['results']) == min(page_size, len(collections))
+    for i in range(1, 3):
+        paged_url = url + '?page={}'.format(i)
+        result = client.get(paged_url)
+        assert len(result.data['results']) == min(page_size, max(0, len(collections) - page_size * (i-1)))
+
+
+@pytest.mark.parametrize('field', ['created_at', 'title'])
+def test_collection_ordering(mocker, logged_in_apiclient, field):
+    """ Verify that results are returned in the appropriate order"""
+    mocker.patch('ui.serializers.get_moira_client')
+    mocker.patch('ui.utils.get_moira_client')
+    CollectionSetPagination.page_size = 5
+    client, user = logged_in_apiclient
+    CollectionFactory.create_batch(10, owner=user)
+    url = reverse('models-api:collection-list')
+    p1_response = client.get('{}?page=1&ordering={}'.format(url, field))
+    assert len(p1_response.data['results']) == 5
+    for i in range(4):
+        assert p1_response.data['results'][i][field].lower() <= p1_response.data['results'][i+1][field].lower()
+    p2_response = client.get('{}?page=2&ordering={}'.format(url, field))
+    assert p1_response.data['results'][-1][field].lower() <= p2_response.data['results'][0][field].lower()
+    for i in range(4):
+        assert p2_response.data['results'][i][field].lower() <= p2_response.data['results'][i+1][field].lower()


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #522

#### What's this PR do?
Adds pagination to the collections API and makes some modifications to the front-end (and its unit tests) to keep everything working with the different output format.

#### How should this be manually tested?
- Go to the `/collections` page, you should still see your collections as usual.  Ditto for the list of collections on the collapsible left side panel.  Unless you have more than 1000 collections, then only 1000 will display.
- Add `PAGE_SIZE_COLLECTIONS=2` to your `.env` file and restart the app.
- You should now see only 2 collections on the `/collections` page and in the left side panel.
- Create a new collection.  It should work as before with no javascript errors.
- Update the collection with a different title or description.  It should work as before with no javascript errors.
- Go to `/api/v0/collections` and try different values for parameters `page_size=`, `page=` and `ordering=` (`title`, `-title`, `created_at`, `-created_at`) - the results should update accordingly.
- Front-end paging controls are not in this PR.

#### Any background context you want to provide?
Without pagination, the API response is simply a list of serialized collections:
```javascript
[
    {
        "key": "9477a10710144e45bda1f195ebd41ac4",
        "created_at": "2018-04-09T15:19:54.769285Z",
        "title": "Dorska's amaaaaaazing videos",
        "description": "guaranteed to entertain and enlighten",
        "view_lists": [],
        "admin_lists": [],
        "video_count": 2
    },
```

With pagination enabled, the response includes `count`, `next`, and `previous` fields, and collections are in a `results` field:
```javascript
{
    "count": 38,
    "next": "http://localhost:8089/api/v0/collections/?page=2",
    "previous": null,
    "results": [
    {
        "key": "9477a10710144e45bda1f195ebd41ac4",
        "created_at": "2018-04-09T15:19:54.769285Z",
        "title": "Dorska's amaaaaaazing videos",
        "description": "guaranteed to entertain and enlighten",
        "view_lists": [],
        "admin_lists": [],
        "video_count": 2
    },
```

This required changing more of the front-end code than anticipated just to keep everything working as before.  Although it would be possible to customize the paginated response to match the non-paginated response, the extra fields will likely be useful for front-end paging controls.