### PR TITLE
Dorska/limit sidebar collections

### DIFF
--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -10,6 +10,8 @@ import * as collectionUiActions from "../../actions/collectionUi"
 import { makeCollectionUrl } from "../../lib/urls"
 import type { Collection } from "../../flow/collectionTypes"
 
+const MAX_VISIBLE_COLLECTIONS = 10
+
 type DrawerProps = {
   open: boolean,
   onDrawerClose: () => void,
@@ -103,7 +105,7 @@ class Drawer extends React.Component<*, void> {
             <div className="mdc-drawer__header-content">Collections</div>
           </header>
           <nav id="nav-collections" className="mdc-drawer__content mdc-list">
-            {collections.map(col => (
+            {collections.slice(0, MAX_VISIBLE_COLLECTIONS).map(col => (
               <a
                 className="mdc-list-item mdc-list-item--activated"
                 href={makeCollectionUrl(col.key)}

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -32,7 +32,7 @@ describe("Drawer", () => {
     listenForActions = store.createListenForActions()
     getCollectionsStub = sandbox
       .stub(api, "getCollections")
-      .returns(Promise.resolve({results: collections}))
+      .returns(Promise.resolve({ results: collections }))
   })
 
   afterEach(() => {
@@ -89,12 +89,15 @@ describe("Drawer", () => {
     assert.isTrue(drawerNode.text().endsWith("Log out"))
   })
 
-  it("drawer element is rendered with collections list", async () => {
+  it("drawer element is rendered with max of 10 collections", async () => {
+    const numCollections = 20
+    collections = [...Array(numCollections).keys()].map(() => makeCollection())
+    getCollectionsStub.returns(Promise.resolve({ results: collections }))
     const wrapper = await renderDrawer()
-    ;[0, 1].forEach(function(col) {
-      const drawerNode = wrapper
-        .find(".mdc-list-item .mdc-list-item--activated")
-        .at(col)
+    const items = wrapper.find(".mdc-list-item .mdc-list-item--activated")
+    assert.equal(items.length, 10)
+    ;[0, 1, 3].forEach(function(col) {
+      const drawerNode = items.at(col)
       assert.equal(drawerNode.text(), collections[col].title)
       assert.equal(
         drawerNode.props().href,


### PR DESCRIPTION
#### What are the relevant tickets?
#523 

#### What's this PR do?
Limits to 10 collections in sidebar.

#### How should this be manually tested?
1. Ensure that you have > 10 collections.
2. Ensure that in `.env`,  your `PAGE_SIZE_COLLECTIONS` is > 10 . (remember to restart if you change the `.env` file)
3. Go to any page and open the side bar. You should see only 10 collections.
