### PR TITLE
add more collections button to sidenav

### DIFF
--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -114,6 +114,14 @@ class Drawer extends React.Component<*, void> {
                 {col.title}
               </a>
             ))}
+            {collections.length > MAX_VISIBLE_COLLECTIONS ? (
+              <a
+                className="mdc-list-item mdc-list-item more-collections-button"
+                href='/collections/'
+              >
+                more collections…
+              </a>
+            ) : null}
             {SETTINGS.editable ? (
               <span>
                 <button

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -89,28 +89,46 @@ describe("Drawer", () => {
     assert.isTrue(drawerNode.text().endsWith("Log out"))
   })
 
-  it("drawer element is rendered with max of 10 collections", async () => {
-    const numCollections = 20
-    collections = [...Array(numCollections).keys()].map(() => makeCollection())
-    getCollectionsStub.returns(Promise.resolve({ results: collections }))
-    const wrapper = await renderDrawer()
-    const items = wrapper.find(".mdc-list-item .mdc-list-item--activated")
-    assert.equal(items.length, 10)
-    ;[0, 1, 3].forEach(function(col) {
-      const drawerNode = items.at(col)
-      assert.equal(drawerNode.text(), collections[col].title)
-      assert.equal(
-        drawerNode.props().href,
-        makeCollectionUrl(collections[col].key)
-      )
+  describe("when there are > 10 collections", () => {
+    beforeEach(() => {
+      const numCollections = 20
+      collections = [...Array(numCollections).keys()].map(() => makeCollection())
+      getCollectionsStub.returns(Promise.resolve({ results: collections }))
+    })
+
+    it("drawer element is rendered with max of 10 collections", async () => {
+      const wrapper = await renderDrawer()
+      const items = wrapper.find(".mdc-list-item .mdc-list-item--activated")
+      assert.equal(items.length, 10)
+      ;[0, 1, 3, 9].forEach(function(col) {
+        const drawerNode = items.at(col)
+        assert.equal(drawerNode.text(), collections[col].title)
+        assert.equal(
+          drawerNode.props().href,
+          makeCollectionUrl(collections[col].key)
+        )
+      })
+    })
+
+    it("has 'more...' button that links to collections page", async () => {
+      const wrapper = await renderDrawer()
+      const moreButton = wrapper.find(".more-collections-button")
+      assert.equal(moreButton.length, 1)
+      assert.equal(moreButton.prop('href'), '/collections/')
     })
   })
 
-  it("drawer element is rendered with a help link", async () => {
-    const wrapper = await renderDrawer()
-    const drawerNode = wrapper.find(".mdc-list-item .mdc-link").at(1)
-    assert.equal(drawerNode.props().href, "/help/")
-    assert.isTrue(drawerNode.text().endsWith("Help"))
+  describe("when there are <= 10 collections", () => {
+    beforeEach(() => {
+      const numCollections = 10
+      collections = [...Array(numCollections).keys()].map(() => makeCollection())
+      getCollectionsStub.returns(Promise.resolve({ results: collections }))
+    })
+
+    it("does not have 'more...' button", async () => {
+      const wrapper = await renderDrawer()
+      assert.isFalse(wrapper.find(".more-collections-button").exists())
+    })
   })
 
   it("drawer element is rendered with a logout link", async () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #524 . 

#### What's this PR do?
Adds 'more' button to the sidenav when there are > 10 collections.

#### How should this be manually tested?

##### First as a user w/ many collections
1. Ensure that you have > 10 collections.
2. Ensure that in .env, your PAGE_SIZE_COLLECTIONS is > 10 . (remember to restart if you change the .env file)
3. Go to any page and open the side bar. You should see a 'more collections...' button.
4. Click the button, ensure that you go to the `/collections/` page.

##### Then as a user w/ < 10 collections
1. Ensure that you have < 10 collections.
2. Ensure that in .env, your PAGE_SIZE_COLLECTIONS is > 10 . (remember to restart if you change the .env file)
3. Go to any page and open the side bar. You should *not* see a 'more collections...' button.


#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
