### PR TITLE
Add option to set start time on video

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@material/base": "^0.29.0",
     "@material/button": "^0.33.0",
+    "@material/checkbox": "^0.33.0",
     "@material/dialog": "^0.33.0",
     "@material/drawer": "^0.33.0",
     "@material/layout-grid": "^0.24.0",

--- a/static/js/actions/videoUi.js
+++ b/static/js/actions/videoUi.js
@@ -38,3 +38,13 @@ export const setVideoFormErrors = createAction(SET_VIDEO_FORM_ERRORS)
 
 export const CLEAR_VIDEO_FORM = qualifiedName("CLEAR_VIDEO_FORM")
 export const clearVideoForm = createAction(CLEAR_VIDEO_FORM)
+
+export const SET_SHARE_VIDEO_TIME = qualifiedName("SET_SHARE_VIDEO_TIME")
+export const setShareVideoTime = createAction(SET_SHARE_VIDEO_TIME)
+
+export const SET_SHARE_VIDEO_TIME_ENABLED = qualifiedName(
+  "SET_SHARE_VIDEO_TIME_ENABLED"
+)
+export const setShareVideoTimeEnabled = createAction(
+  SET_SHARE_VIDEO_TIME_ENABLED
+)

--- a/static/js/components/material/Checkbox.js
+++ b/static/js/components/material/Checkbox.js
@@ -1,0 +1,64 @@
+// @flow
+import React from "react"
+
+type CheckboxProps = {
+  id: string,
+  label: string,
+  checkGroupName: string,
+  value: string,
+  checked?: boolean,
+  onChange: Function,
+  children?: React$Element<*>[],
+  className?: string,
+  disabled?: boolean
+}
+
+export default class Checkbox extends React.Component<*, void> {
+  props: CheckboxProps
+
+  render() {
+    const {
+      value,
+      checked,
+      checkGroupName,
+      id,
+      label,
+      onChange,
+      children,
+      className,
+      disabled
+    } = this.props
+
+    const htmlId = `${checkGroupName}-${id}`
+
+    return (
+      <div className={`mdc-form-field ${className || ""}`} key={htmlId}>
+        <div
+          className={`mdc-checkbox ${disabled ? "mdc-checkbox--disabled" : ""}`}
+        >
+          <input
+            type="checkbox"
+            id="basic-checkbox"
+            onChange={onChange}
+            value={value}
+            checked={checked}
+            className="mdc-checkbox__native-control"
+          />
+          <div className="mdc-checkbox__background">
+            <svg className="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+              <path
+                className="mdc-checkbox__checkmark-path"
+                fill="none"
+                stroke="white"
+                d="M1.73,12.91 8.1,19.28 22.79,4.59"
+              />
+            </svg>
+            <div className="mdc-checkbox__mixedmark" />
+          </div>
+        </div>
+        <label htmlFor={htmlId}>{label}</label>
+        {children}
+      </div>
+    )
+  }
+}

--- a/static/js/flow/videoTypes.js
+++ b/static/js/flow/videoTypes.js
@@ -62,6 +62,11 @@ export type VideoFormState = {
   viewLists: ?string
 };
 
+export type VideoShareState = {
+  shareTime: boolean,
+  videoTime: number
+};
+
 export type VideoSubtitleState = {
   key: ?string,
   language: string,
@@ -76,6 +81,7 @@ export type VideoValidation = {
 export type VideoUiState = {
   editVideoForm: VideoFormState,
   videoSubtitleForm: VideoSubtitleState,
+  shareVideoForm: VideoShareState,
   corner: string,
   errors?: VideoValidation
 };

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -5,9 +5,9 @@ import sanitize from "sanitize-filename"
 import type { Video, VideoFile, VideoSubtitle } from "../flow/videoTypes"
 
 export const makeVideoUrl = (videoKey: string) =>
-  `/videos/${encodeURI(videoKey)}`
+  `/videos/${encodeURI(videoKey)}/`
 export const makeEmbedUrl = (videoKey: string) =>
-  `${makeVideoUrl(videoKey)}/embed/`
+  `${makeVideoUrl(videoKey)}embed/`
 export const makeCollectionUrl = (collectionKey: string) =>
   `/collections/${encodeURI(collectionKey)}/`
 export const makeVideoThumbnailUrl = (video: Video): ?string =>

--- a/static/js/reducers/videoUi.js
+++ b/static/js/reducers/videoUi.js
@@ -11,7 +11,9 @@ import {
   SET_VIEW_CHOICE,
   SET_VIDEO_FORM_ERRORS,
   SET_PERM_OVERRIDE_CHOICE,
-  CLEAR_VIDEO_FORM
+  CLEAR_VIDEO_FORM,
+  SET_SHARE_VIDEO_TIME,
+  SET_SHARE_VIDEO_TIME_ENABLED
 } from "../actions/videoUi"
 import { CANVASES } from "../constants"
 import type { VideoUiState } from "../flow/videoTypes"
@@ -32,9 +34,15 @@ export const INITIAL_UPLOAD_SUBTITLE_FORM_STATE = {
   subtitle: null
 }
 
+export const INITIAL_SHARE_VIDEO_FORM_STATE = {
+  shareTime: false,
+  videoTime: 0
+}
+
 export const INITIAL_UI_STATE = {
   editVideoForm:     INITIAL_EDIT_VIDEO_FORM_STATE,
   videoSubtitleForm: INITIAL_UPLOAD_SUBTITLE_FORM_STATE,
+  shareVideoForm:    INITIAL_SHARE_VIDEO_FORM_STATE,
   corner:            Object.keys(CANVASES)[0]
 }
 
@@ -87,6 +95,22 @@ const reducer = (
       videoSubtitleForm: {
         ...state.videoSubtitleForm,
         subtitle: action.payload
+      }
+    }
+  case SET_SHARE_VIDEO_TIME_ENABLED:
+    return {
+      ...state,
+      shareVideoForm: {
+        ...state.shareVideoForm,
+        shareTime: action.payload
+      }
+    }
+  case SET_SHARE_VIDEO_TIME:
+    return {
+      ...state,
+      shareVideoForm: {
+        ...state.shareVideoForm,
+        videoTime: action.payload
       }
     }
   case SET_VIDEOJS_SYNC:

--- a/static/js/reducers/videoUi_test.js
+++ b/static/js/reducers/videoUi_test.js
@@ -5,6 +5,7 @@ import configureTestStore from "redux-asserts"
 import rootReducer from "../reducers"
 import {
   INITIAL_EDIT_VIDEO_FORM_STATE,
+  INITIAL_SHARE_VIDEO_FORM_STATE,
   INITIAL_UPLOAD_SUBTITLE_FORM_STATE
 } from "./videoUi"
 import {
@@ -26,6 +27,7 @@ describe("videoUi", () => {
     assert.deepEqual(store.getState().videoUi, {
       videoSubtitleForm: INITIAL_UPLOAD_SUBTITLE_FORM_STATE,
       editVideoForm:     INITIAL_EDIT_VIDEO_FORM_STATE,
+      shareVideoForm:    INITIAL_SHARE_VIDEO_FORM_STATE,
       corner:            "camera1"
     })
   })

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -19,3 +19,9 @@ export const calculateListPermissionValue = (
   choice !== PERM_CHOICE_LISTS || !listsInput || listsInput.trim().length === 0
     ? []
     : R.reject(R.isEmpty, R.map(R.trim, R.split(",", listsInput)))
+
+/**
+ * Formats seconds to minutes:seconds string
+ */
+export const formatSecondsToMinutes = (seconds: number) =>
+  (seconds - (seconds %= 60)) / 60 + (9 < seconds ? ":" : ":0") + seconds

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -165,6 +165,17 @@ textarea {
     padding-top: 5px;
   }
 
+  .mdc-form-field {
+    display: flex;
+    flex-direction: row;
+
+    label {
+      align-self: center;
+      width: 88px;
+      padding: 0;
+    }
+  }
+
   .permission-group {
     padding: 20px;
     margin: 0 0 20px;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -8,6 +8,7 @@
 @import "~@material/button/mdc-button";
 @import "~@material/dialog/mdc-dialog";
 @import "~@material/radio/mdc-radio";
+@import "~@material/checkbox/mdc-checkbox";
 @import "~@material/drawer/mdc-drawer";
 @import "~@material/layout-grid/mdc-layout-grid";
 @import "~@material/list/mdc-list";

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,17 @@
     "@material/selection-control" "^0.32.0"
     "@material/theme" "^0.30.0"
 
+"@material/checkbox@^0.33.0":
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/@material/checkbox/-/checkbox-0.33.0.tgz#0cdf9d261c0cd493a3daceb31a476cf62b9f23b2"
+  dependencies:
+    "@material/animation" "^0.25.0"
+    "@material/base" "^0.29.0"
+    "@material/ripple" "^0.33.0"
+    "@material/rtl" "^0.33.0"
+    "@material/selection-control" "^0.33.0"
+    "@material/theme" "^0.33.0"
+
 "@material/chips@^0.32.0":
   version "0.32.0"
   resolved "https://registry.yarnpkg.com/@material/chips/-/chips-0.32.0.tgz#276c9ec8cb14b559ef9d201c5813ebaa765e77e7"
@@ -6293,13 +6304,6 @@ rst-selector-parser@^2.2.3:
   dependencies:
     lodash.flattendeep "^4.4.0"
     nearley "^2.7.10"
-
-rmwc@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/rmwc/-/rmwc-1.4.1.tgz#5c8f5fbf5c1131fdf22374a7089727a169685732"
-  dependencies:
-    classnames "^2.2.5"
-    material-components-web "0.32.0"
 
 run-async@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #279

#### What's this PR do?
Stores current video time in state.  Adds a checkbox in the `ShareVideoDialog` to add the current time to the links.  Starts playing the video at the specified time if the parameter is in the URL.

#### How should this be manually tested?
- Open the 'Share' dialog from a video detail page and from a collection page.  There should be a checkbox to 'Start at <M:S>'.  Checking the box should add `?start=<time_in_seconds>` to the video and embed URL's in the text fields.  Unchecking the box should remove it.  The time should be 0 if the video hasn't started playing.
- Start playing the video and then open the Share dialog again.  The time shown for both the checkbox and URL parameter should increment every second.
- Try out the video detail and embed links with the `start` parameter in a different tab/window.  The video should start playing at the specified time.
- The above should work for regular videos, Youtube videos, and multiangle videos.