### PR TITLE
Use different analytics queries for multiangle/singleangle videos

### DIFF
--- a/static/js/components/analytics/AnalyticsPane.js
+++ b/static/js/components/analytics/AnalyticsPane.js
@@ -133,9 +133,8 @@ class AnalyticsPane extends React.Component<*, *> {
 
   formatAnalyticsData(analyticsData: VideoAnalyticsData): VideoAnalyticsData {
     return {
-      channels:       analyticsData.channels,
+      ...analyticsData,
       times:          this.interpolateTimes(analyticsData.times),
-      views_at_times: analyticsData.views_at_times
     }
   }
 

--- a/static/js/components/analytics/AnalyticsTable.js
+++ b/static/js/components/analytics/AnalyticsTable.js
@@ -19,9 +19,12 @@ export default class AnalyticsTable extends React.Component<*, void> {
           <tr>
             <th>Minute</th>
             <th>Total Viewers</th>
-            {analyticsData.channels.map((channel, i) => {
-              return <th key={i}>{channel}</th>
-            })}
+            {analyticsData.is_multichannel
+              ? analyticsData.channels.map((channel, i) => {
+                return <th key={i}>{channel}</th>
+              })
+              : null
+            }
           </tr>
         </thead>
         <tbody>
@@ -39,21 +42,31 @@ export default class AnalyticsTable extends React.Component<*, void> {
   ) {
     const viewsAtTime = analyticsData.views_at_times[minute] || {}
     const totalViews = _.sum(Object.values(viewsAtTime))
-    const channelViews = analyticsData.channels.map(channel => {
-      return viewsAtTime[channel] || 0
-    })
-    const viewsValues = [totalViews, ...channelViews]
+    let viewsValues = [totalViews]
+    if (analyticsData.is_multichannel) {
+      const channelViews = analyticsData.channels.map(channel => {
+        return viewsAtTime[channel] || 0
+      })
+
+      viewsValues = [viewsValues, ...channelViews]
+    }
     return (
       <tr key={minute}>
-        <td>{this.pad(minute, 4)}</td>
+        <td className="time">{this.pad(minute, 4)}</td>
         {viewsValues.map((numViews, i) => {
-          let pct = 0
-          if (totalViews !== 0) {
-            pct = (numViews / totalViews * 100).toFixed(1)
+          let percentEl = null
+          if (analyticsData.is_multichannel) {
+            let percent = 0
+            if (totalViews !== 0) {
+              percent = (parseFloat(numViews) / totalViews * 100).toFixed(1)
+            }
+            percentEl = (
+              <span className="percent">{`(${percent}%)`}</span>
+            )
           }
           return (
-            <td key={i}>
-              {numViews} ({pct}%)
+            <td className="views" key={i}>
+              {numViews} {percentEl}
             </td>
           )
         })}

--- a/static/js/components/analytics/AnalyticsTable_test.js
+++ b/static/js/components/analytics/AnalyticsTable_test.js
@@ -19,8 +19,30 @@ describe("AnalyticsTable", () => {
     return wrapper
   }
 
-  it("renders", () => {
-    const wrapper = renderTable()
-    assert.isTrue(wrapper.exists())
+  describe("when multichannel", () => {
+    it("shows total views with percentage", () => {
+      analyticsData.is_multichannel = true 
+      const wrapper = renderTable()
+      const row = wrapper.find('tbody > tr').at(0)
+      assert.equal(
+        row.find('td.views').length,
+        analyticsData.channels.length + 1
+      )
+      assert.equal(
+        row.find('.percent').length,
+        analyticsData.channels.length + 1
+      )
+    })
   })
+
+  describe("when not multichannel", () => {
+    it("does not show total views with percentage", () => {
+      analyticsData.is_multichannel = false
+      const wrapper = renderTable()
+      const row = wrapper.find('tbody > tr').at(0)
+      assert.equal(row.find('td.views').length, 1)
+      assert.equal(row.find('.percent').length, 0)
+    })
+  })
+
 })

--- a/static/js/factories/videoAnalytics.js
+++ b/static/js/factories/videoAnalytics.js
@@ -5,9 +5,10 @@ import type { VideoAnalyticsData } from "../flow/videoAnalyticsTypes"
 export const makeVideoAnalyticsData = (n: number): VideoAnalyticsData => {
   n = n || 24
   const videoAnalyticsData = {
-    times:          [...Array(n).keys()],
-    channels:       [...Array(4).keys()].map(i => `channel${i + 1}`),
-    views_at_times: {}
+    is_multichannel: true,
+    times:           [...Array(n).keys()],
+    channels:        [...Array(4).keys()].map(i => `channel${i + 1}`),
+    views_at_times:  {}
   }
   for (let tIdx = 0; tIdx < videoAnalyticsData.times.length; tIdx++) {
     const t = videoAnalyticsData.times[tIdx]

--- a/static/js/flow/videoAnalyticsTypes.js
+++ b/static/js/flow/videoAnalyticsTypes.js
@@ -2,6 +2,7 @@
 
 export type VideoAnalyticsData = {
   channels: Array<string|number>,
+  is_multichannel: boolean,
   times: Array<string|number>,
   views_at_times: {
     [string | number]: {

--- a/ui/views.py
+++ b/ui/views.py
@@ -362,7 +362,8 @@ class VideoViewSet(ModelDetailViewset):
                 if param in request.GET
             })
         else:
-            data = get_video_analytics(key)
+            video = self.get_object()
+            data = get_video_analytics(video)
         return Response({'data': data})
 
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -661,7 +661,7 @@ def test_video_viewset_analytics(mocker, logged_in_apiclient):
     url = reverse('models-api:video-analytics', kwargs={'key': video.hexkey})
     result = client.get(url)
     assert result.status_code == status.HTTP_200_OK
-    assert mock_get_video_analytics.called_once_with(video.hexkey)
+    assert mock_get_video_analytics.called_once_with(video)
     assert result.data['data'] == mock_get_video_analytics.return_value
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
#545 

#### What's this PR do?
Changes the analytics query based on whether a video is single cam or multicam.

#### How should this be manually tested?

1. Ensure that you have analytics events for:
  a. a multicam video
  b. a singlecam video
2. Open an analytics dialog for each type of video. You should see analytics data.