### PR TITLE
add start/end indices to collections pagination output

### DIFF
--- a/ui/pagination.py
+++ b/ui/pagination.py
@@ -16,4 +16,5 @@ class CollectionSetPagination(PageNumberPagination):
         response = super().get_paginated_response(data)
         response.data['start_index'] = self.page.start_index()
         response.data['end_index'] = self.page.end_index()
+        response.data['num_pages'] = self.page.paginator.num_pages
         return response

--- a/ui/pagination.py
+++ b/ui/pagination.py
@@ -10,3 +10,10 @@ class CollectionSetPagination(PageNumberPagination):
     page_size = settings.PAGE_SIZE_COLLECTIONS
     page_size_query_param = settings.PAGE_SIZE_QUERY_PARAM
     max_page_size = settings.PAGE_SIZE_MAXIMUM
+
+    def get_paginated_response(self, data):
+        """Decorate standard response with start/end indices."""
+        response = super().get_paginated_response(data)
+        response.data['start_index'] = self.page.start_index()
+        response.data['end_index'] = self.page.end_index()
+        return response

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -276,6 +276,9 @@ def test_collection_viewset_list(mock_moira_client, logged_in_apiclient):
     result = client.get(url)
     assert result.status_code == status.HTTP_200_OK
     assert len(result.data['results']) == len(expected_collection_keys)
+    assert result.data['count'] == len(expected_collection_keys)
+    assert result.data['start_index'] == 1
+    assert result.data['end_index'] == len(expected_collection_keys)
     for coll_data in result.data['results']:
         assert coll_data['key'] in expected_collection_keys
         assert coll_data['key'] not in prohibited_collection_keys

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -277,6 +277,7 @@ def test_collection_viewset_list(mock_moira_client, logged_in_apiclient):
     assert result.status_code == status.HTTP_200_OK
     assert len(result.data['results']) == len(expected_collection_keys)
     assert result.data['count'] == len(expected_collection_keys)
+    assert result.data['num_pages'] == 1
     assert result.data['start_index'] == 1
     assert result.data['end_index'] == len(expected_collection_keys)
     for coll_data in result.data['results']:


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #521 

#### What's this PR do?
adds start/end indices to pagination response.

#### How should this be manually tested?
1. Go to http://localhost:8089/api/v0/collections/
2. Confirm that start_index/end_index are in the output
3. Change the page, e.g. http://localhost:8089/api/v0/collections/?page=3
4. Confirm that start_index/end_index update as expected.