### PR TITLE
Remove '<', '>' from title/description before uploading to Youtube

### DIFF
--- a/cloudsync/youtube.py
+++ b/cloudsync/youtube.py
@@ -1,5 +1,6 @@
 """ YouTube API interface"""
 import http
+import re
 import time
 import logging
 from tempfile import NamedTemporaryFile
@@ -67,6 +68,19 @@ def resumable_upload(request, max_retries=10):
             time.sleep(sleep_time)
 
     return response
+
+
+def strip_bad_chars(txt):
+    """
+    Remove any characters forbidden by Youtube (<, >) from text
+
+    Args:
+        txt(str): Text to remove characters from.
+
+    Returns:
+        str: Text without bad characters
+    """
+    return re.sub('<|>', '', txt)
 
 
 class YouTubeApi:
@@ -228,8 +242,8 @@ class YouTubeApi:
 
         request_body = dict(
             snippet=dict(
-                title=video.title[:100],
-                description=video.description[:5000]
+                title=strip_bad_chars(video.title)[:100],
+                description=strip_bad_chars(video.description)[:5000]
             ),
             status=dict(
                 privacyStatus=privacy

--- a/cloudsync/youtube_test.py
+++ b/cloudsync/youtube_test.py
@@ -8,7 +8,7 @@ import pytest
 from googleapiclient.errors import HttpError
 
 from cloudsync.conftest import MockHttpErrorResponse
-from cloudsync.youtube import YouTubeApi, YouTubeUploadException
+from cloudsync.youtube import YouTubeApi, YouTubeUploadException, strip_bad_chars
 from ui.constants import VideoStatus
 from ui.factories import VideoFileFactory, VideoSubtitleFactory, VideoFactory
 
@@ -206,3 +206,10 @@ def test_video_status(mocker):
         'pageInfo': {'resultsPerPage': 1, 'totalResults': 1}}
     assert YouTubeApi().video_status('foo') == expected_status
     youtube_mocker().videos.return_value.list.assert_called_once_with(id='foo', part='status')
+
+
+def test_strip_bad_chars():
+    """
+    Test that `<`,`>` characters are removed from text
+    """
+    assert strip_bad_chars('<OV>S>') == 'OVS'


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #562 

#### What's this PR do?
Removes all `>` and `<` characters from video title and description when uploading to Youtube.

#### How should this be manually tested?
- Create a video,  include `>` and `<` characters in the title and description.
- Make the video public (you can do this in the admin page for it)
- Run the following in a shell:
```
from cloudsync.tasks import upload_youtube_videos
upload_youtube_videos()
```
- The video should be uploaded to Youtube successfully (look for it in the `Youtube Videos` section of the Django admin - status should be `processed` within a few minutes, assuming it's not a dupe).
