### PR TITLE
Make TTV collection name display on admin page for TTV video

### DIFF
--- a/techtv2ovs/models.py
+++ b/techtv2ovs/models.py
@@ -17,6 +17,9 @@ class TechTVCollection(models.Model):
     description = models.TextField(blank=True, null=True)
     owner_email = models.EmailField(null=True)
 
+    def __str__(self):
+        return self.name
+
 
 class TechTVVideo(models.Model):
     """


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #553 

#### What's this PR do?
Defines a `__str__` method for the `TechTVCollection` model so that the title will show up on the admin page for a `TechTVVideo`

#### How should this be manually tested?
- Assuming you have already run the TechTV import command on at least one collection, go to the admin page for any `TechTVVideo`.  The object's `TechTVCollection` name should be displayed.
