### PR TITLE
Dorska/toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-test-renderer": "^15.6.1",
+    "react-transition-group": "^2.3.1",
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
     "redux-asserts": "^0.0.10",

--- a/static/js/actions/index.js
+++ b/static/js/actions/index.js
@@ -5,11 +5,14 @@ import { endpoints } from "../lib/redux_rest"
 
 import * as collectionsPagination from "./collectionsPagination"
 import * as videoUi from "./videoUi"
+import * as toast from "./toast"
 
 const actions: Object = {
   collectionsPagination: collectionsPagination.actionCreators,
-  videoUi:               videoUi.actionCreators
+  videoUi:               videoUi.actionCreators,
+  toast:                 toast.actionCreators
 }
+
 endpoints.forEach(endpoint => {
   actions[endpoint.name] = deriveActions(endpoint)
 })

--- a/static/js/actions/toast.js
+++ b/static/js/actions/toast.js
@@ -1,0 +1,14 @@
+// @flow
+import { createAction } from "redux-actions"
+
+const qualifiedName = (name: string) => `TOAST_${name}`
+const constants = {}
+const actionCreators = {}
+
+constants.ADD_MESSAGE = qualifiedName("ADD_MESSAGE")
+actionCreators.addMessage = createAction(constants.ADD_MESSAGE)
+
+constants.REMOVE_MESSAGE = qualifiedName("REMOVE_MESSAGE")
+actionCreators.removeMessage = createAction(constants.REMOVE_MESSAGE)
+
+export { actionCreators, constants }

--- a/static/js/components/analytics/AnalyticsChart.js
+++ b/static/js/components/analytics/AnalyticsChart.js
@@ -61,16 +61,13 @@ export class AnalyticsChart extends React.Component {
 
   render() {
     const { dimensions } = this.state
-    const {
-      analyticsData,
-      getColorForChannel,
-      duration,
-      ...remainingProps
-    } = this.props
-    const passThroughProps = _.omit(remainingProps, [
+    const passThroughProps = _.omit(this.props, [
+      "analyticsData",
       "currentTime",
-      "setVideoTime",
-      "padding"
+      "duration",
+      "getColorForChannel",
+      "padding",
+      "setVideoTime"
     ])
     return (
       <div
@@ -79,31 +76,22 @@ export class AnalyticsChart extends React.Component {
         }}
         {...passThroughProps}
       >
-        {dimensions
-          ? this.renderChart({
-            analyticsData,
-            getColorForChannel,
-            dimensions,
-            duration
-          })
-          : null}
+        {dimensions ? this.renderChart() : null}
       </div>
     )
   }
 
-  renderChart(opts) {
+  renderChart() {
     const { dimensions } = this.state
-    const { analyticsData, getColorForChannel, duration } = opts
+    const { analyticsData, duration, getColorForChannel, padding } = this.props
     const viewsAtTimesByChannel = this._generateViewsAtTimesByChannel(
-      analyticsData
-    )
+      analyticsData)
     const baseLabelStyle = {
       fill:       "#666",
       fontFamily: "'Roboto', 'sans-serif'",
       fontSize:   10
     }
     const chartBodyClipPathId = `${this._namespace}-chart-body-clipPath`
-    const padding = this.props.padding
     const chartBodyBounds = this._getRelativeChartBodyBounds()
     return (
       <VictoryChart

--- a/static/js/components/dialogs/DeleteVideoDialog.js
+++ b/static/js/components/dialogs/DeleteVideoDialog.js
@@ -16,22 +16,32 @@ type DialogProps = {
   open: boolean,
   hideDialog: Function,
   shouldUpdateCollection: boolean,
-  video: Video
+  video: Video,
+  window?: any
 }
 
-class DeleteVideoDialog extends React.Component<*, void> {
+export class DeleteVideoDialog extends React.Component<*, void> {
   props: DialogProps
 
   confirmDeletion = async () => {
     const { dispatch, video, shouldUpdateCollection } = this.props
+    const window_ = this.props.window || window
 
     await dispatch(actions.videos.delete(video.key))
+    dispatch(
+      actions.toast.addMessage({
+        message: {
+          key:     "video-delete",
+          content: `Video "${video.title}" was deleted.`,
+          icon:    "check"
+        }
+      })
+    )
     if (shouldUpdateCollection) {
       dispatch(actions.collections.get(video.collection_key))
     } else {
-      window.location = `${window.location.origin}${makeCollectionUrl(
-        video.collection_key
-      )}`
+      const collectionUrl = makeCollectionUrl(video.collection_key)
+      window_.location = `${window_.location.origin}${collectionUrl}`
     }
   }
 
@@ -59,7 +69,7 @@ class DeleteVideoDialog extends React.Component<*, void> {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state:Object, ownProps:Object) => {
   const { collectionUi: { selectedVideoKey } } = state
   const { collection, video } = ownProps
 
@@ -80,4 +90,6 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default connect(mapStateToProps)(DeleteVideoDialog)
+const ConnectedDeleteVideoDialog = connect(mapStateToProps)(DeleteVideoDialog)
+
+export default ConnectedDeleteVideoDialog

--- a/static/js/components/dialogs/DeleteVideoDialog_test.js
+++ b/static/js/components/dialogs/DeleteVideoDialog_test.js
@@ -1,0 +1,208 @@
+// @flow
+import React from "react"
+import _ from "lodash"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+import sinon from "sinon"
+
+import { DeleteVideoDialog, mapStateToProps } from "./DeleteVideoDialog"
+
+import { makeCollection } from "../../factories/collection"
+import { actions } from "../../actions"
+
+describe("DeleteVideoDialogTests", () => {
+  let sandbox, collection, video
+  const noop = () => null
+
+  beforeEach(() => {
+    collection = makeCollection()
+    video = collection.videos[0]
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe("mapStateToProps", () => {
+    let state, ownProps
+
+    describe("when ownProps has video", () => {
+
+      beforeEach(() => {
+        state = { collectionUi: { selectedVideoKey: video.key } }
+        ownProps = { video }
+      })
+
+      it("returns expected props", () => {
+        const actualProps = mapStateToProps(state, ownProps)
+        const expectedProps = { video, shouldUpdateCollection: false }
+        assert.deepEqual(actualProps, expectedProps)
+      })
+    })
+
+    describe("when ownProps has collection", () => {
+
+      beforeEach(() => {
+        state = { collectionUi: { selectedVideoKey: video.key } }
+        ownProps = { collection }
+      })
+
+      it("returns expected props", () => {
+        const expectedProps = { video, shouldUpdateCollection: true }
+        const actualProps = mapStateToProps(state, ownProps)
+        assert.deepEqual(actualProps, expectedProps)
+      })
+    })
+  })
+
+  describe("DeleteVideoDialog Component", () => {
+    const renderComponent = (extraProps = {}) => {
+      const defaultProps = {
+        hideDialog: noop,
+        open:       true,
+        video
+      }
+      return shallow(<DeleteVideoDialog {...{...defaultProps, ...extraProps}} />)
+    }
+
+    describe("when there is no video", () => {
+      let wrapper
+
+      beforeEach(() => {
+        wrapper = renderComponent({ video: undefined })
+      })
+
+      it("renders nothing", () => {
+        assert.equal(wrapper.get(0), null)
+      })
+    })
+
+    describe("when there is a video", () => {
+      let wrapper, instance
+
+      beforeEach(() => {
+        wrapper = renderComponent()
+        instance = wrapper.instance()
+      })
+
+      it("renders Dialog", () => {
+        const dialogEl = wrapper.find('Dialog')
+        const expectedDialogProps = {
+          title:      "Delete Video",
+          id:         "delete-video-dialog",
+          cancelText: "Cancel",
+          submitText: "Yes, Delete",
+          open:       instance.props.open,
+          hideDialog: instance.props.hideDialog,
+          onAccept:   instance.confirmDeletion
+        }
+        assert.deepEqual(
+          _.omit(dialogEl.props(), ['children']),
+          expectedDialogProps
+        )
+        assert.equal(dialogEl.find('h5').text(), instance.props.video.title)
+      })
+    })
+
+    describe("confirmDeletion", () => {
+      let wrapper, stubs
+
+      beforeEach(async () => {
+        const promises = {
+          videosDelete: Promise.resolve()
+        }
+        stubs = {
+          dispatch:     sandbox.stub(),
+          videosDelete: (
+            sandbox.stub(actions.videos, 'delete')
+              .returns(promises.videosDelete)
+          ),
+          collectionsGet:  sandbox.stub(actions.collections,'get'),
+          toastAddMessage: sandbox.stub(actions.toast, 'addMessage'),
+          window:          { location: { origin: 'someOrigin' } }
+        }
+        await promises.videosDelete
+      })
+
+      const renderComponentWithStubs = (extraProps = {}) => {
+        const wrapper = renderComponent({
+          dispatch: stubs.dispatch,
+          ...extraProps,
+        })
+        return wrapper
+      }
+
+      const generateCommonConfirmDeletionTests = () => {
+        it("dispatches video.delete", () => {
+          sinon.assert.calledWith(stubs.videosDelete, video.key)
+          sinon.assert.calledWith(
+            stubs.dispatch,
+            stubs.videosDelete.returnValues[0]
+          )
+        })
+
+        it("dispatches toast.addMessage", () => {
+          const expectedMessage = {
+            key:     'video-delete',
+            content: `Video "${video.title}" was deleted.`,
+            icon:    'check',
+          }
+          sinon.assert.calledWith(
+            stubs.toastAddMessage,
+            {message: expectedMessage}
+          )
+          sinon.assert.calledWith(
+            stubs.dispatch,
+            stubs.toastAddMessage.returnValues[0]
+          )
+        })
+      }
+
+      describe("when shouldUpdateCollection", () => {
+        beforeEach(async () => {
+          wrapper = renderComponentWithStubs({
+            video,
+            shouldUpdateCollection: true
+          })
+          await wrapper.instance().confirmDeletion()
+        })
+
+        generateCommonConfirmDeletionTests()
+
+        it("dispatches collections.get", () => {
+          sinon.assert.calledWith(
+            stubs.collectionsGet,
+            video.collection_key
+          )
+          sinon.assert.calledWith(
+            stubs.dispatch,
+            stubs.collectionsGet.returnValues[0]
+          )
+        })
+
+      })
+
+      describe("when not shouldUpdateCollection", () => {
+        beforeEach(async () => {
+          wrapper = renderComponentWithStubs({
+            video,
+            shouldUpdateCollection: false,
+            window:                 stubs.window,
+          })
+          await wrapper.instance().confirmDeletion()
+        })
+
+        generateCommonConfirmDeletionTests()
+
+        it("assigns window.location", () => {
+          const expectedLocation = (
+            `someOrigin/collections/${video.collection_key}/`
+          )
+          assert.equal(stubs.window.location, expectedLocation)
+        })
+
+      })
+    })
+  })
+})

--- a/static/js/containers/CollectionsApp.js
+++ b/static/js/containers/CollectionsApp.js
@@ -4,6 +4,7 @@ import { Route } from "react-router-dom"
 
 import CollectionListPage from "../containers/CollectionListPage"
 import CollectionDetailPage from "../containers/CollectionDetailPage"
+import ToastOverlay from "./ToastOverlay"
 
 import type { Match } from "react-router"
 
@@ -16,6 +17,7 @@ class CollectionsApp extends React.Component<*, void> {
     const { match } = this.props
     return (
       <div className="app">
+        <ToastOverlay />
         <Route exact path={match.url} component={CollectionListPage} />
         <Route
           exact

--- a/static/js/containers/CollectionsApp_test.js
+++ b/static/js/containers/CollectionsApp_test.js
@@ -1,0 +1,21 @@
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import CollectionsApp from "./CollectionsApp"
+
+
+describe("CollectionsApp", () => {
+  const renderComponent = (extraProps = {}) => {
+    const mergedProps = {
+      match: {},
+      ...extraProps,
+    }
+    return shallow(<CollectionsApp {...mergedProps}/>)
+  }
+
+  it("has toast message", () => {
+    const wrapper = renderComponent()
+    assert.isTrue(wrapper.find('Connect(ToastOverlay)').exists())
+  })
+})

--- a/static/js/containers/ToastOverlay.js
+++ b/static/js/containers/ToastOverlay.js
@@ -1,0 +1,93 @@
+// @flow
+import React from "react"
+import _ from "lodash"
+import { connect } from "react-redux"
+import type { Dispatch } from "redux"
+import { CSSTransition, TransitionGroup } from 'react-transition-group'
+
+import { actions } from "../actions"
+import type { ToastMessage as ToastMessageType } from "../flow/toastTypes"
+
+const DELAY_MS = 3000
+
+
+export class ToastOverlay extends React.Component<*, void> {
+  props: {
+    dispatch: Dispatch,
+    messages?: Array<ToastMessageType>,
+    MessageComponent?: any,
+  }
+
+  render() {
+    const { messages } = this.props
+    if (_.isEmpty(messages)) { return null }
+    const MessageComponent = this.props.MessageComponent || ToastMessage
+    return (
+      <div className="toast-overlay">
+        <TransitionGroup
+          className="toast-messages"
+          appear={true}
+        >
+          {messages ?
+            messages.map((message) => {
+              return (
+                <CSSTransition
+                  key={message.key}
+                  timeout={1000}
+                  classNames="toast-transition"
+                  unmountOnExit={true}
+                >
+                  <MessageComponent
+                    key={message.key}
+                    removeMessage={(...args) => {
+                      this.removeMessage(...args)
+                    }}
+                    message={message}/>
+                </CSSTransition>
+              )
+            })
+            : null
+          }
+        </TransitionGroup>
+      </div>
+    )
+  }
+
+  removeMessage (opts:{key: string}) {
+    this.props.dispatch(actions.toast.removeMessage(opts))
+  }
+}
+
+
+export class ToastMessage extends React.Component<*, void> {
+  componentDidMount () {
+    setTimeout(() => {
+      this.props.removeMessage({key: this.props.message.key})
+    }, DELAY_MS)
+  }
+
+  render () {
+    const { message } = this.props
+    return (
+      <span className="toast-message">
+        {message.icon ?
+          (
+            <span className="message-icon">
+              <i className="material-icons">{message.icon}</i>
+            </span>
+          )
+          : null
+        }
+        <span className="message-content">{message.content}</span>
+      </span>
+    )
+  }
+}
+
+export const mapStateToProps = (state:Object) => {
+  return {messages: state.toast.messages}
+}
+
+export const ConnectedToastOverlay = connect(mapStateToProps)(ToastOverlay)
+
+export default ConnectedToastOverlay

--- a/static/js/containers/ToastOverlay_test.js
+++ b/static/js/containers/ToastOverlay_test.js
@@ -1,0 +1,154 @@
+// @flow
+import React from "react"
+import _ from "lodash"
+import { mount } from "enzyme"
+import { assert } from "chai"
+import sinon from "sinon"
+
+import type { ToastMessage as ToastMessageType } from "../flow/toastTypes"
+import { ToastOverlay, ToastMessage, mapStateToProps } from "./ToastOverlay"
+
+
+describe("ToastOverlayTests", () => {
+  let sandbox, wrapper
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const generateMessages = (n?:number = 3): Array<ToastMessageType> => {
+    return [...Array(n).keys()].map((i) => generateMessage(i))
+  }
+
+  const generateMessage = (key:(string|number) = 1, extraProps:Object = {}): ToastMessageType => {
+    return { 
+      key,
+      content: `${key}:content`,
+      ...extraProps
+    }
+  }
+
+  describe("mapStateToProps", () => {
+    it("passes messages", () => {
+      const someState = {
+        toast: {
+          "messages": generateMessages()
+        },
+        someOther: "someOtherStateShard",
+      }
+      const expectedProps = {messages: someState.toast.messages}
+      const actualProps = mapStateToProps(someState)
+      assert.deepEqual(actualProps, expectedProps)
+    })
+  })
+
+  describe("ToastOverlay", () => {
+
+    const renderComponent = (extraProps = {}) => {
+      const mergedProps = {
+        dispatch:         sandbox.stub(),
+        messages:         generateMessages(3),
+        MessageComponent: DummyMessageComponent,
+        ...extraProps
+      }
+      return mount(<ToastOverlay {...mergedProps} />)
+    }
+
+    class DummyMessageComponent extends React.Component<*, void> {
+      render () {
+        return (<div/>)
+      }
+    }
+
+    describe("when there are no messages", () => {
+
+      beforeEach(() => {
+        wrapper = renderComponent({messages: []})
+      })
+
+      it("renders nothing", () => {
+        assert.isTrue(wrapper.isEmptyRender())
+      })
+    })
+
+    describe("when there are messages", () => {
+
+      beforeEach(() => {
+        wrapper = renderComponent({
+          messages:         generateMessages(3),
+          MessageComponent: DummyMessageComponent,
+        })
+      })
+
+      it("renders messages with MessageComponent in transition group", () => {
+        const messages = wrapper.prop("messages")
+        assert.isTrue(messages.length > 0)
+        const keyedMessages = _.keyBy(messages, "key")
+        const transitionGroupEl = wrapper.find("TransitionGroup")
+        const cssTransitionEls = transitionGroupEl.find("CSSTransition")
+        assert.equal(cssTransitionEls.length, messages.length)
+        cssTransitionEls.forEach((cssTransitionEl) => {
+          const messageEl = cssTransitionEl.find(
+            wrapper.prop('MessageComponent'))
+          const expectedMessage = keyedMessages[messageEl.key()]
+          assert.equal(messageEl.prop('message'), expectedMessage)
+        })
+      })
+
+      it("passes removeMessage to MessageComponent", () => {
+        const messages = wrapper.prop("messages")
+        assert.isTrue(messages.length > 0)
+        const messageEls = wrapper.find(wrapper.prop('MessageComponent'))
+        const removeMessageStub = sandbox.stub(
+          wrapper.instance(), 'removeMessage')
+        messageEls.forEach((messageEl, i) => {
+          assert.equal(removeMessageStub.callCount, i)
+          messageEl.prop('removeMessage')()
+          assert.equal(removeMessageStub.callCount, i + 1)
+        })
+      })
+    })
+  })
+
+  describe("ToastMessage", () => {
+    const renderComponent = (extraProps = {}) => {
+      const mergedProps = {
+        message: generateMessage(),
+        ...extraProps
+      }
+      return mount(<ToastMessage {...mergedProps} />)
+    }
+
+    it("renders the message", () => {
+      const message = generateMessage()
+      const wrapper = renderComponent({message})
+      assert.equal(wrapper.find('.message-content').text(), message.content)
+    })
+
+    describe("icon", () => {
+      describe("when icon is present", () => {
+        const icon = 'someIcon'
+        const message = generateMessage(1, {icon})
+
+        it("it renders icon", () => {
+          const wrapper = renderComponent({message})
+          assert.equal(wrapper.find('.message-icon').text(), message.icon)
+        })
+      })
+
+      describe("when icon is absent", () => {
+        const message = _.omit(generateMessage(), ['icon'])
+
+        it("it does not render icon", () => {
+          const wrapper = renderComponent({message})
+          assert.equal(wrapper.find('.message-icon').length, 0)
+        })
+      })
+    })
+  })
+
+})

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -20,6 +20,7 @@ import { withDialogs } from "../components/dialogs/hoc"
 import VideoSubtitleCard from "../components/VideoSubtitleCard"
 import VideoSaverScript from "../components/VideoSaverScript"
 import { ConnectedVideoAnalyticsOverlay } from "./VideoAnalyticsOverlay"
+import ToastOverlay from "./ToastOverlay"
 
 import { actions } from "../actions"
 import { setDrawerOpen } from "../actions/commonUi"
@@ -118,6 +119,7 @@ export class VideoDetailPage extends React.Component<*, void> {
     return (
       <DocumentTitle title={`OVS | ${video.title} | Video Detail`}>
         <div>
+          <ToastOverlay />
           <VideoSaverScript />
           <OVSToolbar setDrawerOpen={this.setDrawerOpen.bind(this, true)} />
           <Drawer

--- a/static/js/containers/VideoDetailPage_test.js
+++ b/static/js/containers/VideoDetailPage_test.js
@@ -249,5 +249,11 @@ describe("VideoDetailPage", () => {
       overlayEl.prop("setVideoTime")("argA", "argB")
       sinon.assert.calledWith(setVideoTimeStub, "argA", "argB")
     })
+
+  })
+
+  it("has toast message", async () => {
+    const wrapper = await renderPage()
+    assert.isTrue(wrapper.find("Connect(ToastOverlay)").exists())
   })
 })

--- a/static/js/flow/toastTypes.js
+++ b/static/js/flow/toastTypes.js
@@ -1,0 +1,12 @@
+// @flow
+//
+export type ToastMessage = {
+  key: string,
+  content: string,
+  icon?: string
+}
+
+export type ToastState = {
+  messages: Array<ToastMessage>
+};
+

--- a/static/js/reducers/index.js
+++ b/static/js/reducers/index.js
@@ -8,12 +8,14 @@ import commonUi from "./commonUi"
 import collectionsPagination from "./collectionsPagination"
 import collectionUi from "./collectionUi"
 import videoUi from "./videoUi"
+import toast from "./toast"
 
 const reducers: Object = {
   collectionsPagination,
   commonUi,
   collectionUi,
-  videoUi
+  videoUi,
+  toast
 }
 endpoints.forEach(endpoint => {
   reducers[endpoint.name] = deriveReducers(endpoint, actions[endpoint.name])

--- a/static/js/reducers/toast.js
+++ b/static/js/reducers/toast.js
@@ -1,0 +1,34 @@
+// @flow
+import _ from "lodash"
+import type { Action } from "../flow/reduxTypes"
+import type { ToastState } from "../flow/toastTypes"
+
+import { constants } from "../actions/toast"
+
+export const INITIAL_TOAST_STATE = {
+  messages: [],
+}
+
+const reducer = (
+  state:ToastState = INITIAL_TOAST_STATE,
+  action: Action<any, null>
+) => {
+  switch (action.type) {
+  case constants.ADD_MESSAGE:
+    return {
+      ...state,
+      messages: [...state.messages, action.payload.message],
+    }
+  case constants.REMOVE_MESSAGE:
+    return {
+      ...state,
+      messages: _.filter(state.messages, (message) => {
+        return (message.key !== action.payload.key)
+      })
+    }
+  default:
+    return state
+  }
+}
+
+export default reducer

--- a/static/js/reducers/toast_test.js
+++ b/static/js/reducers/toast_test.js
@@ -1,0 +1,69 @@
+// @flow
+import { assert } from "chai"
+import sinon from "sinon"
+import configureTestStore from "redux-asserts"
+
+import rootReducer from "../reducers"
+import { actions } from "../actions"
+
+
+describe("toast reducer", () => {
+  let store, sandbox
+
+  beforeEach(() => {
+    store = configureTestStore(rootReducer)
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const getToastState = () => {
+    return store.getState().toast
+  }
+
+  const _dispatchAddMessage = (...args) => {
+    store.dispatch(actions.toast.addMessage(...args))
+  }
+
+  const _dispatchRemoveMessage = (...args) => {
+    store.dispatch(actions.toast.removeMessage(...args))
+  }
+
+  it("has initial state", () => {
+    const expectedInitialState = {
+      messages: [],
+    }
+    assert.deepEqual(getToastState(), expectedInitialState)
+  })
+
+  describe("ADD_MESSAGE", () => {
+
+    it("adds message", async () => {
+      assert.deepEqual(getToastState().messages, [])
+      const message1 = {key: '1', content: 'message1'}
+      _dispatchAddMessage({message: message1})
+      assert.deepEqual(getToastState().messages, [message1])
+      const message2 = {key: '2', content: 'message2'}
+      _dispatchAddMessage({message: message2})
+      assert.deepEqual(getToastState().messages, [message1, message2])
+    })
+  })
+
+  describe("REMOVE_MESSAGE", () => {
+
+    it("removes message", async () => {
+      assert.deepEqual(getToastState().messages, [])
+      const message1 = {key: '1', content: 'message1'}
+      _dispatchAddMessage({message: message1})
+      assert.deepEqual(getToastState().messages, [message1])
+      _dispatchRemoveMessage({key: 'baloney'})
+      assert.deepEqual(getToastState().messages, [message1])
+      _dispatchRemoveMessage({key: message1.key})
+      assert.deepEqual(getToastState().messages, [])
+      _dispatchRemoveMessage({key: 'ham'})
+      assert.deepEqual(getToastState().messages, [])
+    })
+  })
+})

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -31,3 +31,4 @@
 @import 'help-page';
 @import 'terms-page';
 @import 'paginator';
+@import 'toast';

--- a/static/scss/toast.scss
+++ b/static/scss/toast.scss
@@ -1,0 +1,43 @@
+.toast-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  color: white;
+  z-index: 1000;
+  text-align: center;
+  font-size: larger;
+
+  .toast-message {
+
+    display: block;
+    margin: auto;
+    background-color: hsla(0, 0%, 10%, .8);
+    padding: 1em 1.5em;
+    border-radius: 2px;
+    box-shadow: 1px 1px 2px hsla(0, 0%, 100%, .3);
+
+    .icon {
+      margin-right: 1em;
+    }
+  }
+}
+
+
+
+.toast-transition-appear, .toast-transition-enter {
+  opacity: 0.01;
+  transform: translateY(-100%);
+}
+
+.toast-transition-appear-active, .toast-transition-enter-active {
+  opacity: 1;
+  transform: translateY(0%);
+  transition: opacity 1s, transform 1s;
+}
+
+.toast-transition-exit-active {
+  transform: translateY(-100%);
+  opacity: 0.01;
+  transition: opacity 1s, transform 1s;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2463,6 +2463,10 @@ doctrine@^2.0.2:
   dependencies:
     esutils "^2.0.2"
 
+dom-helpers@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
+
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -5704,7 +5708,7 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-prop-types@^15.6.0:
+prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -5940,6 +5944,14 @@ react-test-renderer@^15.6.1:
   dependencies:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
+
+react-transition-group@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.1"
 
 react@^15.6.1:
   version "15.6.1"


### PR DESCRIPTION
#### What are the relevant tickets?
Partially implements #272 .

#### What's this PR do?
1. Adds actions/reducers for toast messages.
2. Adds a `ToastOverlay` component for displaying toast messages.
2. Adds a toast message dispatch to the `DeleteVideoDialog`

#### How should this be manually tested?
1. Ensure that you have a video you are willing to delete.
2. Go to that video's collection page.
3. Click the video's 'dot' menu (the vertical ...), and select 'delete video`.
4. After you confirm the delete, you should a toast message like `Video "muggamugga" was deleted.`

#### Any background context you want to provide?
This PR does *not* include other toast messages per #272.

Adding those toast messages will require making changes to how several dialog tests are implemented. This will take a little more time (though I don't think too much).

@pdpinch, do you think it's worth continuing with the other toast messages?

#### What GIF best describes this PR or how it makes you feel?
![toast](https://m.popkey.co/07ab52/bXEpj.gif)
