### PR TITLE
Adjust YouTube video player height/width

### DIFF
--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -64,6 +64,8 @@ describe("VideoPlayer", () => {
       reset:         sandbox.stub().returns(playerStub),
       src:           sandbox.stub().returns(playerStub),
       fluid:         sandbox.stub().returns(playerStub),
+      width:         sandbox.stub(),
+      height:        sandbox.stub(),
       currentTime:   () => 630.5,
       duration:      () => 2400.0,
       videoWidth:    () => 640,
@@ -202,6 +204,29 @@ describe("VideoPlayer", () => {
       left:      "640px",
       top:       "360px",
       transform: "scale(2)"
+    })
+  })
+  ;[1000, 4000].forEach(function(videoWidth) {
+    it("resizeYoutube modifies the video width and height", () => {
+      const wrapper = renderPlayer().find("VideoPlayer")
+      sandbox.stub(window, "getComputedStyle").returns({ maxHeight: "700px" })
+      containerStub = {
+        style:         {},
+        parentElement: { style: {} },
+        clientWidth:   videoWidth
+      }
+      wrapper.instance().player = playerStub
+      wrapper.instance().videoNode = nodeStub
+      wrapper.instance().videoContainer = containerStub
+      wrapper.instance().resizeYouTube()
+      sinon.assert.calledWith(
+        wrapper.instance().player.width,
+        wrapper.instance().videoContainer.clientWidth
+      )
+      sinon.assert.calledWith(
+        wrapper.instance().player.height,
+        Math.min(videoWidth / wrapper.instance().aspectRatio, 700)
+      )
     })
   })
 
@@ -374,7 +399,7 @@ describe("VideoPlayer", () => {
                 ]
               }
             },
-            systemBandwidth: 2000,
+            systemBandwidth: 2000
           }
         }
         const wrapper = renderPlayer().find("VideoPlayer")
@@ -391,14 +416,14 @@ describe("VideoPlayer", () => {
             playlists:      {
               master: {
                 playlists: [
-                  { attributes: { BANDWIDTH: 900 }, disabled: true},
+                  { attributes: { BANDWIDTH: 900 }, disabled: true },
                   { attributes: { BANDWIDTH: 1900 }, disabled: true },
                   { attributes: { BANDWIDTH: 2900 } },
                   { attributes: { BANDWIDTH: 3900 } }
                 ]
               }
             },
-            systemBandwidth: 2000,
+            systemBandwidth: 2000
           }
         }
         const wrapper = renderPlayer().find("VideoPlayer")
@@ -408,7 +433,6 @@ describe("VideoPlayer", () => {
       })
     })
   })
-
   ;[false, true].forEach(function(isPublic) {
     ["asdJ4y", null].forEach(function(youtubeId) {
       it(`checkYouTube ${expect(
@@ -416,6 +440,7 @@ describe("VideoPlayer", () => {
       )} be called if video.is_public=${String(isPublic)} and video.youtube_id=${String(youtubeId)}`, async () => {
         video.is_public = isPublic
         video.youtube_id = youtubeId
+        video.multiangle = false
         const wrapper = renderPlayer().find("VideoPlayer")
         const checkStub = sandbox.stub(wrapper.instance(), "checkYouTube")
         wrapper.instance().componentDidMount()

--- a/static/scss/videoPlayer.scss
+++ b/static/scss/videoPlayer.scss
@@ -8,6 +8,15 @@
   width: 100%;
   margin: auto;
   overflow: hidden;
+  background-color: #000000;
+
+  &:not(.video-odl-embed) {
+    max-height: calc(100vh - 150px);
+
+    @include breakpoint(mobile) {
+      max-height: calc(100vh - 60px);
+    }
+  }
 }
 
 .video-odl-multiangle {
@@ -43,7 +52,7 @@
           position: relative !important;
           width: inherit !important;
           height: inherit !important;
-          max-height: calc(100vh - 200px);
+          max-height: calc(100vh - 150px);
 
           @include breakpoint(mobile) {
             max-height: calc(100vh - 60px);


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #555

#### What's this PR do?
- Dynamically adjusts the width/height of videos playing from YouTube, via javascript (css didn't seem to cut it).

#### How should this be manually tested?
- Set up one or more videos to play from YouTube:
  - Set `is_public=True` in admin
  - Run the following in a shell:
    ```
    from cloudsync.tasks import upload_youtube_videos
    upload_youtube_videos()
    ```
   - Wait a minute or two for the `YouTubeVideo` status to change to `processed`.
   - Go to the detail page for the video.  It should play from Youtube.  Adjust the height and width of the browser window & be sure to make the window extra wide and short. The video height should adjust accordingly, with the entire video always in view.  The width of the video should be 100%, with black bars on either side if the browser window is wider than the video.
   - Do the same for non-Youtube videos and multi-angle videos.
