### PR TITLE
add error message for collections page

### DIFF
--- a/static/js/components/ErrorMessage.js
+++ b/static/js/components/ErrorMessage.js
@@ -1,0 +1,16 @@
+// @flow
+import React from "react"
+
+
+export default class ErrorMessage extends React.Component<*, void> {
+  render() {
+    const { children, className, ...passThroughProps } = this.props
+    let classNames = ["odl-error-message"]
+    if (className) { classNames = [...classNames, className] }
+    return (
+      <div className={classNames.join(" ")} {...passThroughProps}>
+        {children}
+      </div>
+    )
+  }
+}

--- a/static/js/components/ErrorMessage_test.js
+++ b/static/js/components/ErrorMessage_test.js
@@ -1,0 +1,33 @@
+// @flow
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import ErrorMessage from "./ErrorMessage"
+
+describe("ErrorMessage", () => {
+  const renderComponent = (extraProps = {}) => {
+    return shallow(<ErrorMessage {...extraProps}/>)
+  }
+
+  it("has odl-error-message className", () => {
+    const wrapper = renderComponent({
+      className: "some-class"
+    })
+    assert.equal(
+      wrapper.get(0).props.className,
+      "odl-error-message some-class"
+    )
+  })
+
+  it("renders children", () => {
+    const wrapper = renderComponent({
+      children: [
+        (<div key="a" className="a">a</div>),
+        (<div key="b" className="b">b</div>)
+      ]
+    })
+    assert.isTrue(wrapper.find('.a').exists())
+    assert.isTrue(wrapper.find('.b').exists())
+  })
+})

--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -82,7 +82,7 @@ class Drawer extends React.Component<*, void> {
   }
 
   render() {
-    const { collections } = this.props
+    const collections = this.props.collections || []
     return (
       <aside
         className="mdc-drawer mdc-drawer--temporary mdc-typography"

--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -18,6 +18,7 @@ import type { Collection, CollectionsPagination } from "../flow/collectionTypes"
 import withPagedCollections from "./withPagedCollections"
 import LoadingIndicator from "../components/material/LoadingIndicator"
 import Paginator from "../components/Paginator"
+import ErrorMessage from "../components/ErrorMessage"
 
 export class CollectionListPage extends React.Component<*, void> {
   props: {
@@ -87,7 +88,14 @@ export class CollectionListPage extends React.Component<*, void> {
       return null
     }
     if (currentPageData.status === "ERROR") {
-      return <div className="collection-list-page-error">Error!</div>
+      const supportEmail = SETTINGS.support_email_address || ""
+      return (
+        <ErrorMessage>
+          <p>Sorry, we were unable to load the data necessary to process your request. Please reload the page.</p>
+          <p>If this happens again, please contact&nbsp;
+            <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.</p>
+        </ErrorMessage>
+      )
     } else if (currentPageData.status === "LOADING") {
       return <LoadingIndicator />
     } else if (currentPageData.status === "LOADED") {

--- a/static/js/containers/CollectionListPage_test.js
+++ b/static/js/containers/CollectionListPage_test.js
@@ -128,7 +128,7 @@ describe("CollectionListPage", () => {
     it("renders error indicator", () => {
       collectionsPagination.currentPageData.status = "ERROR"
       const wrapper = renderUnconnectedPage()
-      assert.exists(wrapper.find(".collection-list-page-error"))
+      assert.isTrue(wrapper.find("ErrorMessage").exists())
     })
   })
 })

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -239,3 +239,11 @@ textarea {
     background-color: #f9f9f9;
   }
 }
+
+.odl-error-message {
+  background-color: hsl(0, 80%, 80%);
+  color: hsl(0, 80%, 30%);
+  border: thin solid hsl(0, 80%, 40%);
+  padding: 2em;
+  margin: 1em auto;
+}


### PR DESCRIPTION
#### What are the relevant tickets?
Partially implements #463 .

#### What's this PR do?
1. Creates an `ErrorMessage` component.
2. Displays this component with a message on the `CollectionsListPage` when there is an api failure.

#### How should this be manually tested?
1. Go to the collections page `/collections/`
2. Block the url for the collections api. See [this page](    https://stackoverflow.com/questions/27863094/how-to-block-a-url-in-chromes-developer-tools-network-monitor
) for info on how to block.
3. Reload the page.
4. Ensure that the error message looks reasonable.