### PR TITLE
add additional empty check when rendering analytics chart

### DIFF
--- a/static/js/components/analytics/AnalyticsChart.js
+++ b/static/js/components/analytics/AnalyticsChart.js
@@ -197,6 +197,9 @@ export class AnalyticsChart extends React.Component {
 
   _getRelativeChartBodyBounds() {
     const padding = this.props.padding
+    if (!padding) {
+      return null
+    }
     const { dimensions } = this.state
     if (!dimensions) {
       return null


### PR DESCRIPTION
#### What are the relevant tickets?
None, this is a secondary fix.

#### What's this PR do?
Adds an additional check for empty `padding` props to `AnalyticsChart`.

When this check is not present, there are failures in seemingly unrelated tests due to rendering `AnalyticsChart` without padding. I suspect that this is either related to (1) enzyme mounting/unmounting contamination, or (2) some unexpected branch in which a container page eventually renders an analytics chart during an integration-style test.
