### PR TITLE
add toast messages for collection created/updated

### DIFF
--- a/static/js/components/dialogs/CollectionFormDialog.js
+++ b/static/js/components/dialogs/CollectionFormDialog.js
@@ -102,6 +102,13 @@ class CollectionFormDialog extends React.Component<*, void> {
       try {
         const collection = await dispatch(actions.collectionsList.post(payload))
         history.push(makeCollectionUrl(collection.key))
+        this.addToastMessage({
+          message: {
+            key:     "collection-created",
+            content: "Collection created",
+            icon:    "check",
+          }
+        })
         this.onClose()
       } catch (e) {
         this.handleError(e)
@@ -109,11 +116,22 @@ class CollectionFormDialog extends React.Component<*, void> {
     } else {
       try {
         await dispatch(actions.collections.patch(collectionForm.key, payload))
+        this.addToastMessage({
+          message: {
+            key:     "collection-updated",
+            content: "Changes saved",
+            icon:    "check",
+          }
+        })
         this.onClose()
       } catch (e) {
         this.handleError(e)
       }
     }
+  }
+
+  addToastMessage (...args) {
+    this.props.dispatch(actions.toast.addMessage(...args))
   }
 
   onClose = () => {


### PR DESCRIPTION
#### What are the relevant tickets?
Partially implements #272 .

#### What's this PR do?
1. Adds toast message on collection creation.
2. Adds toast message on collection update.

#### How should this be manually tested?
1. Add a new collection. You should see a toast message after you close the edit dialog.
2. Edit an existing collection. You should see a toast message after you close the edit dialog.