### PR TITLE
add contact us link to footer, fix email address var in error messages

### DIFF
--- a/static/js/components/Footer.js
+++ b/static/js/components/Footer.js
@@ -1,4 +1,5 @@
 // @flow
+/* global SETTINGS: false */
 import React from "react"
 import moment from "moment"
 
@@ -34,6 +35,11 @@ export default class Footer extends React.Component<*, void> {
                   </a>
                   <a href="/terms/" rel="noopener noreferrer">
                     ODL Video Services Terms of Service
+                  </a>
+                  <a
+                    className="contact-us"
+                    href={`mailto:${SETTINGS.support_email_address}`}>
+                    Contact Us
                   </a>
                 </div>
                 <address className="footer-address">

--- a/static/js/components/Footer_test.js
+++ b/static/js/components/Footer_test.js
@@ -1,0 +1,20 @@
+// @flow
+/* global SETTINGS: false */
+import React from "react"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+
+import Footer from "./Footer"
+
+describe("Footer", () => {
+  const renderComponent = (props = {}) => {
+    return shallow(<Footer {...props} />)
+  }
+  it("has 'Contact Us' link", () => {
+    SETTINGS.support_email_address = "some@email.address"
+    const wrapper = renderComponent()
+    const link = wrapper.find("a.contact-us")
+    assert.equal(link.text(), "Contact Us")
+    assert.equal(link.prop("href"), `mailto:${SETTINGS.support_email_address}`)
+  })
+})

--- a/static/js/components/errorMessages.js
+++ b/static/js/components/errorMessages.js
@@ -5,8 +5,7 @@ import ErrorMessage from "./ErrorMessage"
 
 
 export const UnableToLoadData = () => {
-  // $FlowFixMe
-  const supportEmail:string = SETTINGS.supportEmail
+  const supportEmail:string = SETTINGS.support_email_address
   return (
     <ErrorMessage>
       <p>Sorry, we were unable to load the data necessary to process your request. Please reload the page.</p>


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #578.

#### What's this PR do?
1. Adds a 'Contact Us' link to the footer.
2. Fixes a bad key name for support email in `errorMessages`

#### How should this be manually tested?
1. Ensure that there is a 'Contact Us' link in the footer that is a mailto link to the support email.