### PR TITLE
anonymize help page

### DIFF
--- a/ui/views.py
+++ b/ui/views.py
@@ -184,19 +184,18 @@ class TechTVEmbed(VideoEmbed):
         return conditional_response(self, ttv_videos[0].video, *args, **kwargs)
 
 
-@method_decorator(login_required, name='dispatch')
 class HelpPageView(TemplateView):
     """View for the help page"""
     template_name = "ui/help.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        has_admin = Collection.objects.all_admin(self.request.user).exists()
-        is_staff_or_superuser = ui_permissions.is_staff_or_superuser(self.request.user)
-        context["js_settings_json"] = json.dumps({
-            **default_js_settings(self.request),
-            'is_admin': has_admin or is_staff_or_superuser
-        })
+        js_settings = default_js_settings(self.request)
+        if not self.request.user.is_anonymous:
+            has_admin = Collection.objects.all_admin(self.request.user).exists()
+            is_staff_or_superuser = ui_permissions.is_staff_or_superuser(self.request.user)
+            js_settings["editable"] = has_admin or is_staff_or_superuser
+        context["js_settings_json"] = json.dumps(js_settings)
         return context
 
 
@@ -211,7 +210,7 @@ class TermsOfServicePageView(TemplateView):
         is_staff_or_superuser = ui_permissions.is_staff_or_superuser(self.request.user)
         context["js_settings_json"] = json.dumps({
             **default_js_settings(self.request),
-            'is_admin': has_admin or is_staff_or_superuser
+            'editable': has_admin or is_staff_or_superuser
         })
         return context
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #577 .

#### What's this PR do?
Allows anonymous access to help page.

#### How should this be manually tested?
1. As anonymous user: ensure that you can see the`/help` page. Drawer should not have "Create Collection" button.

2. As logged in user: ensure that you can see the `/help` page, and that drawer has "Create Collection" button.

#### Any background context you want to provide?
Note that the TermsOfService page was using a defunct 'is_admin' js_setting. This means that the drawer component probably wasn't rendering correctly on the Terms page. This PR changes 'is_admin' to 'editable'.
