### PR TITLE
hides logout button when there is logged in user

### DIFF
--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -146,15 +146,19 @@ class Drawer extends React.Component<*, void> {
               </i>
               Help
             </a>
-            <a className="mdc-list-item mdc-link" href="/logout/">
-              <i
-                className="material-icons mdc-list-item__graphic"
-                aria-hidden="true"
-              >
-                input
-              </i>
-              Log out
-            </a>
+            {
+              SETTINGS.user ? (
+                <a className="mdc-list-item mdc-link logout" href="/logout/">
+                  <i
+                    className="material-icons mdc-list-item__graphic"
+                    aria-hidden="true"
+                  >
+                    input
+                  </i>
+                  Log out
+                </a>
+              ) : null
+            }
           </nav>
         </nav>
       </aside>

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -74,12 +74,28 @@ describe("Drawer", () => {
     assert.isTrue(drawerNode.text().startsWith("foo_user"))
   })
 
-  it("shows a message if the user is not logged in", async () => {
-    SETTINGS.email = null
-    SETTINGS.user = null
+  it("shows logout button", async () => {
     const wrapper = await renderDrawer()
-    const drawerNode = wrapper.find(".mdc-list-item .mdc-link").at(0)
-    assert.isTrue(drawerNode.text().startsWith("Not logged in"))
+    assert.isTrue(wrapper.find(".mdc-list-item.logout").exists())
+  })
+
+  describe("when user is not logged", () => {
+    let wrapper
+
+    beforeEach(async () => {
+      SETTINGS.email = null
+      SETTINGS.user = null
+      wrapper = await renderDrawer()
+    })
+
+    it("shows a message if the user is not logged in", async () => {
+      const drawerNode = wrapper.find(".mdc-list-item .mdc-link").at(0)
+      assert.isTrue(drawerNode.text().startsWith("Not logged in"))
+    })
+
+    it("does not show log out button", () => {
+      assert.isFalse(wrapper.find(".mdc-list-item.logout").exists())
+    })
   })
 
   it("drawer element is rendered with collections", async () => {


### PR DESCRIPTION
#### What are the relevant tickets?
#584 

#### What's this PR do?
Hides 'logout' button in the drawer if there is no logged in user.

#### How should this be manually tested?
1. Go to the '/help' page as an anonymous user. Ensure that there is no 'logout' item in the drawer.
2. Go to the '/help' page as a logged in user. Ensure that there is a 'logout' item in the drawer.
