### PR TITLE
Add status to SimpleVideoSerializer

### DIFF
--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -187,19 +187,9 @@ class SimpleVideoSerializer(VideoSerializer):
             'view_lists',
             'collection_view_lists',
             'videothumbnail_set',
+            'status'
         )
-        read_only_fields = (
-            'key',
-            'created_at',
-            'title',
-            'description',
-            'videosubtitle_set',
-            'is_public',
-            'is_private',
-            'view_lists',
-            'collection_view_lists',
-            'videothumbnail_set',
-        )
+        read_only_fields = fields
 
 
 class CollectionSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #591 

#### What's this PR do?
Adds missing 'status' to video serializer

#### How should this be manually tested?
Upload a new video to the collection.  The video card for it should look like this:
![screen shot 2018-05-02 at 9 17 59 am](https://user-images.githubusercontent.com/187676/39525358-bef31ddc-4de9-11e8-916f-16265947fab9.png)
