### PR TITLE
Don't change fluid property when switching playback source

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -260,7 +260,6 @@ class VideoPlayer extends React.Component<*, void> {
       this.player
         .reset()
         .src(video.sources)
-        .fluid(false)
     }
   }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #593 

#### What's this PR do?
Removes the VideoJS `player.fluid(false)` call when switching the video source from Youtube to Cloudfront (it should now stay the same regardless of the source).

#### How should this be manually tested?
- Set up a video to play back from YouTube
  - Set `is_public=True`
  - In a shell:
    ```python
    from cloudsync.tasks import upload_youtube_videos
    upload_youtube_videos()
    ```
- Create an html page with that video embedded in an iframe:
    ```html
    <html>
      <body>
        <iframe width="544" height="338" frameborder="0" src="https://localhost:8089/videos/<your_video_key>/embed"></iframe>
      </body>
    </html>
    ```
- Run `python -m http.server` and load the page in a browser at `http://localhost:8000`
- The video should play from Youtube and the dimensions should be correct.
- Block Youtube access with an ad-blocker or modification to your hosts file
- Reload the page, the video should now play from Cloudfront and the dimensions should be correct.
- Go `https://localhost:8089/videos/<your_video_key>` in a browser.  The video should play from  from Cloudfront and the dimensions should be correct.
- Stop blocking Youtube and reload the above page.  The video should play from  from YouTube and the dimensions should be correct.

