### PR TITLE
'Digital Learning' => 'Open Learning' in footer

### DIFF
--- a/static/js/components/Footer.js
+++ b/static/js/components/Footer.js
@@ -27,11 +27,11 @@ export default class Footer extends React.Component<*, void> {
                 </a>
                 <div className="footer-links">
                   <a
-                    href="https://odl.mit.edu/"
+                    href="https://openlearning.mit.edu/"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    Office of Digital Learning
+                    MIT Open Learning
                   </a>
                   <a href="/terms/" rel="noopener noreferrer">
                     ODL Video Services Terms of Service


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #473 .

#### How should this be manually tested?
Confirm that footer contains 'MIT Open Learning' link .