### PR TITLE
add video count to collection items in drawer

### DIFF
--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -121,7 +121,7 @@ class Drawer extends React.Component<*, void> {
                 href={makeCollectionUrl(col.key)}
                 key={col.key}
               >
-                {col.title}
+                {col.title} ({col.video_count})
               </a>
             ))}
             {collections.length > MAX_VISIBLE_COLLECTIONS ? (

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -118,7 +118,10 @@ describe("Drawer", () => {
       assert.equal(items.length, 10)
       ;[0, 1, 3, 9].forEach(function(col) {
         const drawerNode = items.at(col)
-        assert.equal(drawerNode.text(), collections[col].title)
+        assert.equal(
+          drawerNode.text(),
+          `${collections[col].title} (${collections[col].video_count})`
+        )
         assert.equal(
           drawerNode.props().href,
           makeCollectionUrl(collections[col].key)


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #273 .

#### What's this PR do?
Adds video counts to collection items in drawer.

#### How should this be manually tested?
Confirm that collection items in drawer have video counts.