### PR TITLE
add django-hijack for user masquerading

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -71,6 +71,9 @@ INSTALLED_APPS = [
     'rest_framework',
     'server_status',
     'raven.contrib.django.raven_compat',
+    'compat',
+    'hijack',
+    'hijack_admin'
 ]
 
 DISABLE_WEBPACK_LOADER_STATS = get_bool("DISABLE_WEBPACK_LOADER_STATS", False)
@@ -540,3 +543,5 @@ PAGE_SIZE_MAXIMUM = get_int('PAGE_SIZE_MAXIMUM', 1000)
 PAGE_SIZE_COLLECTIONS = get_int('PAGE_SIZE_COLLECTIONS', 50)
 
 MOIRA_CACHE_TIMEOUT = get_int('MOIRA_CACHE_TIMEOUT', 10800)
+HIJACK_ALLOW_GET_REQUESTS = True
+HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'

--- a/odl_video/urls.py
+++ b/odl_video/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     url(r'^status/', include('server_status.urls')),
     url(r'^', include('ui.urls')),
     url(r'^', include('cloudsync.urls')),
+    url(r'^hijack/', include('hijack.urls', namespace='hijack')),
 ]
 
 handler403 = 'ui.views.permission_denied_403_view'

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,9 @@ decorator==4.1.1          # via ipython, traitlets
 defusedxml==0.5.0         # via zeep
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-compat==1.0.15
+django-hijack==2.1.7
+django-hijack-admin==2.1.7
 django-redis==4.7.0
 django-server-status==0.5.0
 django-webpack-loader==0.5.0

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -3,11 +3,13 @@
 <head>
   {% spaceless %}
   {% load static %}
+  {% load hijack_tags %}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
     {% load raven %}
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
     <script type="text/javascript">
       var SETTINGS = {{ js_settings_json|safe }};
     </script>
@@ -25,6 +27,7 @@
     {% endspaceless %}
 </head>
 <body class="{% block bodyclass %}{% endblock %}">
+  {% hijack_notification %}
   {% if messages %}
     <ul class="messages">
       {% for message in messages %}


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #245 .

#### What's this PR do?
Uses http://django-hijack.readthedocs.io to add masquerading functionality for admins.

#### How should this be manually tested?
0. Rebuild your python/web docker images, due to changes in `requirements.txt`.
1. Ensure that you have a superuser and normal user.
2. Login as the superuser. Create a collection.
3. Go to the `User` admin page (http://localhost:8089/admin/auth/user/)
4. You should see a button labeled 'Log in as <username>' next to each username. Click it.
5. You should be redirected to the front page and you should see an info message indicating that you are logged in as the other user.
6. Ensure that you can't see the collection created by the superuser.
7. Ensure that what you see at http://localhost:8089/admin is reasonable.

#### What GIF best describes this PR or how it makes you feel?
![alt](https://upload.wikimedia.org/wikipedia/en/thumb/a/ab/This_Masquerade_-_George_Benson.jpg/220px-This_Masquerade_-_George_Benson.jpg)