### PR TITLE
add status messages to embed page

### DIFF
--- a/static/js/containers/VideoEmbedPage.js
+++ b/static/js/containers/VideoEmbedPage.js
@@ -8,8 +8,9 @@ import { actions } from "../actions"
 import VideoPlayer from "../components/VideoPlayer"
 import type { Video, VideoUiState } from "../flow/videoTypes"
 import { initGA, sendGAPageView } from "../util/google_analytics"
+import { videoIsProcessing, videoHasError } from "../lib/video"
 
-class VideoEmbedPage extends React.Component<*, void> {
+export class VideoEmbedPage extends React.Component<*, void> {
   props: {
     dispatch: Dispatch,
     video: Video,
@@ -26,29 +27,72 @@ class VideoEmbedPage extends React.Component<*, void> {
     dispatch(actions.videoUi.updateVideoJsSync(corner))
   }
 
-  render() {
+  renderBody () {
     const { video, videoUi } = this.props
+    const videoStatus = this.getVideoStatus(video)
+    if (videoStatus === 'PROCESSING') {
+      return this.renderProcessingMessage()
+    }
+    else if (videoStatus === 'ERROR') {
+      return this.renderErrorMessage()
+    }
+    return (
+      <div className="embedded-video">
+        <VideoPlayer
+          video={video}
+          cornerFunc={this.updateCorner}
+          selectedCorner={videoUi.corner}
+          embed={true}
+        />
+      </div>
+    )
+  }
 
+  getVideoStatus (video:Video) {
+    if (videoIsProcessing(video)) {
+      return 'PROCESSING'
+    } else if (videoHasError(video)) {
+      return 'ERROR'
+    }
+    return 'READY'
+  }
+
+  renderProcessingMessage () {
+    return (
+      <div className="processing-message">
+        <h5>Video processing...</h5>
+        <p>Please try again later.</p>
+      </div>
+    )
+  }
+
+  renderErrorMessage () {
+    return (
+      <div className="error-message">
+        <h5>Error</h5>
+        <p>Sorry, this video has an error.</p>
+        <p>Please try again later.</p>
+      </div>
+    )
+  }
+
+  render() {
+    const { video } = this.props
     return (
       <DocumentTitle title={`OVS | ${video.title} | Video Embed`}>
-        <div className="embedded-video">
-          <VideoPlayer
-            video={video}
-            cornerFunc={this.updateCorner}
-            selectedCorner={videoUi.corner}
-            embed={true}
-          />
-        </div>
+        {this.renderBody()}
       </DocumentTitle>
     )
   }
 }
 
-const mapStateToProps = state => {
+export const mapStateToProps = (state:{videoUi:VideoUiState}) => {
   const { videoUi } = state
   return {
     videoUi
   }
 }
 
-export default connect(mapStateToProps)(VideoEmbedPage)
+export const ConnectedVideoEmbedPage = connect(mapStateToProps)(VideoEmbedPage)
+
+export default ConnectedVideoEmbedPage

--- a/static/js/containers/VideoEmbedPage_test.js
+++ b/static/js/containers/VideoEmbedPage_test.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react"
 import sinon from "sinon"
-import { mount } from "enzyme"
+import { mount, shallow} from "enzyme"
 import { assert } from "chai"
 import { Provider } from "react-redux"
 import configureTestStore from "redux-asserts"
@@ -9,6 +9,7 @@ import configureTestStore from "redux-asserts"
 import rootReducer from "../reducers"
 import * as libVideo from "../lib/video"
 import VideoEmbedPage from "./VideoEmbedPage"
+import { VideoEmbedPage as UnconnectedVideoEmbedPage } from "./VideoEmbedPage"
 import { makeVideo } from "../factories/video"
 import type { Video } from "../flow/videoTypes"
 
@@ -34,6 +35,36 @@ describe("VideoEmbedPage", () => {
       </Provider>
     )
   }
+
+  describe("when video is processing", () => {
+    let wrapper
+    beforeEach(() => {
+      sandbox
+        .stub(UnconnectedVideoEmbedPage.prototype, 'getVideoStatus')
+        .returns('PROCESSING')
+      const element = (<UnconnectedVideoEmbedPage video={video} />)
+      wrapper = shallow(element)
+    })
+
+    it("renders processing message", () => {
+      assert.isTrue(wrapper.find('.processing-message').exists())
+    })
+  })
+
+  describe("when video has error", () => {
+    let wrapper
+    beforeEach(() => {
+      sandbox
+        .stub(UnconnectedVideoEmbedPage.prototype, 'getVideoStatus')
+        .returns('ERROR')
+      const element = (<UnconnectedVideoEmbedPage video={video} />)
+      wrapper = shallow(element)
+    })
+
+    it("renders error message", () => {
+      assert.isTrue(wrapper.find('.error-message').exists())
+    })
+  })
 
   it("renders a VideoPlayer component", async () => {
     const wrapper = await renderPage()


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #178 .

#### What's this PR do?
Adds status messages to the embed page.

#### How should this be manually tested?
1. Go to the embed page for a video, ensure that it renders normally.
2. Change the video's status to 'error', ensure that the embed page shows a reasonable message.
3. Change the video's status to 'uploading', ensure that the embed page shows a reasonable message.