### PR TITLE
Dorska/analytics close button

### DIFF
--- a/static/js/containers/VideoAnalyticsOverlay.js
+++ b/static/js/containers/VideoAnalyticsOverlay.js
@@ -8,6 +8,17 @@ import { actions } from "../actions"
 
 
 export class VideoAnalyticsOverlay extends React.Component { 
+  renderCloseButton() {
+    return (
+      <span
+        className="close-button"
+        style={{position: 'absolute', right: 0, top: 0, zIndex: 100}}
+        onClick={this.props.onClose}>
+        <i className="material-icons active" style={{fontSize: '36px'}}>highlight_off</i>
+      </span>
+    )
+  }
+
   render () {
     const { video, videoAnalytics, ...passThroughProps } = this.props
     if (!video || !videoAnalytics) {
@@ -31,11 +42,14 @@ export class VideoAnalyticsOverlay extends React.Component {
     }
     const analyticsData = videoAnalytics.data.get(video.key)
     return (
-      <AnalyticsPane
-        analyticsData={analyticsData}
-        video={video}
-        {...passThroughProps}
-      />
+      <div style={{width: '100%', height: '100%', position: 'relative'}}>
+        {this.props.showCloseButton ? this.renderCloseButton() : null}
+        <AnalyticsPane
+          analyticsData={analyticsData}
+          video={video}
+          {...passThroughProps}
+        />
+      </div>
     )
   }
 }

--- a/static/js/containers/VideoAnalyticsOverlay_test.js
+++ b/static/js/containers/VideoAnalyticsOverlay_test.js
@@ -106,4 +106,40 @@ describe("VideoAnalyticsOverlay", () => {
       }
     )
   })
+
+  describe("close button", () => {
+    describe("when showCloseButton is true", () => {
+      let wrapper, onCloseSpy
+
+      beforeEach(() => {
+        onCloseSpy = sandbox.spy()
+        wrapper = renderComponent({
+          showCloseButton: true,
+          onClose:         onCloseSpy
+        })
+      })
+
+      it("renders button", () => {
+        assert.isTrue(wrapper.find('.close-button').exists())
+      })
+
+      it("triggers props.onClose when button is clicked", () => {
+        sinon.assert.notCalled(onCloseSpy)
+        wrapper.find('.close-button').simulate('click')
+        sinon.assert.called(onCloseSpy)
+      })
+    })
+
+    describe("when showCloseButton is not true", () => {
+      let wrapper
+
+      beforeEach(() => {
+        wrapper = renderComponent({ showCloseButton: false })
+      })
+
+      it("does not render button", () => {
+        assert.isFalse(wrapper.find('.close-button').exists())
+      })
+    })
+  })
 })

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -184,9 +184,7 @@ export class VideoDetailPage extends React.Component<*, void> {
                         </Button>
                         <Button
                           className="analytics mdc-button--raised"
-                          onClick={() => {
-                            this.toggleAnalyticsOverlay()
-                          }}
+                          onClick={() => this.toggleAnalyticsOverlay()}
                         >
                           Show/Hide Analytics
                         </Button>
@@ -220,7 +218,7 @@ export class VideoDetailPage extends React.Component<*, void> {
     )
   }
 
-  toggleAnalyticsOverlay() {
+  toggleAnalyticsOverlay = () => {
     this.props.dispatch(actions.videoUi.toggleAnalyticsOverlay())
   }
 
@@ -290,6 +288,8 @@ export class VideoDetailPage extends React.Component<*, void> {
             this.setVideoTime(...args)
           }}
           style={{ width: "100%", height: "100%" }}
+          showCloseButton={true}
+          onClose={this.toggleAnalyticsOverlay}
         />
       </div>
     )

--- a/static/js/containers/VideoDetailPage_test.js
+++ b/static/js/containers/VideoDetailPage_test.js
@@ -324,6 +324,14 @@ describe("VideoDetailPage", () => {
       sinon.assert.calledWith(setVideoTimeStub, "argA", "argB")
     })
 
+    it("passes closeOverlay", () => {
+      assert.equal(overlayEl.prop("onClose"), pageInstance.toggleAnalyticsOverlay)
+    })
+
+    it("passes showCloseButton", () => {
+      assert.isTrue(overlayEl.prop("showCloseButton"))
+    })
+
   })
 
   it("has toast message", async () => {

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -26,6 +26,7 @@ a, a:link, a:visited, a:active {
 
   &.activated {
     color: $icon-hover;
+
     &:hover {
       font-weight: bold;
     }

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -24,6 +24,13 @@ a, a:link, a:visited, a:active {
 .material-icons {
   color: $icon-color;
 
+  &.activated {
+    color: $icon-hover;
+    &:hover {
+      font-weight: bold;
+    }
+  }
+
   &:hover {
     color: $icon-hover;
     cursor: pointer;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #601 

#### What's this PR do?
Adds a close button to the video analytics overlay.

#### How should this be manually tested?
1. Go to a video detail page.
2. Show the analytics overlay.
3. Ensure that clicking the close button closes the overlay.