### PR TITLE
Dorska/analytics width

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -85,7 +85,8 @@ class VideoPlayer extends React.Component<*, void> {
     selectedCorner: string,
     cornerFunc: (corner: string) => void,
     embed: ?boolean,
-    videoPlayerRef?: (player: any) => void
+    videoPlayerRef?: (player: any) => void,
+    overlayChildren?: any,
   }
 
   player: Object
@@ -419,6 +420,7 @@ class VideoPlayer extends React.Component<*, void> {
             video.multiangle ? "video-odl-multiangle" : ""
           } ${embed ? "video-odl-embed" : ""}`}
           ref={node => (this.videoContainer = node)}
+          style={{position: "relative"}}
         >
           <div data-vjs-player className="vjs-big-play-centered">
             <video
@@ -430,6 +432,7 @@ class VideoPlayer extends React.Component<*, void> {
               controls
             />
           </div>
+          {this.props.overlayChildren}
         </div>
         {video.multiangle && (
           <div ref={node => (this.cameras = node)} className="camera-bar">

--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -465,4 +465,14 @@ describe("VideoPlayer", () => {
       )
     })
   })
+
+  it("renders overlayChildren", () => {
+    const overlayChildKeys = [...Array(3).keys()].map((i) => `child-${i}`)
+    const overlayChildren = overlayChildKeys.map((key) => {
+      return (<div key={key} className="overlay-child"/>)
+    })
+    const wrapper = renderPlayer({overlayChildren})
+    const renderedChildKeys = wrapper.find(".overlay-child").map((el) => el.key())
+    assert.deepEqual(overlayChildKeys.sort(), renderedChildKeys.sort())
+  })
 })

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -44,7 +44,6 @@ export class VideoDetailPage extends React.Component<*, void> {
     videoUi: VideoUiState,
     showDialog: Function,
     editable: boolean,
-    VideoAnalyticsOverlayComponent: Function
   }
 
   videoPlayerRef: Object
@@ -246,30 +245,34 @@ export class VideoDetailPage extends React.Component<*, void> {
         }}
       >
         <VideoPlayer
+          id="video-player"
           videoPlayerRef={ref => {
             this.videoPlayerRef = ref
           }}
           video={video}
           cornerFunc={this.updateCorner}
           selectedCorner={videoUi.corner}
-          analyticsOverlayIsVisible={videoUi.analyticsOverlayIsVisible}
-        />
-        {videoUi.analyticsOverlayIsVisible
-          ? this.renderAnalyticsOverlay()
-          : null}
+          overlayChildren={this.renderOverlayChildren()}
+        >
+        </VideoPlayer>
       </div>
     )
   }
 
+  renderOverlayChildren() {
+    return [this.renderAnalyticsOverlay()]
+  }
+
   renderAnalyticsOverlay() {
     const { video } = this.props
-    const { videoTime, duration } = this.props.videoUi
-    const VideoAnalyticsOverlayComponent =
-      this.props.VideoAnalyticsOverlayComponent ||
-      ConnectedVideoAnalyticsOverlay
+    const { analyticsOverlayIsVisible, videoTime, duration } = this.props.videoUi
+    if (! analyticsOverlayIsVisible) {
+      return null
+    }
     const overlayPadding = "10px"
     return (
       <div
+        key="analytics-overlay"
         className="analytics-overlay-container"
         style={{
           position:        "absolute",
@@ -292,7 +295,8 @@ export class VideoDetailPage extends React.Component<*, void> {
             bottom:   overlayPadding
           }}
         >
-          <VideoAnalyticsOverlayComponent
+          <ConnectedVideoAnalyticsOverlay
+            id="video-analytics-overlay"
             video={video}
             currentTime={videoTime || 0}
             duration={duration || 0}

--- a/static/js/containers/VideoDetailPage_test.js
+++ b/static/js/containers/VideoDetailPage_test.js
@@ -73,6 +73,21 @@ describe("VideoDetailPage", () => {
     return wrapper
   }
 
+  const renderPageShallow = (props = {}) => {
+    const propsWithDefaults = {
+      dispatch:    sandbox.spy(),
+      video,
+      videoKey:    video.key,
+      needsUpdate: false,
+      commonUi:    {},
+      videoUi:     {},
+      showDialog:  sandbox.spy(),
+      editable:    false,
+      ...props
+    }
+    return shallow(<UnwrappedVideoDetailPage {...propsWithDefaults} />)
+  }
+
   it("fetches requirements on load", async () => {
     await renderPage()
     sinon.assert.calledWith(getVideoStub, video.key)
@@ -83,11 +98,34 @@ describe("VideoDetailPage", () => {
     assert.equal(store.getState().videoUi.currentVideoKey, video.key)
   })
 
-  it("renders the video player", async () => {
-    const wrapper = await renderPage()
-    const videoPlayerProps = wrapper.find("VideoPlayer").props()
+  it("renders the video player", () => {
+    const videoUi = { corner: 'someCorner' }
+    const pageWrapper = renderPageShallow({videoUi})
+    const pageInstance = pageWrapper.instance()
+    const overlayChildrenStub = sandbox.stub(
+      pageInstance, "renderOverlayChildren")
+    const videoPlayerWrapper = shallow(pageInstance.renderVideoPlayer(video))
+    const videoPlayerProps = videoPlayerWrapper.find("#video-player").props()
     assert.equal(videoPlayerProps.video, video)
-    assert.equal(videoPlayerProps.selectedCorner, "camera1")
+    assert.equal(videoPlayerProps.selectedCorner, videoUi.corner)
+    assert.equal(
+      videoPlayerProps.overlayChildren,
+      overlayChildrenStub.returnValues[0]
+    )
+  })
+
+  describe("renderOverlayChildren", () => {
+    it("includes renderAnalyticsOverlay result", () => {
+      const pageWrapper = renderPageShallow()
+      const pageInstance = pageWrapper.instance()
+      const renderAnalyticsOverlayStub = sandbox.stub(
+        pageInstance, 'renderAnalyticsOverlay')
+      const actualOverlayChildren = pageInstance.renderOverlayChildren()
+      assert.equal(
+        actualOverlayChildren[0],
+        renderAnalyticsOverlayStub.returnValues[0]
+      )
+    })
   })
 
   it("shows the video title, description and upload date, and link to collection", async () => {
@@ -285,25 +323,17 @@ describe("VideoDetailPage", () => {
 
   describe("renderAnalyticsOverlay", () => {
     let pageInstance, overlayEl
-    const noop = () => null
 
     beforeEach(async () => {
-      const pageEl = React.createElement(UnwrappedVideoDetailPage, {
-        commonUi: {},
-        dispatch: noop,
-        video:    makeVideo(),
-        videoUi:  {
-          videoTime: 42,
-          duration:  42
+      pageInstance = renderPageShallow({
+        videoUi: {
+          analyticsOverlayIsVisible: true,
+          videoTime:                 42,
+          duration:                  42,
         },
-        showDialog:                     noop,
-        VideoAnalyticsOverlayComponent: noop
-      })
-      pageInstance = shallow(pageEl).instance()
-      const overlayWrapper = mount(pageInstance.renderAnalyticsOverlay())
-      overlayEl = overlayWrapper.find(
-        pageInstance.props.VideoAnalyticsOverlayComponent
-      )
+      }).instance()
+      const overlayWrapper = shallow(pageInstance.renderAnalyticsOverlay())
+      overlayEl = overlayWrapper.find("#video-analytics-overlay")
     })
 
     it("renders analytics overlay with expected props", () => {


### PR DESCRIPTION
#### What are the relevant tickets?
#603 

#### What's this PR do?

It makes the video analytics overlay be a child of the video player, so that it won't expand past the video player bounds.

#### How should this be manually tested?
0. First, on the master branch, open a video analytics overlay for a multiangle video to see how the overlay currently exceeds the width of the video.
1. Open a video analytics overlay for multiangle/singlecam/youtube videos.
2. Confirm that the overlay looks reasonable.
3. Confirm that the overlay is contained within the video player.

#### Any background context you want to provide?
I implemented this by passing down a set of elements as `overlayChildren` props to the videoPlayer. I think this is a good pattern for passing elements rendered in one component that you want to be contained by a different component.

I also modified some of the tests to be more unit-test style (shallow rendering) rather than integration-style tests (mount rendering + full redux store/actions).