### PR TITLE
Don't require login for 404 collection URLs

### DIFF
--- a/ui/views.py
+++ b/ui/views.py
@@ -2,7 +2,6 @@
 import json
 
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
@@ -91,15 +90,12 @@ def index(request):  # pylint: disable=unused-argument
 
 
 @method_decorator(xframe_options_exempt, name='dispatch')
-@method_decorator(login_required, name='dispatch')
 class CollectionReactView(TemplateView):
     """List of collections"""
     template_name = "ui/collections.html"
 
-    def get_context_data(self, collection_key=None, **kwargs):  # pylint: disable=arguments-differ
+    def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
         context = super().get_context_data(**kwargs)
-        if collection_key:
-            get_object_or_404(Collection, key=collection_key)
         context["js_settings_json"] = json.dumps({
             **default_js_settings(self.request),
             'editable': ui_permissions.is_staff_or_superuser(self.request.user),
@@ -112,6 +108,11 @@ class CollectionReactView(TemplateView):
         next_redirect = request.GET.get('next')
         if next_redirect:
             return redirect(next_redirect)
+        collection_key = kwargs['collection_key']
+        if collection_key:
+            get_object_or_404(Collection, key=collection_key)
+        if not request.user.is_authenticated:
+            return redirect_to_login(self.request.path)
         return super().get(request, *args, **kwargs)
 
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -405,6 +405,20 @@ def test_collection_viewset_detail_404(logged_in_apiclient, collection_key, logg
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
+def test_collection_detail_anonymous(mocker, logged_in_apiclient, settings):
+    """ Test that anonymous users get redirected to login for a collection detail page """
+    mocker.patch('ui.serializers.get_moira_client')
+    mocker.patch('ui.utils.get_moira_client')
+    client, _ = logged_in_apiclient
+    client.logout()
+    collection = CollectionFactory()
+    url = reverse('collection-react-view', kwargs={'collection_key': collection.hexkey})
+    response = client.get(url, follow=True)
+    final_url, status_code = response.redirect_chain[-1]
+    assert '{}?next=/collections/{}'.format(settings.LOGIN_URL, collection.hexkey) == final_url
+    assert status_code == 302
+
+
 def test_collection_viewset_detail_as_superuser(mocker, logged_in_apiclient):
     """
     Tests to retrieve a collection details for a superuser

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -392,16 +392,15 @@ def test_collection_viewset_detail(mocker, logged_in_apiclient):
     assert result.status_code == status.HTTP_204_NO_CONTENT
 
 
-@pytest.mark.parametrize('collection_key', [
-    'fake',
-    'fa478a0f71204913bed17bcf4065a2ee'
-])
-def test_collection_viewset_detail_404(logged_in_apiclient, collection_key):
+@pytest.mark.parametrize('logged_in', [True, False])
+@pytest.mark.parametrize('collection_key', ['fake', 'fa478a0f71204913bed17bcf4065a2ee'])
+def test_collection_viewset_detail_404(logged_in_apiclient, collection_key, logged_in):
     """
     Tests that a non-existent collection key returns a 404 response even if not logged in.
     """
     client, _ = logged_in_apiclient
-    client.logout()
+    if not logged_in:
+        client.logout()
     response = client.get('/collections/{}'.format(collection_key))
     assert response.status_code == status.HTTP_404_NOT_FOUND
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -392,6 +392,20 @@ def test_collection_viewset_detail(mocker, logged_in_apiclient):
     assert result.status_code == status.HTTP_204_NO_CONTENT
 
 
+@pytest.mark.parametrize('collection_key', [
+    'fake',
+    'fa478a0f71204913bed17bcf4065a2ee'
+])
+def test_collection_viewset_detail_404(logged_in_apiclient, collection_key):
+    """
+    Tests that a non-existent collection key returns a 404 response even if not logged in.
+    """
+    client, _ = logged_in_apiclient
+    client.logout()
+    response = client.get('/collections/{}'.format(collection_key))
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
 def test_collection_viewset_detail_as_superuser(mocker, logged_in_apiclient):
     """
     Tests to retrieve a collection details for a superuser


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #604

#### What's this PR do?
Modifies the `CollectionReactView` so that users will be redirected to the 404 page for non-existent collections without requiring login first.

#### How should this be manually tested?
- Log out of the app if already logged in.
- Go to `/collections/revisiting-case` - you should get a 404 page.
- Go to `/collections/fa478a0f71204913bed17bcf4065a2ee` - you should get a 404 page.
- Go to `/collections` - you should be required to log in.  After you log in you should be redirected back to the collections list page.
- Log out again
- Go to `/collections/<real collection key>` - you should be required to log in.  After you log in you should be redirected back to the collection detail page.

