### PR TITLE
remove collections button from drawer, linkify drawer header

### DIFF
--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -6,7 +6,6 @@ import { connect } from "react-redux"
 import { MDCTemporaryDrawer } from "@material/drawer/dist/mdc.drawer"
 
 import { actions } from "../../actions"
-import * as collectionUiActions from "../../actions/collectionUi"
 import { makeCollectionUrl } from "../../lib/urls"
 import type { Collection } from "../../flow/collectionTypes"
 
@@ -24,11 +23,10 @@ class Drawer extends React.Component<*, void> {
   drawer: null
   drawerRoot: ?HTMLElement
   collapseItemButton: ?HTMLElement
-  createCollectionButton: ?HTMLElement
   props: DrawerProps
 
   componentDidMount() {
-    const { onDrawerClose, dispatch } = this.props
+    const { onDrawerClose } = this.props
     this.drawer = new MDCTemporaryDrawer(this.drawerRoot)
     this.drawer.listen("MDCTemporaryDrawer:close", onDrawerClose)
     this.updateRequirements()
@@ -41,19 +39,6 @@ class Drawer extends React.Component<*, void> {
         (event: MouseEvent) => {
           event.preventDefault()
           onDrawerClose()
-        },
-        false
-      )
-    }
-
-    // this will be undefined if SETTINGS.editable is false
-    if (this.createCollectionButton) {
-      this.createCollectionButton.addEventListener(
-        "click",
-        (event: MouseEvent) => {
-          event.preventDefault()
-          onDrawerClose()
-          dispatch(collectionUiActions.showNewCollectionDialog())
         },
         false
       )
@@ -102,17 +87,9 @@ class Drawer extends React.Component<*, void> {
             </a>
           </nav>
           <header className="mdc-drawer__header">
-            <div className="mdc-drawer__header-content">Collections</div>
-            {SETTINGS.editable ? (
-              <span>
-                <button
-                  className="create-collection-button"
-                  ref={node => (this.createCollectionButton = node)}
-                >
-                  <span className="plus">+</span> Create a Collection
-                </button>
-              </span>
-            ) : null}
+            <div className="mdc-drawer__header-content">
+              <a href="/collections/" style={{color: "inherit"}}>My Collections</a>
+            </div>
           </header>
           <nav id="nav-collections" className="mdc-drawer__content mdc-list">
             {collections.slice(0, MAX_VISIBLE_COLLECTIONS).map(col => (

--- a/static/js/components/material/Drawer_test.js
+++ b/static/js/components/material/Drawer_test.js
@@ -13,9 +13,6 @@ import Drawer from "./Drawer"
 import { makeCollection } from "../../factories/collection"
 import { makeCollectionUrl } from "../../lib/urls"
 import type { Collection } from "../../flow/collectionTypes"
-import { SHOW_DIALOG } from "../../actions/commonUi"
-import { SET_IS_NEW } from "../../actions/collectionUi"
-import { DIALOGS } from "../../constants"
 
 describe("Drawer", () => {
   let sandbox,
@@ -171,29 +168,6 @@ describe("Drawer", () => {
       .find("#collapse_item")
       .instance()
       .click()
-    sinon.assert.calledWith(onDrawerCloseStub)
-  })
-
-  it("hides the create collection button if SETTINGS.editable is false", async () => {
-    SETTINGS.editable = false
-    const wrapper = await renderDrawer()
-    assert.lengthOf(wrapper.find(".create-collection-button"), 0)
-  })
-
-  it("opens the collection dialog when the create collection button is clicked", async () => {
-    SETTINGS.editable = true
-    const onDrawerCloseStub = sandbox.stub()
-    const wrapper = await renderDrawer({
-      onDrawerClose: onDrawerCloseStub
-    })
-    const state = await listenForActions([SHOW_DIALOG, SET_IS_NEW], () => {
-      wrapper
-        .find(".create-collection-button")
-        .instance()
-        .click()
-    })
-    assert.isFalse(state.commonUi.drawerOpen)
-    assert.isTrue(state.commonUi.dialogVisibility[DIALOGS.COLLECTION_FORM])
     sinon.assert.calledWith(onDrawerCloseStub)
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #374 .

#### What's this PR do?
1. Removes "create collection" button from drawer.
2. Makes "Collections" header in drawer a link with text "My Collections"

#### How should this be manually tested?
1. Open the drawer, confirm that there is no "create collection" button .
2. Confirm that there is a 'My Collections' link.