### PR TITLE
change 'Only me' => 'Only owner', to clarify permissions behavior

### DIFF
--- a/static/js/components/dialogs/CollectionFormDialog.js
+++ b/static/js/components/dialogs/CollectionFormDialog.js
@@ -195,7 +195,7 @@ class CollectionFormDialog extends React.Component<*, void> {
             <h4>Who can view videos?</h4>
             <Radio
               id="view-only-me"
-              label="Only me"
+              label="Only owner"
               radioGroupName="view-perms"
               value={PERM_CHOICE_NONE}
               selectedValue={collectionForm.viewChoice}
@@ -227,7 +227,7 @@ class CollectionFormDialog extends React.Component<*, void> {
             <h4>Who can upload/edit videos?</h4>
             <Radio
               id="admin-only-me"
-              label="Only me"
+              label="Only owner"
               radioGroupName="admin-perms"
               value={PERM_CHOICE_NONE}
               selectedValue={collectionForm.adminChoice}

--- a/static/js/components/dialogs/EditVideoFormDialog.js
+++ b/static/js/components/dialogs/EditVideoFormDialog.js
@@ -212,7 +212,7 @@ class EditVideoFormDialog extends React.Component<*, void> {
           {`${
             video && video.collection_view_lists.length > 0
               ? _.map(video.collection_view_lists).join(",")
-              : "Only me"
+              : "Only owner"
           }`}
         </div>
         <Radio

--- a/static/scss/generalStyles.scss
+++ b/static/scss/generalStyles.scss
@@ -179,7 +179,7 @@ textarea {
 
     label {
       align-self: center;
-      width: 88px;
+      width: auto;
       padding: 0;
     }
   }
@@ -210,7 +210,7 @@ textarea {
 
       label {
         align-self: center;
-        width: 88px;
+        width: auto;
         padding: 0;
       }
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #444 .

#### What's this PR do?
1. Relabels 'Only me' => 'Only owner', to reflect actual permissions behavior. 

#### How should this be manually tested?
1. Confirm that labels in Collection edit dialog say 'Only owner'.
2. Confirm that labels in Video edit dialog say 'Only owner'.