### PR TITLE
ignore transcode exceptions for deleted videos

### DIFF
--- a/cloudsync/exceptions.py
+++ b/cloudsync/exceptions.py
@@ -3,4 +3,7 @@
 
 class VideoFilenameError(ValueError):
     """Custom exception to be used when a video filename can't be matched to a regex pattern"""
-    pass
+
+
+class TranscodeTargetDoesNotExist(Exception):
+    """Custom exception to be used when a video does not exist for a transcode task"""

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -19,6 +19,7 @@ from moto import mock_s3
 from requests import HTTPError
 
 from cloudsync.conftest import MockBoto, MockHttpErrorResponse
+from cloudsync.exceptions import TranscodeTargetDoesNotExist
 from cloudsync.tasks import (
     VideoTask,
     stream_to_s3,
@@ -152,6 +153,15 @@ def test_transcode_failure(mocker, videofile):
         transcode_from_s3(video.id)
     assert video.encode_jobs.count() == 1
     assert Video.objects.get(id=video.id).status == VideoStatus.TRANSCODE_FAILED_INTERNAL
+
+
+def test_transcode_target_does_not_exist():
+    """
+    Test transcode task, verify exception is thrown when target does not exist.
+    """
+    nonexistent_video_id = 12345
+    with pytest.raises(TranscodeTargetDoesNotExist):
+        transcode_from_s3(nonexistent_video_id)
 
 
 def test_transcode_starting(mocker, videofile):

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -321,7 +321,10 @@ SENTRY_CLIENT = 'raven.contrib.django.raven_compat.DjangoClient'
 RAVEN_CONFIG = {
     'dsn': get_string('SENTRY_DSN', ''),
     'environment': ENVIRONMENT,
-    'release': VERSION
+    'release': VERSION,
+    'ignore_exceptions': [
+        'cloudsync.exceptions.TranscodeTargetDoesNotExist',
+    ]
 }
 
 # MIT keys


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #433 .

#### What's this PR do?
1. Adds a custom exception to handle non-existent transcode targets.
2. Ignores that exception to avoid unwanted sentry entries.

#### How should this be manually tested?
1. replace `odl_video.settings.RAVEN_CONFIG.dsn` with the real sentry DSN, like this:
  ```
...
RAVEN_CONFIG = {
    #'dsn': get_string('SENTRY_DSN', ''),
    'dsn': 'https://<the_real_dsn...@sentry.io/...>'
  ```

2. modify cloudsync.tasks.transcode_from_s3, like this:
  ```
    ...
    try:
        # NEW LINE: set video_id to a fake id.
        video_id = 999999
        video = Video.objects.get(id=video_id)
  ```
3. restart celery
1. watch celery logs (`docker-compose logs -f celery`)
1. upload a video
1. confirm that a `TranscodeTargetDoesNotExist` exception appears in the celery log.
1. Confirm that no error appears in sentry.
1. Reset code to `master`.
1. Make the same modifications to `odl_video.settings` and `cloudsync.tasks.transcode_s3` as you did above.
1. Restart celery.
1. upload a video
1. confirm that a `DoesNotExist` exception appears in the celery log.
1. confirm that an error appears in Sentry
1. reset code to master (to avoid polluting sentry w/ errors from testing).
