### PR TITLE
add collection_key to SimpleVideoSerializer

### DIFF
--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -187,7 +187,8 @@ class SimpleVideoSerializer(VideoSerializer):
             'view_lists',
             'collection_view_lists',
             'videothumbnail_set',
-            'status'
+            'status',
+            'collection_key',
         )
         read_only_fields = fields
 

--- a/ui/serializers_test.py
+++ b/ui/serializers_test.py
@@ -222,3 +222,26 @@ def test_subtitle_serializer():
         'created_at': DateTimeField().to_representation(subtitle.created_at)
     }
     assert serializers.VideoSubtitleSerializer(subtitle).data == expected
+
+
+def test_simplevideo_serializer():
+    """
+    Test for SimpleVideoSerializer
+    """
+    video = factories.VideoFactory()
+    video_thumbnails = [factories.VideoThumbnailFactory(video=video)]
+    expected = {
+        'key': video.hexkey,
+        'created_at': DateTimeField().to_representation(video.created_at),
+        'title': video.title,
+        'description': video.description,
+        'videosubtitle_set': [],
+        'is_public': video.is_public,
+        'is_private': video.is_private,
+        'view_lists': [],
+        'collection_view_lists': [],
+        'videothumbnail_set': serializers.VideoThumbnailSerializer(video_thumbnails, many=True).data,
+        'status': video.status,
+        'collection_key': video.collection.hexkey
+    }
+    assert serializers.SimpleVideoSerializer(video).data == expected


### PR DESCRIPTION
#### What are the relevant tickets?
None.

#### What's this PR do?
1. Adds `collection_key` to `SimpleVideoSerializer`.

It turns out that the front-end client uses `collection_key` to do redirects after video deletion.

#### How should this be manually tested?
1. On `master`, delete a video. Confirm that you see bad behavior.
2. Checkout this branch, and then delete a video. Confirm that delete behaves as expected.
