### PR TITLE
Bring back the login view and make it the default LOGIN_URL

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -115,9 +115,7 @@ if get_bool('USE_SHIBBOLETH', False):
     AUTHENTICATION_BACKENDS = [
         'shibboleth.backends.ShibbolethRemoteUserBackend',
     ]
-    LOGIN_URL = "/collections/"
-else:
-    LOGIN_URL = "/admin/login/"
+LOGIN_URL = "/login/"
 
 
 ROOT_URLCONF = 'odl_video.urls'

--- a/ui/templates/registration/login.html
+++ b/ui/templates/registration/login.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% load render_bundle %}
+
+{% block title %}Login{% endblock %}
+{% block pagetitle %}Login{% endblock %}
+{% block content %}
+{% if form.errors %}
+<p>Your username and password didn't match. Please try again.</p>
+{% endif %}
+
+{% if next %}
+    {% if user.is_authenticated %}
+    <p>Your account doesn't have access to this page. To proceed,
+    please login with an account that has access.</p>
+    {% else %}
+    <p>Please login to see this page.</p>
+    {% endif %}
+{% endif %}
+
+<form method="post" action="{% url 'login' %}">
+{% csrf_token %}
+<table>
+<tr>
+    <td>{{ form.username.label_tag }}</td>
+    <td>{{ form.username }}</td>
+</tr>
+<tr>
+    <td>{{ form.password.label_tag }}</td>
+    <td>{{ form.password }}</td>
+</tr>
+</table>
+
+<input type="submit" value="Login" />
+<input type="hidden" name="next" value="{{ next }}" />
+</form>
+
+{% endblock %}

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -12,6 +12,7 @@ router.register(r'subtitles', views.VideoSubtitleViewSet, base_name='subtitle')
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
+    url(r'^login/$', views.LoginView.as_view(), name='login'),
     url(r'^logout/$', django_logout_view, {'next_page': settings.LOGIN_URL}),
 
     url(r'^collections/(?P<collection_key>[0-9a-f]{32})?/?$', views.CollectionReactView.as_view(),

--- a/ui/views.py
+++ b/ui/views.py
@@ -4,6 +4,7 @@ import json
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import redirect_to_login
+from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import (
@@ -414,3 +415,13 @@ def error_500_view(request, *args, **kwargs):  # pylint: disable=unused-argument
     Handles a 500 response
     """
     return _handle_error_view(request, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+class LoginView(DjangoLoginView):
+    """Login"""
+    def get_context_data(self, **kwargs):  # pylint: disable=arguments-differ
+        context = super().get_context_data(**kwargs)
+        context["js_settings_json"] = json.dumps({
+            **default_js_settings(self.request),
+        })
+        return context


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #614
- Partially addresses #604

#### What's this PR do?
- Brings back the `/login` URL/view and makes it the default `LOGIN_URL`, regardless of whether Touchstone is enabled or not.

#### How should this be manually tested?
Go to any page requiring authentication.  You should be redirected to `/login`.  After logging in you should be redirected back to the original page.
