### PR TITLE
Fix login redirect

### DIFF
--- a/ui/templates/registration/login.html
+++ b/ui/templates/registration/login.html
@@ -7,16 +7,7 @@
 {% if form.errors %}
 <p>Your username and password didn't match. Please try again.</p>
 {% endif %}
-
-{% if next %}
-    {% if user.is_authenticated %}
-    <p>Your account doesn't have access to this page. To proceed,
-    please login with an account that has access.</p>
-    {% else %}
-    <p>Please login to see this page.</p>
-    {% endif %}
-{% endif %}
-
+    
 <form method="post" action="{% url 'login' %}">
 {% csrf_token %}
 <table>

--- a/ui/views.py
+++ b/ui/views.py
@@ -105,10 +105,6 @@ class CollectionReactView(TemplateView):
         return context
 
     def get(self, request, *args, **kwargs):
-        """ This is the Touchstone `login` page, so redirect if `next` is a URL parameter """
-        next_redirect = request.GET.get('next')
-        if next_redirect:
-            return redirect(next_redirect)
         collection_key = kwargs['collection_key']
         if collection_key:
             get_object_or_404(Collection, key=collection_key)
@@ -426,3 +422,10 @@ class LoginView(DjangoLoginView):
             **default_js_settings(self.request),
         })
         return context
+
+    def get(self, request, *args, **kwargs):
+        """ This is the Touchstone `login` page, so redirect if `next` is a URL parameter """
+        next_redirect = request.GET.get('next')
+        if next_redirect and request.user.is_authenticated:
+            return redirect(next_redirect)
+        return super().get(request, *args, **kwargs)

--- a/ui/views.py
+++ b/ui/views.py
@@ -430,5 +430,5 @@ class LoginView(DjangoLoginView):
             if next_redirect:
                 return redirect(next_redirect)
             else:
-                return redirect('/collections/')
+                return redirect('/')
         return super().get(request, *args, **kwargs)

--- a/ui/views.py
+++ b/ui/views.py
@@ -426,6 +426,9 @@ class LoginView(DjangoLoginView):
     def get(self, request, *args, **kwargs):
         """ This is the Touchstone `login` page, so redirect if `next` is a URL parameter """
         next_redirect = request.GET.get('next')
-        if next_redirect and request.user.is_authenticated:
-            return redirect(next_redirect)
+        if request.user.is_authenticated:
+            if next_redirect:
+                return redirect(next_redirect)
+            else:
+                return redirect('/collections/')
         return super().get(request, *args, **kwargs)

--- a/ui/views.py
+++ b/ui/views.py
@@ -425,8 +425,8 @@ class LoginView(DjangoLoginView):
 
     def get(self, request, *args, **kwargs):
         """ This is the Touchstone `login` page, so redirect if `next` is a URL parameter """
-        next_redirect = request.GET.get('next')
         if request.user.is_authenticated:
+            next_redirect = request.GET.get('next')
             if next_redirect:
                 return redirect(next_redirect)
             else:

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -447,14 +447,14 @@ def test_collection_viewset_detail_as_superuser(mocker, logged_in_apiclient):
     assert result.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_collections_next(mock_moira_client, logged_in_apiclient, user_admin_list_data):
+def test_login_next(mock_moira_client, logged_in_apiclient, user_admin_list_data):
     """
     Tests that the collections page redirects to the URL in the `next` parameter if present
     """
     client, user = logged_in_apiclient
     mock_moira_client.return_value.list_members.return_value = [user.username]
     video_url = reverse('video-detail', kwargs={'video_key': user_admin_list_data.video.hexkey})
-    response = client.get('/collections/?next={}'.format(video_url), follow=True)
+    response = client.get('/login/?next={}'.format(video_url), follow=True)
     final_url, status_code = response.redirect_chain[-1]
     assert video_url == final_url
     assert status_code == 302

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -449,7 +449,7 @@ def test_collection_viewset_detail_as_superuser(mocker, logged_in_apiclient):
 
 def test_login_next(mock_moira_client, logged_in_apiclient, user_admin_list_data):
     """
-    Tests that the collections page redirects to the URL in the `next` parameter if present
+    Tests that the login page redirects to the URL in the `next` parameter if present
     """
     client, user = logged_in_apiclient
     mock_moira_client.return_value.list_members.return_value = [user.username]
@@ -457,6 +457,18 @@ def test_login_next(mock_moira_client, logged_in_apiclient, user_admin_list_data
     response = client.get('/login/?next={}'.format(video_url), follow=True)
     final_url, status_code = response.redirect_chain[-1]
     assert video_url == final_url
+    assert status_code == 302
+
+
+def test_login_nonext(mock_moira_client, logged_in_apiclient, user_admin_list_data):
+    """
+    Tests that the login page redirects to the collections page if authenticated
+    """
+    client, user = logged_in_apiclient
+    mock_moira_client.return_value.list_members.return_value = [user.username]
+    response = client.get('/login', follow=True)
+    final_url, status_code = response.redirect_chain[-1]
+    assert final_url == '/collections/'
     assert status_code == 302
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #614
- Fixes #620

#### What's this PR do?
- Brings back the login view; if an authenticated user goes to the login page (as happens after Touchstone login), redirects user to the url specified by the `next` parameter if present or `/collections` otherwise.

#### How should this be manually tested?
- In an incognito tab, go to `/collections`.  You should be redirected to the login page.  Fill out the form and submit.  You should be redirected to `/collections`.
- While still logged in, go to `/login/?next=/collections/<collection_id>`.  You should be redirected to that collection detail page.
- While still logged in, go to `/login/`.  You should be redirected to the `/collections` page.
