### PR TITLE
Dorska/use moira user list membership

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 
 git+https://github.com/mitodl/django-elastic-transcoder.git#egg=django-elastic-transcoder
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
-git+https://github.com/mitodl/mit-moira.git#egg=mit-moira
+git+https://github.com/mitodl/mit-moira.git@bcf99688af5710e4dfb8bcd95a02fec7e2b43a7c#egg=mit-moira
 git+https://github.com/mitodl/pycaption.git#egg=pycaption
 amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via fs, zeep

--- a/ui/conftest.py
+++ b/ui/conftest.py
@@ -27,6 +27,14 @@ def mock_moira_client(mocker):
 
 
 @pytest.fixture
+def mock_user_moira_lists(mocker):
+    """Return a fake moira client"""
+    mocked = mocker.patch('ui.utils.user_moira_lists')
+    mocked.return_value = set()
+    return mocked
+
+
+@pytest.fixture
 def ga_client_mocks(mocker):
     """Return mocker with patches for objects used for google api clients"""
     mocks = {

--- a/ui/models.py
+++ b/ui/models.py
@@ -54,7 +54,7 @@ class CollectionManager(TimestampedModelManager):
         """
         if user.is_superuser:
             return self.all()
-        moira_list_qset = MoiraList.objects.filter(name__in=utils.user_moira_lists(user).member_of)
+        moira_list_qset = MoiraList.objects.filter(name__in=utils.user_moira_lists(user))
         return self.filter(
             models.Q(view_lists__in=moira_list_qset) |
             models.Q(admin_lists__in=moira_list_qset) |
@@ -74,7 +74,7 @@ class CollectionManager(TimestampedModelManager):
         if user.is_superuser:
             return self.all()
         return self.filter(
-            models.Q(admin_lists__in=MoiraList.objects.filter(name__in=utils.user_moira_lists(user).member_of)) |
+            models.Q(admin_lists__in=MoiraList.objects.filter(name__in=utils.user_moira_lists(user))) |
             models.Q(owner=user)).distinct()
 
 

--- a/ui/utils_test.py
+++ b/ui/utils_test.py
@@ -9,7 +9,9 @@ from ui import factories
 from ui.exceptions import MoiraException, GoogleAnalyticsException
 from ui.utils import (
     write_to_file,
+    MOIRA_CACHE_KEY,
     get_moira_client,
+    query_moira_lists,
     user_moira_lists,
     has_common_lists,
     get_video_analytics,
@@ -17,7 +19,7 @@ from ui.utils import (
     generate_google_analytics_query,
     parse_google_analytics_response,
     generate_mock_video_analytics_data,
-    UserMoiraMembership)
+)
 
 # pylint: disable=unused-argument, too-many-arguments
 
@@ -60,81 +62,79 @@ def test_write_to_file():
             assert infile.read() == content
 
 
-def test_user_moira_lists(mock_moira_client):
+def test_query_moira_lists(mock_moira_client):
     """
-    Test that the correct list is returned by user_moira_lists
+    Test that expected lists are returned.
     """
     list_names = ['test_moira_list01', 'test_moira_list02']
-    mock_moira_client.return_value.user_lists.return_value = list_names
+    mock_moira_client.return_value.user_list_membership.return_value = [
+        {'listName': list_name} for list_name in list_names
+    ]
     other_user = factories.UserFactory(email='someone@mit.edu')
-    assert user_moira_lists(other_user).member_of == set(list_names)
+    assert query_moira_lists(other_user) == list_names
 
 
-def test_user_no_moira_lists(mock_moira_client):
+def test_query_moira_lists_no_lists(mock_moira_client):
     """
-    Test that an empty list is returned by user_moira_lists if Moira throws a java NPE
+    Test that an empty list is returned if Moira throws a java NPE
     """
-    mock_moira_client.return_value.user_lists.side_effect = Fault('java.lang.NullPointerException')
+    mock_moira_client.return_value.user_list_membership.side_effect = Fault('java.lang.NullPointerException')
     other_user = factories.UserFactory(email='someone@mit.edu')
-    assert user_moira_lists(other_user).member_of == set()
+    assert query_moira_lists(other_user) == []
 
 
-def test_user_moira_lists_error(mock_moira_client):
+def test_query_moira_lists_error(mock_moira_client):
     """
     Test that a Moira exception is raised if moira client call fails with anything other than a java NPE
     """
-    mock_moira_client.return_value.user_lists.side_effect = Fault("Not a java NPE")
-    other_user = factories.UserFactory()
+    mock_moira_client.return_value.user_list_membership.side_effect = Fault("Not a java NPE")
     with pytest.raises(MoiraException):
-        user_moira_lists(other_user)
+        query_moira_lists(factories.UserFactory())
 
 
-@pytest.mark.parametrize(['member', 'members', 'is_member'], [
-    ['person1@mit.edu', ['person2', 'person3'], False],
-    ['person1@mit.edu', ['person2', 'person1'], True],
-    ['person1@gmail.com', ['person1@gmail.com', 'person3'], True],
-    ['person1@gmail.com', ['person1', 'person3'], False],
-    ['person1@mit.edu', [], False]
-])
-def test_has_common_lists(mocker, mock_moira_client, member, members, is_member):
+def test_user_moira_lists_cache_hit(mocker):
+    """
+    Test that returns from cache if cache has lists.
+    """
+    mock_cache = mocker.patch('ui.utils.cache')
+    mock_query_moira_lists = mocker.patch('ui.utils.query_moira_lists')
+    cached_list_names = set(['some_list'])
+    mock_cache.get.return_value = cached_list_names
+    result = user_moira_lists(factories.UserFactory())
+    assert result == cached_list_names
+    assert not mock_query_moira_lists.called
+
+
+def test_user_moira_lists_cache_miss(mocker, settings):
+    """
+    Test that queries and caches lists if not already in cache.
+    """
+    mock_cache = mocker.patch('ui.utils.cache')
+    mock_query_moira_lists = mocker.patch('ui.utils.query_moira_lists')
+    mock_cache.get.return_value = None
+    user = factories.UserFactory()
+    assert not mock_query_moira_lists.called
+    assert not mock_cache.set.called
+    result = user_moira_lists(user)
+    expected_result = set(mock_query_moira_lists.return_value)
+    assert result == expected_result
+    assert mock_query_moira_lists.called_once_with(user)
+    assert mock_cache.set.called_once_with(
+        MOIRA_CACHE_KEY.format(user_id=user.id),
+        expected_result,
+        settings.MOIRA_CACHE_TIMEOUT
+    )
+
+
+def test_has_common_lists(mocker):
     """
     Test that has_common_lists returns the correct boolean value
     """
-    mocker.patch('ui.utils.cache')
-    mock_moira_client.return_value.list_members.return_value = members
-    user = factories.UserFactory(username=member, email=member)
-    assert has_common_lists(user, ['mock_list1', 'mock_list2']) is is_member
-
-
-def test_has_common_lists_error(mock_moira_client):
-    """
-    Test that a Moira exception is raised if moira client list_members call fails
-    """
-    mock_moira_client.return_value.list_members.side_effect = OSError
-    with pytest.raises(MoiraException) as exc:
-        has_common_lists(factories.UserFactory(), ['mock_list1', 'mock_list2'])
-    assert exc.match('Something went wrong with getting moira-list members')
-
-
-@pytest.mark.parametrize(['member_of', 'not_member_of', 'lists', 'calls', 'accessible'], [
-    [{'list1', 'list2'}, {}, ['list1', 'list2'], 0, True],
-    [{}, {'list1', 'list2'}, ['list1', 'list2'], 0, False],
-    [{'list1', 'list2'}, {}, ['list3', 'list2'], 0, True],
-    [{'list1', 'list2'}, {}, ['list3', 'list4'], 2, False],
-    [{'list1', 'list2'}, {'list3'}, ['list3', 'list4'], 1, False],
-    [{'list1', 'list2'}, {}, ['list5', 'list6', 'list7'], 3, False],
-])
-def test_cached_moiralists(mocker, mock_moira_client, member_of, not_member_of, lists, calls, accessible):
-    """
-    Test that the expected number of moira service calls are made depending on what's available from cache
-    """
-    user_moira_membership = UserMoiraMembership(member_of=member_of, not_member_of=not_member_of)
-    mock_cache = mocker.patch('ui.utils.cache')
-    mock_cache.get.return_value = user_moira_membership
-    mock_moira_client.return_value.list_members.return_value = []
-    has_permission = has_common_lists(factories.UserFactory(), lists)
-    assert has_permission is accessible
-    assert mock_moira_client.return_value.list_members.call_count == calls
+    mock_user_moira_lists = mocker.patch('ui.utils.user_moira_lists')
+    mock_user_moira_lists.return_value = set(['a', 'b'])
+    user = factories.UserFactory()
+    assert has_common_lists(user, ['b', 'c']) is True
+    assert has_common_lists(user, ['c']) is False
 
 
 def test_get_video_analytics(mocker):


### PR DESCRIPTION
#### What are the relevant tickets?
Preparation for #622, in order to partially implement #503.

#### What's this PR do?
1. Uses `mit_moira`'s recently added `get_list_membership` method to get all of user's fully-resolved moira lists, including nested lists.

#### How should this be manually tested?

1. Rebuild your `python` and `web` docker images to reflect changes in `requirements.txt`.
1. Follow the instructions for the two PRs below:
   1. https://github.com/mitodl/odl-video-service/pull/435
   1. https://github.com/mitodl/odl-video-service/pull/587

#### Any background context you want to provide?

##### Re: General Idea
Before this PR, nested lists were accounted for by checking whether a *user* was a member of an *object's lists*, via a for-loop. This was necessary because we did not have a complete and fully-resolved listing of all of a user's lists.

We now have a complete and resolved listing of all of a user's lists, so we can now do the simpler operation of just checking whether a user's full list set contains a given object's list. This also avoids the for-loop strategy, and thus greatly reduces the number of moira queries as well.

##### Re: Coupled Tests :(
An unfortunate artifact in our tests was deep coupling to moira client logic. This PR reduces this coupling (a little) by mocking the higher-level `user_moira_lists` instead of `moira_client`.


