### PR TITLE
restore videofile_set to serializer

### DIFF
--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -181,6 +181,7 @@ class SimpleVideoSerializer(VideoSerializer):
             'created_at',
             'title',
             'description',
+            'videofile_set',
             'videosubtitle_set',
             'is_public',
             'is_private',

--- a/ui/serializers_test.py
+++ b/ui/serializers_test.py
@@ -229,12 +229,14 @@ def test_simplevideo_serializer():
     Test for SimpleVideoSerializer
     """
     video = factories.VideoFactory()
+    video_files = [factories.VideoFileFactory(video=video)]
     video_thumbnails = [factories.VideoThumbnailFactory(video=video)]
     expected = {
         'key': video.hexkey,
         'created_at': DateTimeField().to_representation(video.created_at),
         'title': video.title,
         'description': video.description,
+        'videofile_set': serializers.VideoFileSerializer(video_files, many=True).data,
         'videosubtitle_set': [],
         'is_public': video.is_public,
         'is_private': video.is_private,


### PR DESCRIPTION
#### What are the relevant tickets?
ad-hoc fix. It turns out that the 'save to dropbox' feature in the front-end needs `videofile_set`.

#### What's this PR do?
Adds `videofile_set` to `SimpleVideoSerializer`. 

#### How should this be manually tested?
1. In master branch, select `save to dropbox` from the video menu. You should get a console error.
2. Switch to this branch and select `save to dropbox`. The save dialog should pop up.

#### Any background context you want to provide?
My bad, I missed this when I reviewed the serializer PR earlier.