### PR TITLE
refactoring CollectionDetail, in preparation for videos pagination

### DIFF
--- a/static/js/components/VideoCard.js
+++ b/static/js/components/VideoCard.js
@@ -14,11 +14,11 @@ type VideoCardProps = {
   video: Video,
   isAdmin: boolean,
   isMenuOpen: boolean,
-  showDeleteDialog: Function,
-  showEditDialog: Function,
-  showShareDialog: Function,
+  showDeleteVideoDialog: Function,
+  showEditVideoDialog: Function,
+  showShareVideoDialog: Function,
   showVideoMenu: Function,
-  closeVideoMenu: Function
+  hideVideoMenu: Function
 }
 
 const VideoCard = (props: VideoCardProps) => {
@@ -54,17 +54,19 @@ const VideoCard = (props: VideoCardProps) => {
     )
   }
 
-  let menuItems = [{ label: "Share", action: props.showShareDialog.bind(this) }]
+  let menuItems = [
+    { label: "Share", action: props.showShareVideoDialog.bind(this) }
+  ]
 
   if (props.isAdmin) {
     menuItems = _.concat(
       menuItems,
-      { label: "Edit", action: props.showEditDialog.bind(this) },
+      { label: "Edit", action: props.showEditVideoDialog.bind(this) },
       {
         label:  "Save To Dropbox",
         action: saveToDropbox.bind(this, props.video)
       },
-      { label: "Delete", action: props.showDeleteDialog.bind(this) }
+      { label: "Delete", action: props.showDeleteVideoDialog.bind(this) }
     )
   }
 
@@ -82,7 +84,7 @@ const VideoCard = (props: VideoCardProps) => {
         <Menu
           key={props.video.key}
           showMenu={props.showVideoMenu}
-          closeMenu={props.closeVideoMenu}
+          closeMenu={props.hideVideoMenu}
           open={props.isMenuOpen}
           menuItems={menuItems}
         />

--- a/static/js/components/VideoCard_test.js
+++ b/static/js/components/VideoCard_test.js
@@ -13,22 +13,22 @@ import { makeVideo } from "../factories/video"
 describe("VideoCard", () => {
   let sandbox,
     video,
-    showEditDialogStub,
-    showShareDialogStub,
-    showDeleteDialogStub,
+    showEditVideoDialogStub,
+    showShareVideoDialogStub,
+    showDeleteVideoDialogStub,
     showVideoMenuStub,
-    closeVideoMenuStub,
+    hideVideoMenuStub,
     dropboxSaveMenuStub,
     videoIsProcessingStub,
     videoHasErrorStub
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create()
-    showEditDialogStub = sandbox.stub()
-    showShareDialogStub = sandbox.stub()
-    showDeleteDialogStub = sandbox.stub()
+    showEditVideoDialogStub = sandbox.stub()
+    showShareVideoDialogStub = sandbox.stub()
+    showDeleteVideoDialogStub = sandbox.stub()
     showVideoMenuStub = sandbox.stub()
-    closeVideoMenuStub = sandbox.stub()
+    hideVideoMenuStub = sandbox.stub()
     video = makeVideo()
     videoIsProcessingStub = sandbox
       .stub(libVideo, "videoIsProcessing")
@@ -47,11 +47,11 @@ describe("VideoCard", () => {
         video={video}
         isAdmin={true}
         isMenuOpen={false}
-        showEditDialog={showEditDialogStub}
-        showShareDialog={showShareDialogStub}
-        showDeleteDialog={showDeleteDialogStub}
+        showEditVideoDialog={showEditVideoDialogStub}
+        showShareVideoDialog={showShareVideoDialogStub}
+        showDeleteVideoDialog={showDeleteVideoDialogStub}
         showVideoMenu={showVideoMenuStub}
-        closeVideoMenu={closeVideoMenuStub}
+        hideVideoMenu={hideVideoMenuStub}
         {...props}
       />
     )
@@ -82,13 +82,13 @@ describe("VideoCard", () => {
     const wrapper = renderComponent({ isAdmin: true })
     const menuItems = wrapper.find("Menu").props().menuItems
     menuItems[0].action()
-    sinon.assert.called(showShareDialogStub)
+    sinon.assert.called(showShareVideoDialogStub)
     menuItems[1].action()
-    sinon.assert.called(showEditDialogStub)
+    sinon.assert.called(showEditVideoDialogStub)
     menuItems[2].action()
     sinon.assert.called(dropboxSaveMenuStub)
     menuItems[3].action()
-    sinon.assert.called(showDeleteDialogStub)
+    sinon.assert.called(showDeleteVideoDialogStub)
   })
 
   it("Menu has correct show and hide functions", () => {
@@ -97,7 +97,7 @@ describe("VideoCard", () => {
     menu.props().showMenu()
     sinon.assert.calledOnce(showVideoMenuStub)
     menu.props().closeMenu()
-    sinon.assert.calledOnce(closeVideoMenuStub)
+    sinon.assert.calledOnce(hideVideoMenuStub)
   })
 
   it(`should have a title that links to the video detail page`, () => {

--- a/static/js/components/VideoList.js
+++ b/static/js/components/VideoList.js
@@ -1,0 +1,51 @@
+// @flow
+import React from "react"
+
+import VideoCard from "./VideoCard"
+
+
+export class VideoList extends React.Component<*, void> {
+  props: {
+    className?: string,
+    style?: {[string]: any},
+    videos: ?Array<Video>,
+    isAdmin: boolean,
+    showDeleteVideoDialog: Function,
+    showEditVideoDialog: Function,
+    showShareVideoDialog: Function,
+    showVideoMenu: Function,
+    hideVideoMenu: Function,
+    isVideoMenuOpen: Function,
+  }
+
+  render () {
+    const className = `video-list ${this.props.className || ''}`
+    return (
+      <div className={className} style={this.props.style}>
+        {
+          this.props.videos ?
+            this.props.videos.map((video) => this.renderVideoCard(video))
+            : null
+        }
+      </div>
+    )
+  }
+
+  renderVideoCard (video:Video) {
+    return (
+      <VideoCard
+        key={video.key}
+        video={video}
+        isAdmin={this.props.isAdmin}
+        showDeleteVideoDialog={() => this.props.showDeleteVideoDialog(video.key)}
+        showEditVideoDialog={() => this.props.showEditVideoDialog(video.key)}
+        showShareVideoDialog={() => this.props.showShareVideoDialog(video.key)}
+        showVideoMenu={() => this.props.showVideoMenu(video.key)}
+        hideVideoMenu={() => this.props.hideVideoMenu(video.key)}
+        isMenuOpen={this.props.isVideoMenuOpen(video.key)}
+      />
+    )
+  }
+}
+
+export default VideoList

--- a/static/js/components/VideoList_test.js
+++ b/static/js/components/VideoList_test.js
@@ -1,0 +1,101 @@
+// @flow
+import React from "react"
+import _ from "lodash"
+import sinon from "sinon"
+import { shallow } from "enzyme"
+import { assert } from "chai"
+import { makeVideo } from "../factories/video"
+
+import VideoList from "./VideoList"
+
+describe("VideoList", () => {
+  let sandbox, props
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+    props = {
+      videos:                [...Array(3).keys()].map(() => makeVideo()),
+      isAdmin:               true,
+      showDeleteVideoDialog: sandbox.stub(),
+      showEditVideoDialog:   sandbox.stub(),
+      showShareVideoDialog:  sandbox.stub(),
+      showVideoMenu:         sandbox.stub(),
+      hideVideoMenu:         sandbox.stub(),
+      isVideoMenuOpen:       sandbox.stub(),
+    }
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  const renderComponent = (overrides = {}) => {
+    return shallow(<VideoList {...props} {...overrides} />)
+  }
+
+  describe("render", () => {
+    it("renders a VideoCard for each video", () => {
+      sandbox.stub(VideoList.prototype, 'renderVideoCard').callsFake((video) => {
+        return (<div className="mocked-renderVideoCard" key={video.key}></div>)
+      })
+      const wrapper = renderComponent()
+      const videos = wrapper.instance().props.videos
+      const videoCards = wrapper.find('.mocked-renderVideoCard')
+      assert.equal(videoCards.length, videos.length)
+      assert.deepEqual(
+        videoCards.map((videoCard) => videoCard.key()),
+        videos.map((video) => video.key)
+      )
+    })
+  })
+
+  describe("renderVideoCard", () => {
+    let video, videoList, videoCard
+
+    beforeEach(() => {
+      video = makeVideo()
+      videoList = new VideoList(props)
+      videoCard = videoList.renderVideoCard(video)
+    })
+
+    it("sets key", () => {
+      assert.equal(videoCard.key, video.key)
+    })
+
+    it("sets basic props", () => {
+      const expectedBasicProps = {
+        video,
+        isAdmin: videoList.props.isAdmin,
+      }
+      assert.deepEqual(
+        _.pick(videoCard.props, Object.keys(expectedBasicProps)),
+        expectedBasicProps
+      )
+    })
+
+    it("sets isMenuOpen", () => {
+      sinon.assert.calledWith(videoList.props.isVideoMenuOpen, video.key)
+      assert.equal(
+        videoCard.props.isMenuOpen,
+        videoList.props.isVideoMenuOpen.returnValues[0]
+      )
+    })
+
+    describe("function props", () => {
+      const propNames = [
+        "showDeleteVideoDialog",
+        "showEditVideoDialog",
+        "showShareVideoDialog",
+        "showVideoMenu",
+        "hideVideoMenu",
+      ]
+      _.forEach(propNames, (propName) => {
+        it(`sets ${propName}`, () => {
+          sinon.assert.notCalled(videoList.props[propName])
+          videoCard.props[propName]()
+          sinon.assert.calledWith(videoList.props[propName], video.key)
+        })
+      })
+    })
+  })
+})

--- a/static/js/containers/CollectionDetailPage_test.js
+++ b/static/js/containers/CollectionDetailPage_test.js
@@ -1,295 +1,610 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
+import _ from "lodash"
 import sinon from "sinon"
-import { mount, shallow } from "enzyme"
+import { shallow } from "enzyme"
 import { assert } from "chai"
-import { Provider } from "react-redux"
-import configureTestStore from "redux-asserts"
 
-import ConnectedCollectionDetailPage from "./CollectionDetailPage"
-import {
-  CollectionDetailPage as UnconnectedCollectionDetailPage
-} from "./CollectionDetailPage"
-
-import * as api from "../lib/api"
+import { mapStateToProps, CollectionDetailPage } from "./CollectionDetailPage"
 import { actions } from "../actions"
-import {
-  INIT_COLLECTION_FORM,
-  SET_IS_NEW,
-  SET_SELECTED_VIDEO_KEY
-} from "../actions/collectionUi"
-import { HIDE_MENU, SHOW_DIALOG, SHOW_MENU } from "../actions/commonUi"
-import rootReducer from "../reducers"
+import * as collectionUiActions from "../actions/collectionUi"
+import * as commonUiActions from "../actions/commonUi"
 import { makeCollection } from "../factories/collection"
-import { makeVideos } from "../factories/video"
-import { expect } from "../util/test_utils"
 import { DIALOGS } from "../constants"
-import { makeInitializedForm } from "../lib/collection"
-import * as videoUiActions from "../actions/videoUi"
-import { PERM_CHOICE_COLLECTION } from "../lib/dialog"
-
-const { INIT_EDIT_VIDEO_FORM } = videoUiActions.constants
 
 describe("CollectionDetailPage", () => {
-  let sandbox, store, getCollectionStub, collection, listenForActions
-  let actionsToAwait
-
-  const selectors = {
-    TITLE:         ".collection-detail-content h1",
-    DESCRIPTION:   "p.description",
-    MENU_BTN:      ".menu-button",
-    SETTINGS_BTN:  "#edit-collection-button",
-    DROPBOX_BTN:   ".dropbox-btn",
-    NO_VIDEOS_MSG: ".no-videos"
-  }
+  let sandbox
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create()
-    store = configureTestStore(rootReducer)
-    listenForActions = store.createListenForActions()
-    collection = makeCollection()
-    const collections = [makeCollection(), collection]
-
-    getCollectionStub = sandbox
-      .stub(api, "getCollection")
-      .returns(Promise.resolve(collection))
-    sandbox
-      .stub(api, "getCollections")
-      .returns(Promise.resolve({ results: collections }))
-
-    actionsToAwait = [
-      actions.collections.get.requestType,
-      actions.collections.get.successType
-    ]
   })
 
   afterEach(() => {
     sandbox.restore()
   })
 
-  const renderPage = async (props = {}) => {
-    let wrapper
-    // Simulate the react-router match object
-    const matchObj = { params: { collectionKey: collection.key } }
-    await listenForActions(
-      actionsToAwait,
-      () => {
-        wrapper = mount(
-          <Provider store={store}>
-            <ConnectedCollectionDetailPage match={matchObj} {...props} />
-          </Provider>
-        )
-      }
-    )
-    if (!wrapper) throw new Error("Never will happen, make flow happy")
-    wrapper.update()
-    return wrapper
+  const stubRenderingMethod = methodName => {
+    sandbox
+      .stub(CollectionDetailPage.prototype, methodName)
+      .returns(<i id={`mocked-${methodName}`} key={`mocked-${methodName}`} />)
   }
 
-  it("fetches requirements on load", async () => {
-    await renderPage()
-    sinon.assert.calledWith(getCollectionStub, collection.key)
-  })
+  const stubRenderingMethods = methodNames => {
+    methodNames.forEach(methodName => stubRenderingMethod(methodName))
+  }
 
-  it("renders each video in the collection", async () => {
-    const addedVideos = makeVideos(3, collection.key)
-    const expectedVideoCount = collection.videos.length + addedVideos.length
-    collection.videos = collection.videos.concat(addedVideos)
+  describe("mapStateToProps", () => {
+    let state, ownProps
 
-    const wrapper = await renderPage()
-    assert.lengthOf(wrapper.find("VideoCard"), expectedVideoCount)
-  })
-
-  it("shows a message when no videos have been added to the collection yet", async () => {
-    collection.videos = []
-    const wrapper = await renderPage()
-    const messageContainer = wrapper.find(selectors.NO_VIDEOS_MSG)
-    assert.isTrue(messageContainer.exists())
-    assert.include(messageContainer.text(), "You have not added any videos yet")
-  })
-
-  describe("when there is an error", () => {
-    const error = {
-      detail:          "Verboten Badness",
-      errorStatusCode: 403
-    }
-
-    it("shows an error message", async () => {
-      const wrapper = shallow(
-        <UnconnectedCollectionDetailPage
-          collectionError={error}
-        />
-      )
-      const errorMessageEl = wrapper.find("ErrorMessage")
-      assert.deepEqual(
-        errorMessageEl.get(0).props.children,
-        ["Error: ", error.detail]
-      )
-    })
-  })
-
-  ;[
-    ["Collection description", true, "non-empty description"],
-    [null, false, "empty description"]
-  ].forEach(([collectionDescription, shouldShow, testDescriptor]) => {
-    it(`description ${expect(
-      shouldShow
-    )} be shown with ${testDescriptor}`, async () => {
-      collection.description = collectionDescription
-      const wrapper = await renderPage()
-      const descriptionEl = wrapper.find(selectors.DESCRIPTION)
-      assert.equal(descriptionEl.exists(), shouldShow)
-      if (shouldShow) {
-        assert.equal(descriptionEl.text(), collectionDescription)
+    beforeEach(() => {
+      state = {
+        collections: {},
+        commonUi:    {}
+      }
+      ownProps = {
+        match: {
+          params: { collectionKey: "some_collectionKey" }
+        }
       }
     })
-  })
-  ;[[2, true, "one or more videos"], [0, false, "no videos"]].forEach(
-    ([videoCount, shouldShow, testDescriptor]) => {
-      it(`video count ${expect(
-        shouldShow
-      )} be shown with ${testDescriptor}`, async () => {
-        collection.videos = makeVideos(videoCount, collection.key)
-        const wrapper = await renderPage()
-        const titleText = wrapper.find(selectors.TITLE).text()
-        assert.equal(titleText.indexOf(`(${videoCount})`) >= 0, shouldShow)
+
+    it("selects collectionKey", () => {
+      const actualProps = mapStateToProps(state, ownProps)
+      const expectedCollectionKey = ownProps.match.params.collectionKey
+      assert.equal(actualProps.collectionKey, expectedCollectionKey)
+    })
+
+    describe("when selecting collection", () => {
+      const testDefs = [
+        { opts: { loaded: true, data: undefined }, expected: null },
+        { opts: { loaded: true, data: "somedata" }, expected: "somedata" },
+        { opts: { loaded: false, data: undefined }, expected: null },
+        { opts: { loaded: false, data: "somedata" }, expected: null }
+      ]
+      testDefs.forEach(testDef => {
+        const { opts, expected } = testDef
+        // $FlowFixMe: we can coerce to string.
+        it(`it selects collection as ${expected} when opts are ${JSON.stringify(
+          opts
+        )} `, () => {
+          state = {
+            ...state,
+            collections: Object.assign({}, state.collections, {
+              loaded: testDef.opts.loaded,
+              data:   testDef.opts.data
+            })
+          }
+          const actualProps = mapStateToProps(state, ownProps)
+          assert.equal(actualProps.collection, testDef.expected)
+        })
       })
-    }
-  )
-
-  it("has a toolbar whose handler will dispatch an action to open the drawer", async () => {
-    const wrapper = await renderPage()
-    wrapper.find(selectors.MENU_BTN).simulate("click")
-    assert.isTrue(store.getState().commonUi.drawerOpen)
-  })
-  ;[
-    [false, false, "user without admin permissions"],
-    [true, true, "user with admin permissions"]
-  ].forEach(([adminPermissionSetting, shouldShow, testDescriptor]) => {
-    it(`${expect(
-      shouldShow
-    )} render VideoCard with admin flag for ${testDescriptor}`, async () => {
-      collection.is_admin = adminPermissionSetting
-      const wrapper = await renderPage()
-      assert.equal(
-        wrapper
-          .find("VideoCard")
-          .first()
-          .prop("isAdmin"),
-        shouldShow
-      )
     })
-  })
-  ;[
-    [false, false, "user without admin permissions"],
-    [true, true, "user with admin permissions"]
-  ].forEach(([adminPermissionSetting, shouldShow, testDescriptor]) => {
-    it(`${expect(
-      shouldShow
-    )} show dropbox upload & settings buttons for ${testDescriptor}`, async () => {
-      collection.is_admin = adminPermissionSetting
-      const wrapper = await renderPage()
-      assert.equal(wrapper.find(selectors.DROPBOX_BTN).exists(), shouldShow)
-      assert.equal(wrapper.find(selectors.SETTINGS_BTN).exists(), shouldShow)
-    })
-  })
 
-  it("uploads a video and reloads the collection page", async () => {
-    const uploadVideoStub = sandbox
-      .stub(api, "uploadVideo")
-      .returns(Promise.resolve({}))
-    const mockFiles = [{ name: "file1" }, { name: "file2" }]
-    collection.is_admin = true
-    const wrapper = await renderPage()
-
-    await listenForActions(
-      [
-        actions.uploadVideo.post.requestType,
-        actions.uploadVideo.post.successType,
-        actions.collections.get.requestType
-      ],
-      () => {
-        wrapper.find("DropboxChooser").prop("success")(mockFiles)
-      }
-    )
-
-    sinon.assert.calledWith(uploadVideoStub, collection.key, mockFiles)
-  })
-
-  it("shows the edit video dialog", async () => {
-    const wrapper = await renderPage()
-    const state = await listenForActions(
-      [SET_SELECTED_VIDEO_KEY, SHOW_DIALOG, INIT_EDIT_VIDEO_FORM],
-      () => {
-        wrapper
-          .find("VideoCard")
-          .first()
-          .prop("showEditDialog")()
-      }
-    )
-
-    const video = collection.videos[0]
-    assert.equal(state.collectionUi.selectedVideoKey, video.key)
-    assert.isTrue(state.commonUi.dialogVisibility[DIALOGS.EDIT_VIDEO])
-    assert.deepEqual(state.videoUi.editVideoForm, {
-      description:    video.description,
-      key:            video.key,
-      title:          video.title,
-      overrideChoice: PERM_CHOICE_COLLECTION,
-      viewChoice:     PERM_CHOICE_COLLECTION,
-      viewLists:      ""
-    })
-  })
-
-  it("shows the share video dialog", async () => {
-    const wrapper = await renderPage()
-    const state = await listenForActions(
-      [SET_SELECTED_VIDEO_KEY, SHOW_DIALOG],
-      () => {
-        wrapper
-          .find("VideoCard")
-          .first()
-          .prop("showShareDialog")()
-      }
-    )
-    assert.equal(state.collectionUi.selectedVideoKey, collection.videos[0].key)
-    assert.isTrue(state.commonUi.dialogVisibility[DIALOGS.SHARE_VIDEO])
-  })
-
-  it("clicks the edit collection button", async () => {
-    const wrapper = await renderPage()
-    const eventStub = {
-      preventDefault: sandbox.stub()
-    }
-    const state = await listenForActions(
-      [INIT_COLLECTION_FORM, SET_IS_NEW, SHOW_DIALOG],
-      () => {
-        wrapper.find("#edit-collection-button").prop("onClick")(eventStub)
-      }
-    )
-    sinon.assert.calledWith(eventStub.preventDefault)
-    assert.isFalse(state.collectionUi.isNew)
-    assert.deepEqual(
-      state.collectionUi.editCollectionForm,
-      makeInitializedForm(collection)
-    )
-    assert.isTrue(state.commonUi.dialogVisibility[DIALOGS.COLLECTION_FORM])
-  })
-  ;[
-    ["showVideoMenu", true, [SET_SELECTED_VIDEO_KEY, SHOW_MENU]],
-    ["closeVideoMenu", false, [SET_SELECTED_VIDEO_KEY, HIDE_MENU]]
-  ].forEach(([action, expectedVisibility, expectedActions]) => {
-    it(`${action} sets menu visibility to ${expectedVisibility.toString()}`, async () => {
-      const wrapper = await renderPage()
-      const state = await listenForActions(expectedActions, () => {
-        wrapper
-          .find("VideoCard")
-          .first()
-          .prop(action)()
+    describe("when selecting collectionError", () => {
+      it("selects collections.error if present", () => {
+        state = {
+          ...state,
+          collections: Object.assign({}, state.collections, {
+            error: "someError"
+          })
+        }
+        const actualProps = mapStateToProps(state, ownProps)
+        assert.equal(actualProps.collectionError, state.collections.error)
       })
-      const video = collection.videos[0]
-      assert.equal(state.commonUi.menuVisibility[video.key], expectedVisibility)
+
+      it("selects null if collection.error empty", () => {
+        state = {
+          ...state,
+          collections: Object.assign({}, state.collections, {
+            error: undefined
+          })
+        }
+        const actualProps = mapStateToProps(state, ownProps)
+        assert.equal(actualProps.collectionError, null)
+      })
+    })
+
+    describe("when selecting needsUpdate", () => {
+      const collection = { key: "someKey" }
+      const testDefs = [
+        {
+          opts:     { processing: true, loaded: true, matchKey: true },
+          expected: false
+        },
+        {
+          opts:     { processing: true, loaded: true, matchKey: false },
+          expected: true
+        },
+        {
+          opts:     { processing: true, loaded: false, matchKey: true },
+          expected: false
+        },
+        {
+          opts:     { processing: true, loaded: false, matchKey: false },
+          expected: false
+        },
+        {
+          opts:     { processing: false, loaded: true, matchKey: true },
+          expected: false
+        },
+        {
+          opts:     { processing: false, loaded: true, matchKey: false },
+          expected: true
+        },
+        {
+          opts:     { processing: false, loaded: false, matchKey: true },
+          expected: true
+        },
+        {
+          opts:     { processing: false, loaded: false, matchKey: false },
+          expected: true
+        }
+      ]
+      testDefs.forEach(testDef => {
+        const { opts, expected } = testDef
+        // $FlowFixMe: we can coerce to string.
+        it(`it selects needsUpdate as ${expected} when opts are ${JSON.stringify(
+          opts
+        )} `, () => {
+          ownProps = {
+            ...ownProps,
+            match: {
+              params: {
+                collectionKey: opts.matchKey ? collection.key : "otherKey"
+              }
+            }
+          }
+          state = {
+            ...state,
+            collections: Object.assign({}, state.collections, {
+              processing: opts.processing,
+              loaded:     opts.loaded,
+              data:       collection
+            })
+          }
+          const actualProps = mapStateToProps(state, ownProps)
+          assert.equal(actualProps.needsUpdate, expected)
+        })
+      })
+    })
+
+    it("passes through commonUi", () => {
+      state = {
+        ...state,
+        commonUi: { some: "value" }
+      }
+      const actualProps = mapStateToProps(state, ownProps)
+      assert.equal(actualProps.commonUi, state.commonUi)
+    })
+  })
+
+  describe("Component", () => {
+    let collection, props, wrapper, page
+
+    beforeEach(() => {
+      collection = makeCollection()
+      props = {
+        dispatch:        sandbox.stub(),
+        collection,
+        collectionError: undefined,
+        collectionKey:   collection.key,
+        editable:        true,
+        needsUpdate:     false,
+        commonUi:        {},
+        showDialog:      sandbox.stub()
+      }
+    })
+
+    describe("render", () => {
+      const render = (extraProps = {}) => {
+        return shallow(
+          <CollectionDetailPage {...{ ...props, ...extraProps }} />
+        )
+      }
+
+      beforeEach(() => {
+        stubRenderingMethods(["renderError", "renderBody"])
+      })
+
+      it("renders drawer", () => {
+        wrapper = render()
+        assert.isTrue(wrapper.find("Connect(WithDrawer)").exists())
+      })
+
+      describe("when there is an error", () => {
+        beforeEach(() => {
+          wrapper = render({ collectionError: "someError" })
+        })
+
+        it("renders error", () => {
+          sinon.assert.calledWith(
+            wrapper.instance().renderError,
+            wrapper.instance().props.collectionError
+          )
+          sinon.assert.notCalled(wrapper.instance().renderBody)
+        })
+      })
+
+      describe("when there is no error", () => {
+        beforeEach(() => {
+          wrapper = render({ collectionError: undefined })
+        })
+
+        it("renders body", () => {
+          sinon.assert.called(wrapper.instance().renderBody)
+          sinon.assert.notCalled(wrapper.instance().renderError)
+        })
+      })
+    })
+
+    describe("renderBody", () => {
+      beforeEach(() => {
+        stubRenderingMethods([
+          "renderTools",
+          "renderDescription",
+          "renderVideos"
+        ])
+      })
+
+      const renderBody = ({ extraProps = {} } = {}) => {
+        page = new CollectionDetailPage({ ...props, ...extraProps })
+        return shallow(page.renderBody())
+      }
+
+      it("renders tools", () => {
+        assert.isTrue(
+          renderBody()
+            .find("#mocked-renderTools")
+            .exists()
+        )
+      })
+
+      it("renders description", () => {
+        assert.isTrue(
+          renderBody()
+            .find("#mocked-renderDescription")
+            .exists()
+        )
+      })
+
+      it("renders videos", () => {
+        assert.isTrue(
+          renderBody()
+            .find("#mocked-renderVideos")
+            .exists()
+        )
+      })
+    })
+
+    describe("renderTools", () => {
+      beforeEach(() => {
+        stubRenderingMethods(["renderAdminTools"])
+      })
+
+      // $FlowFixMe: defaults are ok.
+      const renderTools = ({ extraProps = {}, isAdmin = false } = {}) => {
+        page = new CollectionDetailPage({ ...props, ...extraProps })
+        return shallow(page.renderTools(isAdmin))
+      }
+
+      it("has tools class", () => {
+        assert.isTrue(
+          renderTools()
+            .at(0)
+            .hasClass("tools")
+        )
+      })
+
+      it("renders admin tools if isAdmin", () => {
+        assert.isTrue(
+          renderTools({ isAdmin: true })
+            .find("#mocked-renderAdminTools")
+            .exists()
+        )
+      })
+
+      it("does not render admin tools if not isAdmin", () => {
+        assert.isFalse(
+          renderTools({ isAdmin: false })
+            .find("#mocked-renderAdminTools")
+            .exists()
+        )
+      })
+    })
+
+    describe("renderAdminTools", () => {
+      beforeEach(() => {
+        stubRenderingMethods(["renderSettingsFrob", "renderUploadFrob"])
+      })
+
+      const renderAdminTools = ({ extraProps = {} } = {}) => {
+        page = new CollectionDetailPage({ ...props, ...extraProps })
+        return shallow(<div>{page.renderAdminTools()}</div>)
+      }
+
+      it("renders settings frob", () => {
+        assert.isTrue(
+          renderAdminTools()
+            .find("#mocked-renderSettingsFrob")
+            .exists()
+        )
+      })
+
+      it("renders upload frob", () => {
+        assert.isTrue(
+          renderAdminTools()
+            .find("#mocked-renderUploadFrob")
+            .exists()
+        )
+      })
+    })
+
+    describe("renderSettingsFrob", () => {
+      const renderSettingsFrob = ({ extraProps = {} } = {}) => {
+        page = new CollectionDetailPage({ ...props, ...extraProps })
+        return shallow(page.renderSettingsFrob())
+      }
+
+      it("has settings icon", () => {
+        assert.equal(
+          renderSettingsFrob()
+            .find(".material-icons")
+            .text(),
+          "settings"
+        )
+      })
+
+      it("triggers showEditCollectionDialog when clicked", () => {
+        sandbox.stub(CollectionDetailPage.prototype, "showEditCollectionDialog")
+        sinon.assert.notCalled(
+          CollectionDetailPage.prototype.showEditCollectionDialog
+        )
+        renderSettingsFrob()
+          .at(0)
+          .simulate("click")
+        sinon.assert.called(
+          CollectionDetailPage.prototype.showEditCollectionDialog
+        )
+      })
+    })
+
+    describe("renderUploadFrob", () => {
+      const renderUploadFrob = ({ extraProps = {} } = {}) => {
+        page = new CollectionDetailPage({ ...props, ...extraProps })
+        return shallow(<div>{page.renderUploadFrob()}</div>)
+      }
+
+      it("renders DropBoxChooser with expected simple props", () => {
+        SETTINGS.dropbox_key = "someAppKey"
+        const chooser = renderUploadFrob().find("DropboxChooser")
+        const expectedSimpleProps = {
+          appKey:      SETTINGS.dropbox_key,
+          linkType:    "direct",
+          multiselect: true,
+          extensions:  ["video"]
+        }
+        assert.deepEqual(
+          _.pick(chooser.props(), Object.keys(expectedSimpleProps)),
+          expectedSimpleProps
+        )
+      })
+
+      it("passes upload handler to DropBoxChooser", () => {
+        sandbox.stub(CollectionDetailPage.prototype, "handleUpload")
+        const chooser = renderUploadFrob().find("DropboxChooser")
+        sinon.assert.notCalled(CollectionDetailPage.prototype.handleUpload)
+        chooser.prop("success")()
+        sinon.assert.called(CollectionDetailPage.prototype.handleUpload)
+      })
+    })
+
+    describe("handleUpload", () => {
+      let chosenFiles
+
+      beforeEach(() => {
+        sandbox.stub().returns(Promise.resolve())
+        sandbox.stub(actions.uploadVideo, "post")
+        sandbox.stub(actions.collections, "get")
+        chosenFiles = [...Array(3).keys()].map(i => ({ id: i }))
+        page = new CollectionDetailPage(props)
+      })
+
+      it("dispatches upload action", async () => {
+        sinon.assert.notCalled(actions.uploadVideo.post)
+        await page.handleUpload(chosenFiles)
+        // $FlowFixMe: collection won't be null.
+        const expectedArgs = [page.props.collection.key, chosenFiles]
+        sinon.assert.calledWith(actions.uploadVideo.post, ...expectedArgs)
+      })
+
+      it("dispatches collections.get action to refresh collection", async () => {
+        sinon.assert.notCalled(actions.uploadVideo.post)
+        await page.handleUpload(chosenFiles)
+        // $FlowFixMe: won't be null
+        const expectedArgs = [page.props.collection.key]
+        sinon.assert.calledWith(actions.collections.get, ...expectedArgs)
+      })
+    })
+
+    describe("renderDescription", () => {
+      // $FlowFixMe: defaults are ok.
+      const renderDescription = ({extraProps = {}, description = ""} = {}) => {
+        page = new CollectionDetailPage({ ...props, ...extraProps })
+        return shallow(<div>{page.renderDescription(description)}</div>)
+      }
+
+      it("renders description text when description is not empty", () => {
+        const description = "someDescription"
+        const rendered = renderDescription({ description }).childAt(0)
+        assert.equal(rendered.text(), description)
+        assert.isTrue(rendered.hasClass("description"))
+      })
+
+      it("is null when description is empty", () => {
+        const emptyDescriptions = ["", null, undefined]
+        for (const description of emptyDescriptions) {
+          assert.isFalse(
+            renderDescription({ description })
+              .find(".description")
+              .exists()
+          )
+        }
+      })
+    })
+
+    describe("renderVideos", () => {
+      // $FlowFixMe: defaults are ok.
+      const renderVideos = ({extraProps = {}, videos = [], isAdmin = true} = {}) => {
+        page = new CollectionDetailPage({ ...props, ...extraProps })
+        // $FlowFixMe: isAdmin is ok.
+        return shallow(<div>{page.renderVideos(videos, isAdmin)}</div>)
+      }
+
+      it("renders 'no videos' message", () => {
+        assert.isTrue(
+          renderVideos({ videos: [] })
+            .find(".no-videos")
+            .exists()
+        )
+      })
+
+      describe("when there are videos", () => {
+        const videos = makeCollection().videos
+        const isAdmin = "someIsAdminValue"
+
+        it("renders VideoList with expected basic props", () => {
+          const videoList = renderVideos({ videos, isAdmin }).find("VideoList")
+          const expectedBasicProps = {
+            className: "videos",
+            videos,
+            commonUi:  page.props.commonUi,
+            isAdmin
+          }
+          assert.deepEqual(
+            _.pick(videoList.props(), Object.keys(expectedBasicProps)),
+            expectedBasicProps
+          )
+        })
+
+        describe("VideoList function props", () => {
+          const methodNames = [
+            "showDeleteVideoDialog",
+            "showEditVideoDialog",
+            "showShareVideoDialog",
+            "showVideoMenu",
+            "hideVideoMenu",
+            "isVideoMenuOpen"
+          ]
+          _.forEach(methodNames, methodName => {
+            it(`it passes bound ${methodName} to VideoList`, () => {
+              sandbox.stub(CollectionDetailPage.prototype, methodName)
+              const videoList = renderVideos({ videos, isAdmin }).find(
+                "VideoList"
+              )
+              // $FlowFixMe: ignore index access
+              sinon.assert.notCalled(CollectionDetailPage.prototype[methodName])
+              videoList.prop(methodName)()
+              // $FlowFixMe: ignore index access
+              sinon.assert.called(CollectionDetailPage.prototype[methodName])
+            })
+          })
+        })
+      })
+    })
+
+    describe("showVideoDialog methods", () => {
+      describe("showVideoDialog", () => {
+        const dialogName = "someDialogName"
+        const videoKey = "someVideoKey"
+
+        // Ideally we would stub collectionUiActions.setSelectedVideoKey
+        // to decouple this test from the internal logic of collectionUiActions,
+        // but because of the way that actions/collectionUiActions.js defines
+        // exports (as of 2018-05-10) that's not possible.
+        // So we just leave it unstubbed, since it makes no api calls and has
+        // no side-effects.
+        // dorska, 2018-05-10.
+
+        // $FlowFixMe: defaults are ok.
+        const showVideoDialog = ({extraProps = {}, dialogName = "", videoKey = ""} = {}) => {
+          // $FlowFixMe: Constructor call is intentional.
+          page = new CollectionDetailPage({ ...props, ...extraProps })
+          page.showVideoDialog(dialogName, videoKey)
+        }
+
+        it("dispatches setSelectedVideoKey action", () => {
+          showVideoDialog({ dialogName, videoKey })
+          const expectedArgs = [
+            collectionUiActions.setSelectedVideoKey(videoKey)
+          ]
+          sinon.assert.calledWith(page.props.dispatch, ...expectedArgs)
+        })
+
+        it("calls props.showDialog", () => {
+          showVideoDialog({ dialogName, videoKey })
+          sinon.assert.called(page.props.showDialog)
+        })
+      })
+
+      describe("proxying dialog methods", () => {
+        beforeEach(() => {
+          sandbox.stub(CollectionDetailPage.prototype, "showVideoDialog")
+        })
+
+        const methodNamesToDialogNames = {
+          showEditVideoDialog:   DIALOGS.EDIT_VIDEO,
+          showShareVideoDialog:  DIALOGS.SHARE_VIDEO,
+          showDeleteVideoDialog: DIALOGS.DELETE_VIDEO
+        }
+        _.forEach(methodNamesToDialogNames, (dialogName, methodName) => {
+          it("proxies to showVideoDialog", () => {
+            const videoKey = "someVideoKey"
+            // $FlowFixMe: Constructor call is intentional.
+            const page = new CollectionDetailPage(props)
+            sinon.assert.notCalled(page.showVideoDialog)
+            page[methodName](videoKey)
+            sinon.assert.calledWith(page.showVideoDialog, dialogName, videoKey)
+          })
+        })
+      })
+    })
+
+    describe("videoMenu methods", () => {
+      // Ditto comment above re: stubbing actions here.
+      const showHideItems = ["show", "hide"]
+      _.forEach(showHideItems, showHide => {
+        const methodName = `${showHide}VideoMenu`
+        it(methodName, () => {
+          const videoKey = "someVideoKey"
+          // $FlowFixMe: Constructor call is intentional.
+          const page = new CollectionDetailPage(props)
+          sinon.assert.notCalled(page.props.dispatch)
+          page[methodName](videoKey)
+          sinon.assert.calledWith(
+            page.props.dispatch,
+            collectionUiActions.setSelectedVideoKey(videoKey)
+          )
+          sinon.assert.calledWith(
+            page.props.dispatch,
+            commonUiActions[`${showHide}Menu`](videoKey)
+          )
+        })
+      })
+
+      it("isVideoMenuOpen selects from commonUi", () => {
+        const videoKey = "someVideoKey"
+        const expectedVisibilityValue = "someVisibilityValue"
+        const page = new CollectionDetailPage({
+          ...props,
+          commonUi: Object.assign({}, props.commonUi, {
+            menuVisibility: {
+              [videoKey]: expectedVisibilityValue
+            }
+          })
+        })
+        assert.equal(page.isVideoMenuOpen(videoKey), expectedVisibilityValue)
+      })
     })
   })
 })


### PR DESCRIPTION
#### What are the relevant tickets?
Preparation for front-end part of #503 .

#### What's this PR do?
Refactors `CollectionDetailPage`:

1. Breaks out videos list into its own component (this is where pagination will happen)
2. Refactors `CollectionDetailPage_test.js` into unit tests using shallow
3. Harmonizes property names between video components.

#### How should this be manually tested?
Click around the collection detail page, ensure that everything looks as it did before.