### PR TITLE
Fix permissions issue with anonymous users and public videos

### DIFF
--- a/ui/models.py
+++ b/ui/models.py
@@ -139,6 +139,8 @@ class VideoManager(TimestampedModelManager):
         """
         if user.is_superuser:
             return self.all()
+        if user.is_anonymous:
+            return self.filter(is_public=True)
         moira_list_qset = MoiraList.objects.filter(
             name__in=utils.user_moira_lists(user))
         return self.filter(

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -88,6 +88,8 @@ def query_moira_lists(user):
     Returns:
         list_names(list): A list of names of moira lists which contain the user as a member.
     """
+    if user.is_anonymous:
+        return []
     moira_user = get_moira_user(user)
     moira = get_moira_client()
     try:
@@ -113,6 +115,8 @@ def user_moira_lists(user):
         list_names(set): An set containing all known lists the user belongs to,
             including ancestors of nested lists.
     """
+    if user.is_anonymous:
+        return []
     list_names = cache.get(MOIRA_CACHE_KEY.format(user_id=user.id), None)
     if list_names is None:
         list_names = set(query_moira_lists(user))

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -88,8 +88,6 @@ def query_moira_lists(user):
     Returns:
         list_names(list): A list of names of moira lists which contain the user as a member.
     """
-    if user.is_anonymous:
-        return []
     moira_user = get_moira_user(user)
     moira = get_moira_client()
     try:

--- a/ui/utils_test.py
+++ b/ui/utils_test.py
@@ -3,6 +3,7 @@ from tempfile import NamedTemporaryFile
 import json
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from zeep.exceptions import Fault
 
 from ui import factories
@@ -124,6 +125,13 @@ def test_user_moira_lists_cache_miss(mocker, settings):
         expected_result,
         settings.MOIRA_CACHE_TIMEOUT
     )
+
+
+def test_user_moira_lists_anonymous():
+    """
+    Test that empty list is returned for anonymous user
+    """
+    assert user_moira_lists(AnonymousUser()) == []
 
 
 def test_has_common_lists(mocker):

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -521,6 +521,19 @@ def test_video_detail_anonymous(settings, logged_in_apiclient, user_admin_list_d
     assert '?next=/videos/{}'.format(user_admin_list_data.video.hexkey) in last_url
 
 
+def test_public_video_detail_anonymous(settings, logged_in_apiclient, user_admin_list_data):
+    """
+    Tests that an anonymous user can access a public video
+    """
+    client, _ = logged_in_apiclient
+    client.logout()
+    user_admin_list_data.video.is_public = True
+    user_admin_list_data.video.save()
+    url = reverse('video-detail', kwargs={'video_key': user_admin_list_data.video.hexkey})
+    response = client.get(url, follow=True)
+    assert response.status_code == 200
+
+
 @pytest.mark.parametrize('url', ['/videos/{}', '/videos/{}-foo'])
 def test_techtv_detail_standard_url(mock_user_moira_lists, user_view_list_data, logged_in_apiclient, url):
     """

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -918,6 +918,25 @@ def test_video_viewset_list(mock_user_moira_lists, logged_in_apiclient):
     # pylint: enable-msg=too-many-locals
 
 
+def test_video_viewset_list_anonymous(logged_in_apiclient):
+    """
+    Tests the list of collections for an anonymous user
+    """
+    client, _ = logged_in_apiclient
+    client.logout()
+    url = reverse('models-api:video-list')
+    collection = CollectionFactory()
+    public_video_keys = [
+        VideoFactory(collection=collection, is_public=True).hexkey for _ in range(2)
+    ]
+    VideoFactory(collection=collection, is_public=False)
+    result = client.get(url)
+    assert result.status_code == status.HTTP_200_OK
+    assert len(result.data['results']) == len(public_video_keys)
+    for coll_data in result.data['results']:
+        assert coll_data['key'] in public_video_keys
+
+
 def test_video_viewset_list_superuser(logged_in_apiclient, settings):
     """
     Tests the list of collections for a superuser


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #634 

#### What's this PR do?
Fixes the VideoViewSet filtering for anonymous users

#### How should this be manually tested?
- Make a video public (from admin page).
- Try to view the video detail page as an anonymous user
