### PR TITLE
Exclude 'Cloudfront' stream_source videos from Youtube upload task

### DIFF
--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -19,7 +19,7 @@ from cloudsync.api import refresh_status, process_watch_file, transcode_video
 from cloudsync.exceptions import TranscodeTargetDoesNotExist
 from cloudsync.youtube import YouTubeApi, API_QUOTA_ERROR_MSG
 from ui.models import Video, YouTubeVideo, VideoSubtitle
-from ui.constants import VideoStatus, YouTubeStatus
+from ui.constants import VideoStatus, YouTubeStatus, StreamSource
 from ui.utils import get_bucket
 
 log = logging.getLogger(__name__)
@@ -168,7 +168,7 @@ def upload_youtube_videos():
     """
     yt_queue = Video.objects.filter(is_public=True).filter(
         status=VideoStatus.COMPLETE).filter(youtubevideo__id__isnull=True).exclude(
-            collection__stream_source='cloudfront').order_by('-created_at')[:settings.YT_DAILY_UPLOAD_LIMIT]
+            collection__stream_source=StreamSource.CLOUDFRONT).order_by('-created_at')[:settings.YT_DAILY_UPLOAD_LIMIT]
     for video in yt_queue.all():
         youtube_video = YouTubeVideo.objects.create(video=video)
         try:

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -36,10 +36,10 @@ from ui.factories import (
     VideoFileFactory,
     UserFactory,
     VideoSubtitleFactory,
-    YouTubeVideoFactory
-)
+    YouTubeVideoFactory,
+    CollectionFactory)
 from ui.models import Video, YouTubeVideo
-from ui.constants import VideoStatus, YouTubeStatus
+from ui.constants import VideoStatus, YouTubeStatus, StreamSource
 
 pytestmark = pytest.mark.django_db
 
@@ -346,15 +346,19 @@ def test_monitor_watch_badname(mocker):
     assert Video.objects.get(source_url__endswith=filenames[2])
 
 
+@pytest.mark.parametrize('source', [StreamSource.CLOUDFRONT, StreamSource.YOUTUBE, None])
 @pytest.mark.parametrize('max_uploads', [2, 4])
-def test_upload_youtube_videos(mocker, max_uploads):
+def test_upload_youtube_videos(mocker, source, max_uploads):
     """
     Test that the upload_youtube_videos task calls YouTubeApi.upload_video
     & creates a YoutubeVideo object for each public video, up to the max daily limit
     """
     settings.YT_DAILY_UPLOAD_LIMIT = max_uploads
     private_videos = VideoFactory.create_batch(2, is_public=False, status=VideoStatus.COMPLETE)
-    VideoFactory.create_batch(3, is_public=True, status=VideoStatus.COMPLETE)
+    VideoFactory.create_batch(3,
+                              collection=CollectionFactory(stream_source=source),
+                              is_public=True,
+                              status=VideoStatus.COMPLETE)
     mock_uploader = mocker.patch('cloudsync.tasks.YouTubeApi.upload_video', return_value={
         'id': ''.join([random.choice(string.ascii_lowercase) for n in range(8)]),
         'status': {
@@ -362,9 +366,12 @@ def test_upload_youtube_videos(mocker, max_uploads):
         }
     })
     upload_youtube_videos()
-    assert mock_uploader.call_count == min(3, max_uploads)
+    assert mock_uploader.call_count == (min(3, max_uploads) if source != StreamSource.CLOUDFRONT else 0)
     for video in Video.objects.filter(is_public=True).order_by('-created_at')[:settings.YT_DAILY_UPLOAD_LIMIT]:
-        assert YouTubeVideo.objects.filter(video=video).first() is not None
+        if video.collection.stream_source != StreamSource.CLOUDFRONT:
+            assert YouTubeVideo.objects.filter(video=video).first() is not None
+        else:
+            assert YouTubeVideo.objects.filter(video=video).first() is None
     for video in private_videos:
         assert YouTubeVideo.objects.filter(video=video).first() is None
 


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #637 

#### What's this PR do?
- Fixes the stream_source filter in the `upload_youtube_videos` task

#### How should this be manually tested?
- Create/edit a collection and set `stream_source=Cloudfront`
- Create a public video in that collection
- Create/edit a different collection and set `stream_source=YouTube`
- Create a public video in that collection
- in a django shell:
  ```python
  from cloudsync.tasks import upload_youtube_videos
  upload_youtube_videos()
  ```
- A `YoutubeVideo` object should be created for the video in the `stream_source=Youtube` collection but not the video in the `stream_source=Cloudfront` collection.
