### PR TITLE
Public video download links

### DIFF
--- a/ui/models.py
+++ b/ui/models.py
@@ -231,6 +231,20 @@ class Video(TimestampedModel):
                       key=lambda x: EncodingNames.MP4.index(x.encoding) if x.encoding in EncodingNames.MP4 else 0)
 
     @property
+    def download(self):
+        """
+        Return the most appropriate videofile for downloading.
+
+        Returns:
+            VideoFile: The videofile most appropriate for download (highest quality MP4 transcode or original upload)
+        """
+        files = sorted(self.videofile_set.exclude(encoding=EncodingNames.HLS),
+                       key=lambda x: EncodingNames.MP4.index(x.encoding) if x.encoding in EncodingNames.MP4 else 5)
+        if files:
+            return files[0]
+        return None
+
+    @property
     def sources(self):
         """
         Generate a sources dict for VideoJS

--- a/ui/models.py
+++ b/ui/models.py
@@ -238,8 +238,12 @@ class Video(TimestampedModel):
         Returns:
             VideoFile: The videofile most appropriate for download (highest quality MP4 transcode or original upload)
         """
-        files = sorted(self.videofile_set.exclude(encoding=EncodingNames.HLS),
-                       key=lambda x: EncodingNames.MP4.index(x.encoding) if x.encoding in EncodingNames.MP4 else 5)
+        files = sorted(
+            self.videofile_set.exclude(encoding=EncodingNames.HLS),
+            key=lambda x: EncodingNames.MP4.index(x.encoding) if x.encoding in EncodingNames.MP4 else len(
+                EncodingNames.MP4
+            )
+        )
         if files:
             return files[0]
         return None

--- a/ui/models_test.py
+++ b/ui/models_test.py
@@ -300,6 +300,20 @@ def test_transcoded_hls_video():
     assert video.transcoded_videos[0] == videofiles[1]
 
 
+@pytest.mark.parametrize('encodings,download', [
+    [[EncodingNames.ORIGINAL, EncodingNames.SMALL, EncodingNames.HD, EncodingNames.HLS], EncodingNames.HD],
+    [[EncodingNames.ORIGINAL, EncodingNames.HLS], EncodingNames.ORIGINAL],
+    [[EncodingNames.ORIGINAL, EncodingNames.LARGE], EncodingNames.LARGE],
+    [[EncodingNames.SMALL, EncodingNames.HD], EncodingNames.HD],
+])
+def test_download_mp4(encodings, download):
+    """ Tests that video.download returns the most appropriate file for download """
+    video = VideoFactory()
+    for encoding in encodings:
+        VideoFileFactory(video=video, s3_object_key='{}.mp4'.format(encoding), encoding=encoding)
+    assert video.download.encoding == download
+
+
 @pytest.mark.parametrize('status', [YouTubeStatus.UPLOADED, YouTubeStatus.PROCESSED, YouTubeStatus.FAILED, None])
 def test_video_youtube_id(status, video):
     """

--- a/ui/models_test.py
+++ b/ui/models_test.py
@@ -305,13 +305,17 @@ def test_transcoded_hls_video():
     [[EncodingNames.ORIGINAL, EncodingNames.HLS], EncodingNames.ORIGINAL],
     [[EncodingNames.ORIGINAL, EncodingNames.LARGE], EncodingNames.LARGE],
     [[EncodingNames.SMALL, EncodingNames.HD], EncodingNames.HD],
+    [[], None],
 ])
 def test_download_mp4(encodings, download):
     """ Tests that video.download returns the most appropriate file for download """
     video = VideoFactory()
     for encoding in encodings:
         VideoFileFactory(video=video, s3_object_key='{}.mp4'.format(encoding), encoding=encoding)
-    assert video.download.encoding == download
+    if not download:
+        assert video.download is None
+    else:
+        assert video.download.encoding == download
 
 
 @pytest.mark.parametrize('status', [YouTubeStatus.UPLOADED, YouTubeStatus.PROCESSED, YouTubeStatus.FAILED, None])

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -23,9 +23,12 @@ urlpatterns = [
 
     url(r'^videos/(?P<video_key>[0-9a-f]{32})/$', views.VideoDetail.as_view(), name='video-detail'),
     url(r'^videos/(?P<video_key>[0-9a-f]{32})/embed/$', views.VideoEmbed.as_view(), name='video-embed'),
+    url(r'^videos/(?P<video_key>[0-9a-f]{32})/download', views.VideoDownload.as_view(), name='video-download'),
     url(r'^videos/(?P<video_key>\d+)(-.+)?/?$', views.TechTVDetail.as_view(), name='techtv-detail'),
     url(r'^videos/(?P<video_key>.+)/private/?$', views.TechTVPrivateDetail.as_view(), name='techtv-private'),
+    url(r'^videos/(?P<video_key>\d+)(-.+)?/download', views.TechTVDownload.as_view(), name='techtv-download'),
     url(r'^embeds/(?P<video_key>\d+)(-.+)?/?$', views.TechTVEmbed.as_view(), name='techtv-embed'),
+
 
     url(r'^transcode/', include('dj_elastictranscoder.urls')),
     url(r'^api/v0/upload_videos/$', views.UploadVideosFromDropbox.as_view(), name='upload-videos'),

--- a/ui/views.py
+++ b/ui/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.auth.views import LoginView as DjangoLoginView
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse, StreamingHttpResponse
+from django.http import HttpResponse, StreamingHttpResponse, Http404
 from django.shortcuts import (
     get_object_or_404,
     redirect,
@@ -168,6 +168,8 @@ class VideoDownload(VideoDetail):
             HttpResponse: the response videofile content and a file attachment header
         """
         video_file = video.download
+        if not video_file:
+            raise Http404()
         _, ext = splitext(video_file.s3_object_key)
         video_bytes = requests.get(video_file.cloudfront_url, stream=True)
         response = StreamingHttpResponse(

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -549,6 +549,19 @@ def test_video_download(logged_in_client, is_public, mocker):
 
 
 @pytest.mark.parametrize('is_public', [True, False])
+def test_video_download_nofiles(logged_in_client, is_public, mocker):
+    """ Tests that a 404 is returned if no videofiles are available """
+    mocker.patch('ui.views.requests.get')
+    client, _ = logged_in_client
+    client.logout()
+    video = VideoFactory(is_public=is_public)
+    assert video.download is None
+    url = reverse('video-download', kwargs={'video_key': video.hexkey})
+    result = client.get(url)
+    assert result.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.parametrize('is_public', [True, False])
 def test_techtv_video_download(logged_in_client, is_public, mocker):
     """ Tests that a TechTV video can be downloaded if public, returns 404 otherwise """
     mocker.patch('ui.views.requests.get')

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -16,6 +16,7 @@ from rest_framework.reverse import reverse
 from techtv2ovs.factories import TechTVVideoFactory
 from ui import factories
 from ui.constants import YouTubeStatus
+from ui.encodings import EncodingNames
 from ui.factories import (
     UserFactory,
     CollectionFactory,
@@ -532,6 +533,32 @@ def test_public_video_detail_anonymous(settings, logged_in_apiclient, user_admin
     url = reverse('video-detail', kwargs={'video_key': user_admin_list_data.video.hexkey})
     response = client.get(url, follow=True)
     assert response.status_code == 200
+
+
+@pytest.mark.parametrize('is_public', [True, False])
+def test_video_download(logged_in_client, is_public, mocker):
+    """ Tests that a video can be downloaded if public, returns 404 otherwise """
+    mocker.patch('ui.views.requests.get')
+    client, _ = logged_in_client
+    client.logout()
+    video = VideoFactory(is_public=is_public)
+    VideoFileFactory(video=video, encoding=EncodingNames.ORIGINAL)
+    url = reverse('video-download', kwargs={'video_key': video.hexkey})
+    result = client.get(url)
+    assert result.status_code == (status.HTTP_200_OK if is_public else status.HTTP_404_NOT_FOUND)
+
+
+@pytest.mark.parametrize('is_public', [True, False])
+def test_techtv_video_download(logged_in_client, is_public, mocker):
+    """ Tests that a TechTV video can be downloaded if public, returns 404 otherwise """
+    mocker.patch('ui.views.requests.get')
+    client, _ = logged_in_client
+    client.logout()
+    ttv_video = TechTVVideoFactory(video=VideoFactory(is_public=is_public))
+    VideoFileFactory(video=ttv_video.video, encoding=EncodingNames.ORIGINAL)
+    url = reverse('techtv-download', kwargs={'video_key': ttv_video.ttv_id})
+    result = client.get(url)
+    assert result.status_code == (status.HTTP_200_OK if is_public else status.HTTP_404_NOT_FOUND)
 
 
 @pytest.mark.parametrize('url', ['/videos/{}', '/videos/{}-foo'])

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -574,6 +574,19 @@ def test_techtv_video_download(logged_in_client, is_public, mocker):
     assert result.status_code == (status.HTTP_200_OK if is_public else status.HTTP_404_NOT_FOUND)
 
 
+@pytest.mark.parametrize('is_public', [True, False])
+def test_techtv_video_download_nofiles(logged_in_client, is_public, mocker):
+    """ Tests that a 404 is returned if no videofiles are available for a TechTV video"""
+    mocker.patch('ui.views.requests.get')
+    client, _ = logged_in_client
+    client.logout()
+    ttv_video = TechTVVideoFactory(video=VideoFactory(is_public=is_public))
+    assert ttv_video.video.download is None
+    url = reverse('techtv-download', kwargs={'video_key': ttv_video.ttv_id})
+    result = client.get(url)
+    assert result.status_code == status.HTTP_404_NOT_FOUND
+
+
 @pytest.mark.parametrize('url', ['/videos/{}', '/videos/{}-foo'])
 def test_techtv_detail_standard_url(mock_user_moira_lists, user_view_list_data, logged_in_apiclient, url):
     """


### PR DESCRIPTION
#### What are the relevant tickets?
- Closes #639 

#### What's this PR do?
- Creates download links for public videos

#### How should this be manually tested?
- If you don't have any imported TechTV collections/videos, create one in a shell for a normal public video that already exists:
  ```python
  from ui.models import Video
  from techtv2ovs.models import *
  my_video = Video.objects.get(<your_video_id>)
  my_video.is_public=True
  my_video.save()
  ttv_collection = TechTVCollection.objects.create(id=100, title='My TTV colletion')
  TechTVVideo.objects.create(id=1, ttv_id=101, ttv_collection=ttv_collection, video=my_video, status='Complete')
   ```
- Go to `/videos/101`, you should get the detail page for the video via the TechTV id (`ttv_id`)
- Go to `/videos/101/download`, `videos/101/download.mp4`, `videos/101/download.avi`, they should all result in the same file being downloaded with the name `<video-title-slug>.<actual_extension_of_file>`
- Go to `/videos/<ovs_video_key>`, you should get the detail page for the video via the video uuid key(`video.hexkey`)
- Go to `/videos/<ovs_video_key>/download`, `videos/<ovs_video_key>/download.mp4`, `videos/<ovs_video_key>/download.avi`, they should all result in the same file being downloaded with the name `<video-title-slug>.<actual_extension_of_file>`
- If you change the video to `is_public=False`, the download links should all return 404's