### PR TITLE
Add sentry handler to root and django logger configurations

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -284,7 +284,7 @@ LOGGING = {
         'django': {
             'propagate': True,
             'level': DJANGO_LOG_LEVEL,
-            'handlers': ['console', 'syslog'],
+            'handlers': ['console', 'syslog', 'sentry'],
         },
         'django.request': {
             'handlers': ['mail_admins'],
@@ -301,17 +301,10 @@ LOGGING = {
         }
     },
     'root': {
-        'handlers': ['console', 'syslog'],
+        'handlers': ['console', 'syslog', 'sentry'],
         'level': LOG_LEVEL,
     },
 }
-
-# to run the app locally on mac you need to bypass syslog
-if get_bool('ODL_VIDEO_BYPASS_SYSLOG', False):
-    LOGGING['handlers'].pop('syslog')
-    LOGGING['loggers']['root']['handlers'] = ['console']
-    LOGGING['loggers']['ui']['handlers'] = ['console']
-    LOGGING['loggers']['django']['handlers'] = ['console']
 
 # Sentry
 ENVIRONMENT = get_string('ODL_VIDEO_ENVIRONMENT', 'dev')

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 Django==1.11.10
 boto3==1.4.4
-celery==4.0.2
+celery==4.2.0
 cryptography
 dj-database-url==0.3.0
 dj-static==0.0.6
@@ -15,7 +15,7 @@ ipython
 newrelic
 psycopg2==2.7.3.2
 pytz
-raven
+raven==6.9.0
 redis==2.10.5
 requests
 uwsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ git+https://github.com/mitodl/mit-moira.git#egg=mit-moira==0.0.4
 git+https://github.com/mitodl/pycaption.git#egg=pycaption
 amqp==2.2.1               # via kombu
 appdirs==1.4.3            # via fs, zeep
-appnope==0.1.0            # via ipython
 asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.6.0
 billiard==3.5.0.3         # via celery
@@ -24,12 +23,11 @@ bz2file==0.98             # via smart-open
 cached-property==1.3.0    # via zeep
 cachetools==2.0.1         # via google-auth
 celery-redbeat==0.11.1
-celery==4.0.2
+celery==4.2.0
 certifi==2017.4.17        # via requests
 cffi==1.10.0              # via cryptography
 chardet==3.0.4            # via requests
 colorama==0.3.9           # via mondrian
-contextlib2==0.5.5        # via raven
 cryptography==2.1.4
 cssutils==1.0.2
 decorator==4.1.1          # via ipython, traitlets
@@ -66,7 +64,7 @@ isodate==0.5.4            # via zeep
 jedi==0.10.2              # via ipython
 jinja2==2.10              # via bonobo
 jmespath==0.9.3           # via boto3, botocore
-kombu==4.0.2              # via celery, django-server-status
+kombu==4.2.1              # via celery, django-server-status
 lxml==4.1.1               # via zeep
 markupsafe==1.0           # via jinja2
 mondrian==0.6.1           # via bonobo
@@ -91,7 +89,7 @@ pyparsing==2.2.0          # via packaging
 python-dateutil==2.6.1    # via botocore, celery-redbeat, faker
 python-slugify==1.2.4     # via bonobo
 pytz==2017.2
-raven==6.1.0
+raven==6.9.0
 redis==2.10.5
 requests-oauthlib==0.8.0  # via google-auth-oauthlib
 requests-toolbelt==0.8.0  # via zeep


### PR DESCRIPTION
#### What are the relevant tickets?
Related to https://github.com/mitodl/open-discussions/pull/813
Related to https://github.com/mitodl/odl-video-service/issues/462

#### What's this PR do?
Adds `sentry` handler to root and django loggers. Also updates a couple dependencies.

#### How should this be manually tested?
In the heroku shell type `logging.getLogger().error('just testing an error')`. You should see this error message show up in sentry.
