### PR TITLE
Add version to django-shibboleth-remoteuser to force upgrade

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -35,7 +35,7 @@ django-hijack==2.1.7
 django-hijack-admin==2.1.7
 
 # Touchstone
--e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
+-e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser==0.9
 
 # MIT-Moira
 -e git+https://github.com/mitodl/mit-moira.git#egg=mit-moira==0.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 --no-binary psycopg2
 
 git+https://github.com/mitodl/django-elastic-transcoder.git#egg=django-elastic-transcoder==0.9.7
-git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser
+git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser==0.9
 git+https://github.com/mitodl/mit-moira.git#egg=mit-moira==0.0.4
 git+https://github.com/mitodl/pycaption.git#egg=pycaption
 amqp==2.2.1               # via kombu


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #665 

#### What's this PR do?
Specifies version 0.9 for django-shibboleth-remoteuser

#### How should this be manually tested?
```
docker-compose build
docker-compose up
```
Log out and then log back in.  You should not get a 500 error.

