### PR TITLE
Remove IS_OSX variable

### DIFF
--- a/scripts/envs.sh
+++ b/scripts/envs.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-# Set IS_OSX to true or false depending on which environment we're running in
-if [[ ! -z "$DOCKER_HOST" && "$DOCKER_HOST" != "missing" ]]
-then
-    # OS X, either container or host but docker-machine is set up beforehand
-    IS_OSX="true"
-elif [[ $(uname -s) == "Darwin" ]]
-then
-    # OS X host, docker-machine is not configured
-    IS_OSX="true"
-else
-    IS_OSX="false"
-fi
-
 # If we're running from inside a container /.dockerenv should exist (not a guarantee but the best we can do)
 if [[ -e "/.dockerenv" ]]
 then
@@ -28,54 +15,34 @@ WEBPACK_DEV_SERVER_HOST="localhost"
 # Set WEBPACK_SELENIUM_DEV_SERVER_HOST to the IP address for the webpack dev server
 # This is different from WEBPACK_DEV_SERVER_HOST because localhost won't suffice here since the request
 # is coming from a docker container, not the browser. If we can't detect this the user must set it via a script.
-if [[ "$IS_OSX" == "true" ]]
+if [[ "$INSIDE_CONTAINER" == "true" ]]
 then
-    if [[ "$INSIDE_CONTAINER" == "true" ]]
-    then
-        if [[ "$CONTAINER_NAME" != "watch" ]]
-        then
-            # This should be already defined and passed in via script. If not, we should error.
-            if [[ -z "$WEBPACK_SELENIUM_DEV_SERVER_HOST" ]]
-            then
-                echo "WEBPACK_SELENIUM_DEV_SERVER_HOST is undefined. Did you run the management command from a script?"
-                exit 1
-            fi
-        fi
-        # Else webpack_dev_server.sh should handle the exit message
-    else
-        if [[ -z "$DOCKER_HOST" ]]
-        then
-            # If we're running the webpack dev server we don't need this
-            WEBPACK_SELENIUM_DEV_SERVER_HOST=""
-        else
-            # This is kind of kludgy. The DOCKER_HOST ip address is usually something like 192.168.99.100.
-            # We can access the webpack dev server running on the host by using the gateway IP for this subnet,
-            # 192.168.99.1. To get it we need to look up the interface for the DOCKER_HOST ip, then look up
-            # the gateway IP address for that interface.
-            DOCKER_HOST_IP="$(echo "$DOCKER_HOST" | awk -F'/|:' '{print $4}' )"
-            VBOXNET_INTERFACE="$(arp -an | grep "$DOCKER_HOST_IP" | awk -F'on' '{print $2}' | awk '{print $1}')"
-            WEBPACK_SELENIUM_DEV_SERVER_HOST="$(ifconfig "$VBOXNET_INTERFACE" | grep inet | awk '{print $2}')"
-        fi
-    fi
+    # Linux container
+    WEBPACK_SELENIUM_DEV_SERVER_HOST="$(ip route | grep default | awk '{ print $3 }')"
 else
-    if [[ "$INSIDE_CONTAINER" == "true" ]]
+    # Linux host
+    CONTAINER_NAME="$(docker-compose ps -q watch)"
+    if [[ -z "$CONTAINER_NAME" ]]
     then
-        # Linux container
-        WEBPACK_SELENIUM_DEV_SERVER_HOST="$(ip route | grep default | awk '{ print $3 }')"
-    else
-        # Linux host
-        CONTAINER_NAME="$(docker-compose ps -q watch)"
-        WEBPACK_SELENIUM_DEV_SERVER_HOST="$(docker exec "$CONTAINER_NAME" ip route | grep default | awk '{ print $3 }')"
+        echo "Missing container watch"
+        exit 1
     fi
+
+    CONTAINER_STATUS="$(docker inspect "$CONTAINER_NAME" -f '{{.State.Status}}')"
+    if [[ "$CONTAINER_STATUS" != "running" ]]
+    then
+        echo "watch container status for $CONTAINER_NAME was expected to be running but is $CONTAINER_STATUS"
+        exit 1
+    fi
+
+    WEBPACK_SELENIUM_DEV_SERVER_HOST="$(docker exec "$CONTAINER_NAME" ip route | grep default | awk '{ print $3 }')"
 fi
 
-export IS_OSX="$IS_OSX"
 export INSIDE_CONTAINER="$INSIDE_CONTAINER"
 export WEBPACK_DEV_SERVER_HOST="$WEBPACK_DEV_SERVER_HOST"
 export WEBPACK_SELENIUM_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST"
 
 echo "Vars set:"
-echo IS_OSX="$IS_OSX"
 echo INSIDE_CONTAINER="$INSIDE_CONTAINER"
 echo WEBPACK_DEV_SERVER_HOST="$WEBPACK_DEV_SERVER_HOST"
 echo WEBPACK_SELENIUM_DEV_SERVER_HOST="$WEBPACK_SELENIUM_DEV_SERVER_HOST"

--- a/webpack_dev_server.sh
+++ b/webpack_dev_server.sh
@@ -1,24 +1,11 @@
 #!/bin/bash
 set -ef -o pipefail
 
-# Define some environment variables to figure out where we are running
-source ./scripts/envs.sh
-
 WEBPACK_HOST='0.0.0.0'
 WEBPACK_PORT='8082'
 
-# The webpack server should only be run in one of two cases:
-#    1) We are running Linux and inside the Docker container
-#    2) We're on an OSX host machine. Our current workflow for developing on a Docker container involves running
-#       the webpack server on the host machine rather than the container.
-# If neither of those are true, running this script is basically a no-op.
-
-if [[ "$IS_OSX" == "true" && "$INSIDE_CONTAINER" == "true" ]] ; then
-  echo -e "EXITING WEBPACK STARTUP SCRIPT\nOSX Users: The webpack dev server should be run on your host machine."
-else
-  if [[ "$1" == "--install" ]] ; then
+if [[ "$1" == "--install" ]] ; then
     yarn install --frozen-lockfile && echo "Finished yarn install"
-  fi
-  # Start the webpack dev server on the appropriate host and port
-  node ./hot-reload-dev-server.js --host "$WEBPACK_HOST" --port "$WEBPACK_PORT"
 fi
+# Start the webpack dev server on the appropriate host and port
+node ./hot-reload-dev-server.js --host "$WEBPACK_HOST" --port "$WEBPACK_PORT"


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Removes `IS_OSX` environment variable which is unnecessary with Docker for Mac

#### How should this be manually tested?
Nothing should break when run with a Mac
