### PR TITLE
Add a missing TechTV route to urls.py

### DIFF
--- a/ui/urls.py
+++ b/ui/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
 
     url(r'^collections/(?P<collection_key>[0-9a-f]{32})?/?$', views.CollectionReactView.as_view(),
         name='collection-react-view'),
-    url(r'^collections/\w+/videos/(?P<video_key>\d+)(-.+)?/?$', views.TechTVDetail.as_view(),
+    url(r'^collections/[0-9A-Za-z\-_\:]+/videos/(?P<video_key>\d+)(-.+)?/?$', views.TechTVDetail.as_view(),
         name='techtv-collection-detail'),
 
     url(r'^help/', views.HelpPageView.as_view(), name='help-react-view'),

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -17,6 +17,8 @@ urlpatterns = [
 
     url(r'^collections/(?P<collection_key>[0-9a-f]{32})?/?$', views.CollectionReactView.as_view(),
         name='collection-react-view'),
+    url(r'^collections/\w+/videos/(?P<video_key>\d+)(-.+)?/?$', views.TechTVDetail.as_view(),
+        name='techtv-collection-detail'),
 
     url(r'^help/', views.HelpPageView.as_view(), name='help-react-view'),
     url(r'^terms/', views.TermsOfServicePageView.as_view(), name='terms-react-view'),

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -591,7 +591,7 @@ def test_techtv_video_download_nofiles(logged_in_client, is_public, mocker):
     '/videos/{}',
     '/videos/{}-foo',
     '/collections/foo/videos/{}',
-    '/collections/foo/videos/{}-bar'
+    '/collections/foo-bar:935/videos/{}-bar/'
 ])
 def test_techtv_detail_standard_url(mock_user_moira_lists, user_view_list_data, logged_in_apiclient, url):
     """

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -587,7 +587,12 @@ def test_techtv_video_download_nofiles(logged_in_client, is_public, mocker):
     assert result.status_code == status.HTTP_404_NOT_FOUND
 
 
-@pytest.mark.parametrize('url', ['/videos/{}', '/videos/{}-foo'])
+@pytest.mark.parametrize('url', [
+    '/videos/{}',
+    '/videos/{}-foo',
+    '/collections/foo/videos/{}',
+    '/collections/foo/videos/{}-bar'
+])
 def test_techtv_detail_standard_url(mock_user_moira_lists, user_view_list_data, logged_in_apiclient, url):
     """
     Tests that a URL based on a TechTV id returns the correct Video detail page


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #676 

#### What's this PR do?
Adds a new route to urls.py to handle old TechTV URL's that include the collection name, such as https://techtv.mit.edu/collections/ifluids/videos/32592-aerodynamic-generation-of-a-sound 

#### How should this be manually tested?
- If you don't already have a TechTV video, convert an existing video into one:
  ```
  from ui.models import Video
  from techtv2ovs.models import *
  my_video = Video.objects.get(<your_video_id>)
  my_video.is_public=True
  my_video.save()
  ttv_collection = TechTVCollection.objects.create(id=100, title='My TTV colletion')
  TechTVVideo.objects.create(id=1, ttv_id=101, ttv_collection=ttv_collection, video=my_video, 
    status='Complete')
  ```

- Go to the URL `/collections/ifluids/videos/<ttv_id>-extra-text`.  It should load the detail page for the correct video.
- The collection slug used in the URL doesn't matter, only the `TechTVVideo.ttv_id` value is important.  Any collection slug with alphanumeric characters as well as `_, -, :`should work.
