### PR TITLE
Clear collection errors from state after form submission

### DIFF
--- a/static/js/actions/collectionUi.js
+++ b/static/js/actions/collectionUi.js
@@ -39,6 +39,9 @@ export const setIsNew = createAction(SET_IS_NEW)
 export const CLEAR_COLLECTION_FORM = qualifiedName("CLEAR_COLLECTION_FORM")
 export const clearCollectionForm = createAction(CLEAR_COLLECTION_FORM)
 
+export const CLEAR_COLLECTION_ERRORS = qualifiedName("CLEAR_COLLECTION_ERRORS")
+export const clearCollectionErrors = createAction(CLEAR_COLLECTION_ERRORS)
+
 export const showNewCollectionDialog = () => (dispatch: Dispatch) => {
   dispatch(setIsNew(true))
   dispatch(showDialog(DIALOGS.COLLECTION_FORM))

--- a/static/js/components/dialogs/CollectionFormDialog.js
+++ b/static/js/components/dialogs/CollectionFormDialog.js
@@ -7,21 +7,22 @@ import Radio from "../material/Radio"
 import Textfield from "../material/Textfield"
 import Textarea from "../material/Textarea"
 
+import Dialog from "../material/Dialog"
+
 import * as uiActions from "../../actions/collectionUi"
 import { actions } from "../../actions"
 import { PERM_CHOICE_NONE, PERM_CHOICE_LISTS } from "../../lib/dialog"
 import { getCollectionForm } from "../../lib/collection"
+import { makeCollectionUrl } from "../../lib/urls"
+import { calculateListPermissionValue } from "../../util/util"
+import { setCollectionFormErrors, clearCollectionErrors } from "../../actions/collectionUi"
 
 import type {
   CollectionFormState,
   CollectionUiState,
   Collection
 } from "../../flow/collectionTypes"
-import { makeCollectionUrl } from "../../lib/urls"
-import { calculateListPermissionValue } from "../../util/util"
-import { setCollectionFormErrors } from "../../actions/collectionUi"
-import Dialog from "../material/Dialog"
-import { clearCollectionErrors } from "../../actions/collectionUi"
+
 
 type DialogProps = {
   dispatch: Dispatch,

--- a/static/js/components/dialogs/CollectionFormDialog.js
+++ b/static/js/components/dialogs/CollectionFormDialog.js
@@ -21,6 +21,7 @@ import { makeCollectionUrl } from "../../lib/urls"
 import { calculateListPermissionValue } from "../../util/util"
 import { setCollectionFormErrors } from "../../actions/collectionUi"
 import Dialog from "../material/Dialog"
+import { clearCollectionErrors } from "../../actions/collectionUi"
 
 type DialogProps = {
   dispatch: Dispatch,
@@ -106,7 +107,7 @@ export class CollectionFormDialog extends React.Component<*, void> {
           message: {
             key:     "collection-created",
             content: "Collection created",
-            icon:    "check",
+            icon:    "check"
           }
         })
       } else {
@@ -115,7 +116,7 @@ export class CollectionFormDialog extends React.Component<*, void> {
           message: {
             key:     "collection-updated",
             content: "Changes saved",
-            icon:    "check",
+            icon:    "check"
           }
         })
       }
@@ -126,7 +127,7 @@ export class CollectionFormDialog extends React.Component<*, void> {
     }
   }
 
-  addToastMessage (...args:any[]) {
+  addToastMessage(...args: any[]) {
     this.props.dispatch(actions.toast.addMessage(...args))
   }
 
@@ -144,6 +145,7 @@ export class CollectionFormDialog extends React.Component<*, void> {
         errors: error
       })
     )
+    dispatch(clearCollectionErrors())
   }
 
   render() {
@@ -256,7 +258,7 @@ export class CollectionFormDialog extends React.Component<*, void> {
   }
 }
 
-export const mapStateToProps = (state:any) => {
+export const mapStateToProps = (state: any) => {
   const { collectionUi } = state
 
   const collectionForm = getCollectionForm(collectionUi)
@@ -266,5 +268,7 @@ export const mapStateToProps = (state:any) => {
   }
 }
 
-const ConnectedCollectionFormDialog = connect(mapStateToProps)(CollectionFormDialog)
+const ConnectedCollectionFormDialog = connect(mapStateToProps)(
+  CollectionFormDialog
+)
 export default ConnectedCollectionFormDialog

--- a/static/js/components/dialogs/CollectionFormDialog_test.js
+++ b/static/js/components/dialogs/CollectionFormDialog_test.js
@@ -27,7 +27,8 @@ import {
   showNewCollectionDialog,
   showEditCollectionDialog,
   CLEAR_COLLECTION_FORM,
-  SET_COLLECTION_FORM_ERRORS
+  SET_COLLECTION_FORM_ERRORS,
+  CLEAR_COLLECTION_ERRORS
 } from "../../actions/collectionUi"
 import * as toastActions from "../../actions/toast"
 import { INITIAL_UI_STATE } from "../../reducers/collectionUi"
@@ -126,13 +127,15 @@ describe("CollectionFormDialog", () => {
           expectedActionTypes = [
             actions.collectionsList.post.requestType,
             "RECEIVE_POST_COLLECTIONS_LIST_FAILURE",
-            SET_COLLECTION_FORM_ERRORS
+            SET_COLLECTION_FORM_ERRORS,
+            CLEAR_COLLECTION_ERRORS
           ]
         } else {
           expectedActionTypes = [
             actions.collections.patch.requestType,
             "RECEIVE_PATCH_COLLECTIONS_FAILURE",
-            SET_COLLECTION_FORM_ERRORS
+            SET_COLLECTION_FORM_ERRORS,
+            CLEAR_COLLECTION_ERRORS
           ]
         }
         await listenForActions(expectedActionTypes, () => {
@@ -158,7 +161,6 @@ describe("CollectionFormDialog", () => {
         store.dispatch(setViewLists(listInput))
         store.dispatch(setCollectionDesc("new description"))
         store.dispatch(setCollectionTitle("new title"))
-
 
         sandbox.stub(api, "getCollections").returns(Promise.resolve({}))
         let apiStub, expectedActionTypes
@@ -231,7 +233,7 @@ describe("CollectionFormDialog", () => {
           expectedActionTypes = [
             actions.collectionsList.post.requestType,
             actions.collectionsList.post.successType,
-            toastActions.constants.ADD_MESSAGE,
+            toastActions.constants.ADD_MESSAGE
           ]
         } else {
           sandbox
@@ -240,7 +242,7 @@ describe("CollectionFormDialog", () => {
           expectedActionTypes = [
             actions.collections.patch.requestType,
             actions.collections.patch.successType,
-            toastActions.constants.ADD_MESSAGE,
+            toastActions.constants.ADD_MESSAGE
           ]
         }
 
@@ -250,49 +252,44 @@ describe("CollectionFormDialog", () => {
         })
 
         if (isNew) {
-          assert.deepEqual(
-            state.toast.messages,
-            [{
+          assert.deepEqual(state.toast.messages, [
+            {
               key:     "collection-created",
               content: "Collection created",
               icon:    "check"
-            }]
-          )
+            }
+          ])
         } else {
-          assert.deepEqual(
-            state.toast.messages,
-            [{
+          assert.deepEqual(state.toast.messages, [
+            {
               key:     "collection-updated",
               content: "Changes saved",
               icon:    "check"
-            }]
-          )
+            }
+          ])
         }
       })
-
 
       it("updates collections list for drawer", async () => {
         const stubs = {
           // Stub dispatch to return collection, per isNew=true condition.
           dispatch: sandbox.stub().returns(Promise.resolve(collection)),
-          history:            {
-            push: sandbox.stub(),
+          history:  {
+            push: sandbox.stub()
           },
           collectionsListGet:  sandbox.stub(actions.collectionsList, "get"),
-          collectionsListPost: (
-            sandbox.stub(actions.collectionsList, "post")
-              .returns(Promise.resolve(collection))
-          ),
-          collectionsPatch:    (
-            sandbox.stub(actions.collections, "patch")
-              .returns(Promise.resolve())
-          ),
+          collectionsListPost: sandbox
+            .stub(actions.collectionsList, "post")
+            .returns(Promise.resolve(collection)),
+          collectionsPatch: sandbox
+            .stub(actions.collections, "patch")
+            .returns(Promise.resolve())
         }
         const wrapper = shallow(
           <UnconnectedCollectionFormDialog
             dispatch={stubs.dispatch}
             history={stubs.history}
-            collectionUi={{isNew}}
+            collectionUi={{ isNew }}
             collectionForm={{}}
           />
         )

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -28,6 +28,7 @@ import type { Video } from "../flow/videoTypes"
 import type { CommonUiState } from "../reducers/commonUi"
 import * as commonUiActions from "../actions/commonUi"
 import VideoSaverScript from "../components/VideoSaverScript"
+import { clearCollectionErrors } from "../actions/collectionUi"
 
 export class CollectionDetailPage extends React.Component<*, void> {
   props: {
@@ -46,7 +47,10 @@ export class CollectionDetailPage extends React.Component<*, void> {
   }
 
   updateRequirements() {
-    const { dispatch, needsUpdate, collectionKey } = this.props
+    const { dispatch, needsUpdate, collectionKey, collectionError } = this.props
+    if (collectionError) {
+      dispatch(clearCollectionErrors())
+    }
     if (needsUpdate) {
       dispatch(actions.collections.get(collectionKey))
     }
@@ -68,7 +72,7 @@ export class CollectionDetailPage extends React.Component<*, void> {
         <WithDrawer>
           <VideoSaverScript />
           <div className="collection-detail-content">
-            {!collection && collectionError
+            {collectionError
               ? this.renderError(collectionError)
               : this.renderBody()}
           </div>

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -68,7 +68,7 @@ export class CollectionDetailPage extends React.Component<*, void> {
         <WithDrawer>
           <VideoSaverScript />
           <div className="collection-detail-content">
-            {collectionError
+            {!collection && collectionError
               ? this.renderError(collectionError)
               : this.renderBody()}
           </div>

--- a/static/js/containers/CollectionDetailPage_test.js
+++ b/static/js/containers/CollectionDetailPage_test.js
@@ -212,26 +212,28 @@ describe("CollectionDetailPage", () => {
         assert.isTrue(wrapper.find("Connect(WithDrawer)").exists())
       })
 
-      //
-      ;[true, false].forEach(hasCollectionData => {
-        [true, false].forEach(hasCollectionError => {
-          const displayError = !hasCollectionData && hasCollectionError
-          it(`will ${
-            displayError ? "" : " not"
-          } render error instead of detail page`, () => {
-            wrapper = render({
-              collectionError: hasCollectionError ? "some error" : undefined,
-              collection:      hasCollectionData ? collection : undefined
-            })
-            assert.equal(
-              wrapper.instance().renderError.calledWith("some error"),
-              displayError
-            )
-            assert.equal(
-              wrapper.instance().renderBody.calledOnce,
-              hasCollectionData
-            )
-          })
+      describe("when there is an error", () => {
+        beforeEach(() => {
+          wrapper = render({ collectionError: "someError" })
+        })
+
+        it("renders error", () => {
+          sinon.assert.calledWith(
+            wrapper.instance().renderError,
+            wrapper.instance().props.collectionError
+          )
+          sinon.assert.notCalled(wrapper.instance().renderBody)
+        })
+      })
+
+      describe("when there is no error", () => {
+        beforeEach(() => {
+          wrapper = render({ collectionError: undefined })
+        })
+
+        it("renders body", () => {
+          sinon.assert.called(wrapper.instance().renderBody)
+          sinon.assert.notCalled(wrapper.instance().renderError)
         })
       })
     })
@@ -427,10 +429,7 @@ describe("CollectionDetailPage", () => {
 
     describe("renderDescription", () => {
       // $FlowFixMe: defaults are ok.
-      const renderDescription = ({
-        extraProps = {},
-        description = ""
-      } = {}) => {
+      const renderDescription = ({extraProps = {}, description = ""} = {}) => {
         page = new CollectionDetailPage({ ...props, ...extraProps })
         return shallow(<div>{page.renderDescription(description)}</div>)
       }
@@ -456,11 +455,7 @@ describe("CollectionDetailPage", () => {
 
     describe("renderVideos", () => {
       // $FlowFixMe: defaults are ok.
-      const renderVideos = ({
-        extraProps = {},
-        videos = [],
-        isAdmin = true
-      } = {}) => {
+      const renderVideos = ({extraProps = {}, videos = [], isAdmin = true} = {}) => {
         page = new CollectionDetailPage({ ...props, ...extraProps })
         // $FlowFixMe: isAdmin is ok.
         return shallow(<div>{page.renderVideos(videos, isAdmin)}</div>)
@@ -532,11 +527,7 @@ describe("CollectionDetailPage", () => {
         // dorska, 2018-05-10.
 
         // $FlowFixMe: defaults are ok.
-        const showVideoDialog = ({
-          extraProps = {},
-          dialogName = "",
-          videoKey = ""
-        } = {}) => {
+        const showVideoDialog = ({extraProps = {}, dialogName = "", videoKey = ""} = {}) => {
           // $FlowFixMe: Constructor call is intentional.
           page = new CollectionDetailPage({ ...props, ...extraProps })
           page.showVideoDialog(dialogName, videoKey)

--- a/static/js/containers/CollectionDetailPage_test.js
+++ b/static/js/containers/CollectionDetailPage_test.js
@@ -212,28 +212,26 @@ describe("CollectionDetailPage", () => {
         assert.isTrue(wrapper.find("Connect(WithDrawer)").exists())
       })
 
-      describe("when there is an error", () => {
-        beforeEach(() => {
-          wrapper = render({ collectionError: "someError" })
-        })
-
-        it("renders error", () => {
-          sinon.assert.calledWith(
-            wrapper.instance().renderError,
-            wrapper.instance().props.collectionError
-          )
-          sinon.assert.notCalled(wrapper.instance().renderBody)
-        })
-      })
-
-      describe("when there is no error", () => {
-        beforeEach(() => {
-          wrapper = render({ collectionError: undefined })
-        })
-
-        it("renders body", () => {
-          sinon.assert.called(wrapper.instance().renderBody)
-          sinon.assert.notCalled(wrapper.instance().renderError)
+      //
+      ;[true, false].forEach(hasCollectionData => {
+        [true, false].forEach(hasCollectionError => {
+          const displayError = !hasCollectionData && hasCollectionError
+          it(`will ${
+            displayError ? "" : " not"
+          } render error instead of detail page`, () => {
+            wrapper = render({
+              collectionError: hasCollectionError ? "some error" : undefined,
+              collection:      hasCollectionData ? collection : undefined
+            })
+            assert.equal(
+              wrapper.instance().renderError.calledWith("some error"),
+              displayError
+            )
+            assert.equal(
+              wrapper.instance().renderBody.calledOnce,
+              hasCollectionData
+            )
+          })
         })
       })
     })
@@ -429,7 +427,10 @@ describe("CollectionDetailPage", () => {
 
     describe("renderDescription", () => {
       // $FlowFixMe: defaults are ok.
-      const renderDescription = ({extraProps = {}, description = ""} = {}) => {
+      const renderDescription = ({
+        extraProps = {},
+        description = ""
+      } = {}) => {
         page = new CollectionDetailPage({ ...props, ...extraProps })
         return shallow(<div>{page.renderDescription(description)}</div>)
       }
@@ -455,7 +456,11 @@ describe("CollectionDetailPage", () => {
 
     describe("renderVideos", () => {
       // $FlowFixMe: defaults are ok.
-      const renderVideos = ({extraProps = {}, videos = [], isAdmin = true} = {}) => {
+      const renderVideos = ({
+        extraProps = {},
+        videos = [],
+        isAdmin = true
+      } = {}) => {
         page = new CollectionDetailPage({ ...props, ...extraProps })
         // $FlowFixMe: isAdmin is ok.
         return shallow(<div>{page.renderVideos(videos, isAdmin)}</div>)
@@ -527,7 +532,11 @@ describe("CollectionDetailPage", () => {
         // dorska, 2018-05-10.
 
         // $FlowFixMe: defaults are ok.
-        const showVideoDialog = ({extraProps = {}, dialogName = "", videoKey = ""} = {}) => {
+        const showVideoDialog = ({
+          extraProps = {},
+          dialogName = "",
+          videoKey = ""
+        } = {}) => {
           // $FlowFixMe: Constructor call is intentional.
           page = new CollectionDetailPage({ ...props, ...extraProps })
           page.showVideoDialog(dialogName, videoKey)

--- a/static/js/reducers/collections.js
+++ b/static/js/reducers/collections.js
@@ -1,8 +1,10 @@
 // @flow
 import { GET, PATCH, POST, INITIAL_STATE } from "redux-hammock/constants"
+import R from "ramda"
 
 import * as api from "../lib/api"
 import type { Collection, CollectionList } from "../flow/collectionTypes"
+import { CLEAR_COLLECTION_ERRORS } from "../actions/collectionUi"
 
 export const collectionsListEndpoint = {
   name:               "collectionsList",
@@ -11,7 +13,7 @@ export const collectionsListEndpoint = {
   getFunc:            (): Promise<CollectionList> => api.getCollections(),
   postFunc:           (collection: Collection) => api.createCollection(collection),
   postSuccessHandler: (payload: Collection, data: Object) => {
-    return {results: [payload, ...(data ? data.results || [] : [])]}
+    return { results: [payload, ...(data ? data.results || [] : [])] }
   }
 }
 
@@ -22,7 +24,10 @@ export const collectionsEndpoint = {
   getFunc:      (collectionKey: string): Promise<Collection> =>
     api.getCollection(collectionKey),
   patchFunc: (collectionKey: string, payload: Object): Promise<Collection> =>
-    api.updateCollection(collectionKey, payload)
+    api.updateCollection(collectionKey, payload),
+  extraActions: {
+    [CLEAR_COLLECTION_ERRORS]: R.dissoc("error")
+  }
 }
 
 export const uploadVideoEndpoint = {


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #680 

#### What's this PR do?
Clears collection errors from state at the end of `CollectionFormDialog.handleError()` and also in `CollectionDetailPage.updateRequirements()`

#### How should this be manually tested?
- Go to any collection detail page and open the edit dialog.  
- Make the title blank and submit.  A validation error message should appear under the title field.  The collection detail page in the background should continue to display as before, and not show an error message.
- Correct the title and submit.  The collection detail page should display with the new title.
- In another browser, log in as a user who does not have permission to view that collection and go to the collection detail page.  You should see an error page indicating that you don't have the required permissions.

