### PR TITLE
Configure raven.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "prettier-eslint-cli": "^4.7.0",
     "prop-types": "^15.5.10",
     "ramda": "^0.24.1",
+    "raven-js": "^3.26.4",
     "react": "^15.6.1",
     "react-addons-shallow-compare": "^15.6.0",
     "react-document-title": "^2.0.3",

--- a/static/js/entry/collections.js
+++ b/static/js/entry/collections.js
@@ -10,6 +10,15 @@ import { createBrowserHistory } from "history"
 import configureStore from "../store/configureStore"
 import Router, { routes } from "../Router"
 
+import Raven from "raven-js"
+
+Raven.config(SETTINGS.sentry_dsn, {
+  release:     SETTINGS.release_version,
+  environment: SETTINGS.environment
+}).install()
+
+window.Raven = Raven
+
 // Object.entries polyfill
 import entries from "object.entries"
 if (!Object.entries) {

--- a/static/js/entry/error.js
+++ b/static/js/entry/error.js
@@ -9,6 +9,15 @@ import { Provider } from "react-redux"
 import ErrorPage from "../containers/ErrorPage"
 import configureStore from "../store/configureStore"
 
+import Raven from "raven-js"
+
+Raven.config(SETTINGS.sentry_dsn, {
+  release:     SETTINGS.release_version,
+  environment: SETTINGS.environment
+}).install()
+
+window.Raven = Raven
+
 // Object.entries polyfill
 import entries from "object.entries"
 if (!Object.entries) {

--- a/static/js/entry/help_page.js
+++ b/static/js/entry/help_page.js
@@ -10,6 +10,15 @@ import HelpPage from "../containers/HelpPage"
 
 import configureStore from "../store/configureStore"
 
+import Raven from "raven-js"
+
+Raven.config(SETTINGS.sentry_dsn, {
+  release:     SETTINGS.release_version,
+  environment: SETTINGS.environment
+}).install()
+
+window.Raven = Raven
+
 // Object.entries polyfill
 import entries from "object.entries"
 if (!Object.entries) {

--- a/static/js/entry/terms_page.js
+++ b/static/js/entry/terms_page.js
@@ -10,6 +10,15 @@ import TermsPage from "../containers/TermsPage"
 
 import configureStore from "../store/configureStore"
 
+import Raven from "raven-js"
+
+Raven.config(SETTINGS.sentry_dsn, {
+  release:     SETTINGS.release_version,
+  environment: SETTINGS.environment
+}).install()
+
+window.Raven = Raven
+
 // Object.entries polyfill
 import entries from "object.entries"
 if (!Object.entries) {

--- a/static/js/entry/video_detail.js
+++ b/static/js/entry/video_detail.js
@@ -10,6 +10,15 @@ import VideoDetailPage from "../containers/VideoDetailPage"
 
 import configureStore from "../store/configureStore"
 
+import Raven from "raven-js"
+
+Raven.config(SETTINGS.sentry_dsn, {
+  release:     SETTINGS.release_version,
+  environment: SETTINGS.environment
+}).install()
+
+window.Raven = Raven
+
 // Object.entries polyfill
 import entries from "object.entries"
 if (!Object.entries) {

--- a/static/js/entry/video_embed.js
+++ b/static/js/entry/video_embed.js
@@ -10,6 +10,16 @@ import { Provider } from "react-redux"
 import configureStore from "../store/configureStore"
 import VideoEmbedPage from "../containers/VideoEmbedPage"
 
+import Raven from "raven-js"
+
+Raven.config(SETTINGS.sentry_dsn, {
+  release:     SETTINGS.release_version,
+  environment: SETTINGS.environment
+}).install()
+
+window.Raven = Raven
+
+
 // Object.entries polyfill
 import entries from "object.entries"
 if (!Object.entries) {

--- a/static/js/flow/declarations.js
+++ b/static/js/flow/declarations.js
@@ -18,7 +18,10 @@ declare var SETTINGS: {
   support_email_address: string,
   status_code?: number,
   is_admin: boolean,
-  ga_dimension_camera: string
+  ga_dimension_camera: string,
+  sentry_dsn: string,
+  release_version: string,
+  environment: string
 };
 
 // mocha

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -8,6 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
     {% load raven %}
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
+    {% load raven %}
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
     <script type="text/javascript">

--- a/ui/views.py
+++ b/ui/views.py
@@ -17,6 +17,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import TemplateView
+from raven.contrib.django.raven_compat.models import client as sentry
 from rest_framework import (
     authentication,
     permissions,
@@ -55,6 +56,9 @@ def default_js_settings(request):
     """Default JS settings for views"""
     return {
         "gaTrackingID": settings.GA_TRACKING_ID,
+        "environment": settings.ENVIRONMENT,
+        "sentry_dsn": sentry.get_public_dsn(),
+        "release_version": settings.VERSION,
         "public_path": public_path(request),
         "cloudfront_base_url": settings.VIDEO_CLOUDFRONT_BASE_URL,
         "user": request.user.username if request.user.is_authenticated else None,

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -113,6 +113,8 @@ def test_video_detail(logged_in_client, settings):
     client, user = logged_in_client
     settings.GA_DIMENSION_CAMERA = 'camera1'
     settings.GA_TRACKING_ID = 'UA-xyz-1'
+    settings.ENVIRONMENT = 'test'
+    settings.VERSION = '1.2.3'
     settings.ENABLE_VIDEO_PERMISSIONS = False
     videofileHLS = VideoFileFactory(hls=True, video__collection__owner=user)
     videofileHLS.video.status = 'Complete'
@@ -122,6 +124,9 @@ def test_video_detail(logged_in_client, settings):
     assert js_settings_json == {
         'editable': True,
         "gaTrackingID": settings.GA_TRACKING_ID,
+        'environment': settings.ENVIRONMENT,
+        'release_version': settings.VERSION,
+        'sentry_dsn': None,
         "ga_dimension_camera": settings.GA_DIMENSION_CAMERA,
         "public_path": '/static/bundles/',
         "videoKey": videofileHLS.video.hexkey,
@@ -141,6 +146,8 @@ def test_video_embed(logged_in_client, settings):  # pylint: disable=redefined-o
     client, user = logged_in_client
     settings.GA_DIMENSION_CAMERA = 'camera1'
     settings.GA_TRACKING_ID = 'UA-xyz-1'
+    settings.ENVIRONMENT = 'test'
+    settings.VERSION = '1.2.3'
     settings.ENABLE_VIDEO_PERMISSIONS = False
     videofileHLS = VideoFileFactory(
         hls=True,
@@ -155,6 +162,9 @@ def test_video_embed(logged_in_client, settings):  # pylint: disable=redefined-o
     assert js_settings_json == {
         "video": VideoSerializer(video).data,
         "gaTrackingID": settings.GA_TRACKING_ID,
+        'release_version': settings.VERSION,
+        'environment': settings.ENVIRONMENT,
+        'sentry_dsn': None,
         "ga_dimension_camera": settings.GA_DIMENSION_CAMERA,
         "public_path": "/static/bundles/",
         "cloudfront_base_url": settings.VIDEO_CLOUDFRONT_BASE_URL,
@@ -739,6 +749,8 @@ def test_page_not_found(url, logged_in_apiclient, settings):
     """
     settings.VIDEO_CLOUDFRONT_BASE_URL = 'cloudfront_base_url'
     settings.GA_TRACKING_ID = 'tracking_id'
+    settings.ENVIRONMENT = 'test'
+    settings.VERSION = '1.2.3'
     settings.GA_DIMENSION_CAMERA = 'camera1'
     settings.EMAIL_SUPPORT = 'support'
     settings.ENABLE_VIDEO_PERMISSIONS = False
@@ -749,6 +761,9 @@ def test_page_not_found(url, logged_in_apiclient, settings):
     assert json.loads(resp.context[0]['js_settings_json']) == {
         'cloudfront_base_url': settings.VIDEO_CLOUDFRONT_BASE_URL,
         'gaTrackingID': settings.GA_TRACKING_ID,
+        'environment': settings.ENVIRONMENT,
+        'release_version': settings.VERSION,
+        'sentry_dsn': None,
         "ga_dimension_camera": settings.GA_DIMENSION_CAMERA,
         'public_path': '/static/bundles/',
         'status_code': status.HTTP_404_NOT_FOUND,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5826,6 +5826,10 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven-js@^3.26.4:
+  version "3.26.4"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.4.tgz#32aae3a63a9314467a453c94c89a364ea43707be"
+
 rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"


### PR DESCRIPTION
#### What are the relevant tickets?
See also https://github.com/mitodl/open-discussions/pull/1142

#### What's this PR do?
Configures raven.js so Sentry will catch front end errors

#### How should this be manually tested?
In the PR build, go to the homepage and open up the browser console. Type:

    var body = document.getElementsByTagName("body")
    var script = document.createElement("script")
    script.innerHTML = "throw new Error('something unique to make it obviously a test')"
    body.append(script)

You should see an exception in the console. If you open up the stack trace of the exception there should be some mention of raven (not sure if this is true for all browsers). Go to Sentry and verify that it caught an error with the error text from a CI environment.
