### PR TITLE
remove target from mailto links in faq

### DIFF
--- a/static/js/data/faqs.js
+++ b/static/js/data/faqs.js
@@ -34,9 +34,7 @@ export const sectionFAQs = {
           Some rooms on campus at MIT have been configured to automatically
           record lectures using multiple cameras. Currently these rooms include
           2-131, 2-190, 6-120 and 34-101. Recording requests should be sent to{" "}
-          <a
-            href={`mailto:${SETTINGS.support_email_address}`}
-          >
+          <a href={`mailto:${SETTINGS.support_email_address}`}>
             {SETTINGS.support_email_address}
           </a>
         </div>
@@ -53,9 +51,7 @@ export const sectionFAQs = {
         Automated lecture capture is currently available in rooms 2-131, 2-190,
         6-120 and 34-101. You can request that your lectures be recorded by
         sending an email to{" "}
-        <a
-          href={`mailto:${SETTINGS.support_email_address}`}
-        >
+        <a href={`mailto:${SETTINGS.support_email_address}`}>
           {SETTINGS.support_email_address}
         </a>
       </div>
@@ -75,9 +71,7 @@ export const sectionFAQs = {
         <li>Anyone in the MIT community can host videos on OVS.</li>
         <li>
           To request permission to upload your own videos, contact:{" "}
-          <a
-            href={`mailto:${SETTINGS.support_email_address}`}
-          >
+          <a href={`mailto:${SETTINGS.support_email_address}`}>
             {SETTINGS.support_email_address}
           </a>
         </li>

--- a/static/js/data/faqs.js
+++ b/static/js/data/faqs.js
@@ -36,8 +36,6 @@ export const sectionFAQs = {
           2-131, 2-190, 6-120 and 34-101. Recording requests should be sent to{" "}
           <a
             href={`mailto:${SETTINGS.support_email_address}`}
-            target="_blank"
-            rel="noopener noreferrer"
           >
             {SETTINGS.support_email_address}
           </a>
@@ -57,8 +55,6 @@ export const sectionFAQs = {
         sending an email to{" "}
         <a
           href={`mailto:${SETTINGS.support_email_address}`}
-          target="_blank"
-          rel="noopener noreferrer"
         >
           {SETTINGS.support_email_address}
         </a>
@@ -81,8 +77,6 @@ export const sectionFAQs = {
           To request permission to upload your own videos, contact:{" "}
           <a
             href={`mailto:${SETTINGS.support_email_address}`}
-            target="_blank"
-            rel="noopener noreferrer"
           >
             {SETTINGS.support_email_address}
           </a>


### PR DESCRIPTION
#### What are the relevant tickets?

fixup to #686 

#### What's this PR do?

removes `target="_blank"` from mailto links in FAQ

#### How should this be manually tested?

Click on a mailto link in the FAQ. See that it doesn't open a new tab/window. 

#### Any background context you want to provide?

we don't need `nofollow` and `noreferrer` either for mailto links. 

I am a little too lazy to replace the hard-coded mailto links. If that offends you, just add it to your comments. =)

