### PR TITLE
Fix video start time in Safari

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -369,12 +369,12 @@ class VideoPlayer extends React.Component<*, void> {
           gaEvents.forEach((event: string) => {
             createEventHandler(event, video.key)
           })
+          const params = new URLSearchParams(window.location.search)
+          this.currentTime(parseInt(params.get("start")) || 0)
         })
         if (this.tech_.hls !== undefined) {
           this.tech_.hls.selectPlaylist = selectPlaylist
         }
-        const params = new URLSearchParams(window.location.search)
-        this.currentTime(parseInt(params.get("start")) || 0)
       }
     )
     if (useYouTube) {

--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -127,16 +127,13 @@ describe("VideoPlayer", () => {
         })
         const enableTouchActivityStub = sandbox.stub()
         const onStub = sandbox.stub()
-        const timeStub = sandbox.stub()
         args[2].call({
           enableTouchActivity: enableTouchActivityStub,
           on:                  onStub,
-          currentTime:         timeStub,
           tech_:               { hls: {} }
         })
         sinon.assert.calledWith(enableTouchActivityStub)
         sinon.assert.calledWith(onStub)
-        sinon.assert.calledWith(timeStub)
         if (video.multiangle) {
           sinon.assert.calledWith(gaSetStub, {
             dimension1: "camera1"


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #697

#### What's this PR do?
Use the on `loademetadata` listener to set the start time of the video.

#### How should this be manually tested?
Open a video with the start time specified in Safari, the video should start at the specified time.

