### PR TITLE
Added default sorting to created_at descending

### DIFF
--- a/ui/views.py
+++ b/ui/views.py
@@ -397,7 +397,8 @@ class VideoViewSet(mixins.ListModelMixin, ModelDetailViewset):
     )
     pagination_class = VideoSetPagination
     filter_backends = (OrderingFilter,)
-    ordering_fields = ('created_at', 'title')
+    ordering_fields = ('created_at', 'title', )
+    ordering = ('-created_at',)
 
     def get_queryset(self):
         return Video.objects.all_viewable(self.request.user)


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/odl-video-service/issues/700

#### What's this PR do?
It sorts videos by default on the base of created date in descending order. You can also sort by title from url.

#### How should this be manually tested?
Go to collection page http://od.odl.local:8089/collections/?

@pdpinch 

#### Screenshots (if appropriate)
<img width="1235" alt="screen shot 2018-10-08 at 6 01 42 pm" src="https://user-images.githubusercontent.com/10431250/46610464-41eb4900-cb24-11e8-805e-96c024bd7f25.png">

