### PR TITLE
Change no-videos message for anonymous

### DIFF
--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -195,11 +195,12 @@ export class CollectionDetailPage extends React.Component<*, void> {
   renderEmptyVideoMessage(isAdmin: boolean) {
     let message = "There are no public videos available for viewing."
     if (isAdmin) {
-      message = "There are no videos yet. Click the button above to add videos from a linked Dropbox account."
+      message =
+        "There are no videos yet. Click the button above to add videos from a linked Dropbox account."
     }
     return (
       <div className="no-videos">
-        <p>{ message }</p>
+        <p>{message}</p>
       </div>
     )
   }

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -193,14 +193,16 @@ export class CollectionDetailPage extends React.Component<*, void> {
   }
 
   renderEmptyVideoMessage(isAdmin: boolean) {
-    let message = "There are no public videos available for viewing."
+    const { collectionKey } = this.props
+
+    let message = <p>There are no public videos available for viewing. Please{" "}
+      <a href={`/login/?next=/collections/${collectionKey}`}>login</a> to view private videos.</p>
     if (isAdmin) {
-      message =
-        "There are no videos yet. Click the button above to add videos from a linked Dropbox account."
+      message = <p>There are no videos yet. Click the button above to add videos from a linked Dropbox account.</p>
     }
     return (
       <div className="no-videos">
-        <p>{message}</p>
+        {message}
       </div>
     )
   }

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -195,16 +195,22 @@ export class CollectionDetailPage extends React.Component<*, void> {
   renderEmptyVideoMessage(isAdmin: boolean) {
     const { collectionKey } = this.props
 
-    let message = <p>There are no public videos available for viewing. Please{" "}
-      <a href={`/login/?next=/collections/${collectionKey}`}>login</a> to view private videos.</p>
-    if (isAdmin) {
-      message = <p>There are no videos yet. Click the button above to add videos from a linked Dropbox account.</p>
-    }
-    return (
-      <div className="no-videos">
-        {message}
-      </div>
+    let message = (
+      <p>
+        There are no public videos available for viewing. Please{" "}
+        <a href={`/login/?next=/collections/${collectionKey}`}>login</a> to view
+        private videos.
+      </p>
     )
+    if (isAdmin) {
+      message = (
+        <p>
+          There are no videos yet. Click the button above to add videos from a
+          linked Dropbox account.
+        </p>
+      )
+    }
+    return <div className="no-videos">{message}</div>
   }
 
   showVideoMenu(videoKey: string) {

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -174,7 +174,7 @@ export class CollectionDetailPage extends React.Component<*, void> {
 
   renderVideos(videos: Array<Video>, isAdmin: boolean) {
     if (videos.length === 0) {
-      return this.renderEmptyVideoMessage()
+      return this.renderEmptyVideoMessage(isAdmin)
     }
     return (
       <VideoList
@@ -192,13 +192,14 @@ export class CollectionDetailPage extends React.Component<*, void> {
     )
   }
 
-  renderEmptyVideoMessage() {
+  renderEmptyVideoMessage(isAdmin: boolean) {
+    let message = "There are no public videos available for viewing."
+    if (isAdmin) {
+      message = "There are no videos yet. Click the button above to add videos from a linked Dropbox account."
+    }
     return (
       <div className="no-videos">
-        <h3>You have not added any videos yet.</h3>
-        <p>
-          Click the button above to add videos from a linked Dropbox account.
-        </p>
+        <p>{ message }</p>
       </div>
     )
   }

--- a/static/js/containers/CollectionDetailPage_test.js
+++ b/static/js/containers/CollectionDetailPage_test.js
@@ -477,6 +477,15 @@ describe("CollectionDetailPage", () => {
         )
       })
 
+      it("renders 'no videos' message for anonymous", () => {
+        assert.equal(
+          renderVideos({ videos: [], isAdmin: false })
+            .find(".no-videos a")
+            .text(),
+          "login"
+        )
+      })
+
       describe("when there are videos", () => {
         const videos = makeCollection().videos
         const isAdmin = "someIsAdminValue"


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #718

#### What's this PR do?
If an anonymous user tries to view a collection's detail page and there are no public videos the message should be different: 
<img width="624" alt="screen shot 2018-10-22 at 9 54 05 am" src="https://user-images.githubusercontent.com/7574259/47296700-174bc680-d5e1-11e8-8d22-1b6c85248285.png">

<img width="1398" alt="screen shot 2018-10-22 at 10 17 05 am" src="https://user-images.githubusercontent.com/7574259/47297674-bec9f880-d5e3-11e8-8c54-bdb63872452d.png">



#### How should this be manually tested?
Try to access a collections page with no public videos.