### PR TITLE
Handle bad video duration values for the analytics chart

### DIFF
--- a/static/js/components/analytics/AnalyticsChart.js
+++ b/static/js/components/analytics/AnalyticsChart.js
@@ -108,7 +108,12 @@ export class AnalyticsChart extends React.Component {
     return (
       <VictoryChart
         {...dimensions}
-        domain={{ x: [0, duration / 60 || 1] }}
+        domain={{
+          x: [
+            0,
+            duration > 0 ? duration / 60 : analyticsData.times.slice(-1)[0]
+          ]
+        }}
         domainPadding={{ x: [0, 0], y: [0, 0] }}
         padding={padding}
       >

--- a/static/js/components/analytics/AnalyticsChart.js
+++ b/static/js/components/analytics/AnalyticsChart.js
@@ -105,14 +105,15 @@ export class AnalyticsChart extends React.Component {
     const chartBodyClipPathId = `${this._namespace}-chart-body-clipPath`
     const chartBodyBounds = this._getRelativeChartBodyBounds()
     const yTicks = this._getYTicks({ analyticsData })
+    const xMax =
+      duration > 0
+        ? duration / 60
+        : analyticsData.times ? analyticsData.times.slice(-1)[0] : 0
     return (
       <VictoryChart
         {...dimensions}
         domain={{
-          x: [
-            0,
-            duration > 0 ? duration / 60 : analyticsData.times.slice(-1)[0]
-          ]
+          x: [0, xMax]
         }}
         domainPadding={{ x: [0, 0], y: [0, 0] }}
         padding={padding}

--- a/static/js/lib/test_utils.js
+++ b/static/js/lib/test_utils.js
@@ -20,3 +20,5 @@ export const assertIsJust = (m: Maybe, val: any) => {
 export const assertIsJustNoVal = (m: Maybe) => {
   assert(m.isJust, "should be a Just")
 }
+
+export const shouldIf = (tf: boolean) => (tf ? "should" : "should not")


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #729 

#### What's this PR do?
If the video duration reported by the VideoJS player is 0 or NaN, the latest minute interval from the analytics data will be used as the duration instead when generating the analytics graph.

#### How should this be manually tested?
- VideoJS can't seem to determine Youtube video lengths, so create/update a collection to have `stream_source=Youtube`, and associate a public video in that collection to a YoutubeVideo (you can do this from the admin console).
- Temporarily modify `ui.views.VideoViewSet.analytics` to always return mock data.
- Load the video detail page and click the analytics link.  On this branch you should see a valid graph.  On the master branch only minute 0 will have data.

