### PR TITLE
Filter out bad analytics data

### DIFF
--- a/ui/utils.py
+++ b/ui/utils.py
@@ -327,10 +327,11 @@ def parse_google_analytics_response(ga_response):
             channel = row['dimensions'][1]
         else:
             channel = 'views'
-        viewers = int(row['metrics'][0]['values'][0])
-        views_at_times.setdefault(time_, {}).update({channel: viewers})
-        times.add(time_)
-        channels.add(channel)
+        if re.match(r'camera\d+|views', channel):
+            viewers = int(row['metrics'][0]['values'][0])
+            views_at_times.setdefault(time_, {}).update({channel: viewers})
+            times.add(time_)
+            channels.add(channel)
     return {
         'times': sorted(list(times)),
         'channels': sorted(list(channels)),

--- a/ui/utils_test.py
+++ b/ui/utils_test.py
@@ -268,6 +268,10 @@ def test_parse_google_analytics_response_multiangle():
                         "dimensions": ["T0002", "camera2"],
                         "metrics": [{"values": ["3"]}]
                     },
+                    {
+                        "dimensions": ["T0002", "Bad channel"],
+                        "metrics": [{"values": ["3"]}]
+                    },
                 ],
                 "totals": [{"values": ["30"]}]
             }


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #728

#### What's this PR do?
Filters out any bad 'channels' in the analytics data that are not expected before generating a graph.

#### How should this be manually tested?
- Temporarily modify `ui.utils.get_video_analytics` to parse fake data with a bad channel:
```python
def get_video_analytics(video):
    """Get video analytics data from Google Analytics."""
    ga_client = get_google_analytics_client()
    ga_response = ga_client.reports().batchGet(
        body=generate_google_analytics_query(video)).execute()
    try:
        mock_response = {
            "reports": [{
                "columnHeader": {
                    "dimensions": ["ga:eventAction", "ga:dimension1"],
                    "metricHeader": {
                        "metricHeaderEntries": [
                            {
                                "name": "ga:totalEvents",
                                "type": "INTEGER"
                            },
                        ]
                    },
                },
                "data": {
                    "maximums": [{"values": ["2"]}],
                    "minimums": [{"values": ["1"]}],
                    "rowCount": 5,
                    "rows": [
                        {
                            "dimensions": ["changeCameraView", "camera2"],
                            "metrics": [{"values": ["16"]}]
                        },
                        {
                            "dimensions": ["Pause", "camera1"],
                            "metrics": [{"values": ["4"]}]
                        },
                        {
                            "dimensions": ["T0000", "camera1"],
                            "metrics": [{"values": ["102"]}]
                        },
                        {
                            "dimensions": ["T0002", "camera1"],
                            "metrics": [{"values": ["98"]}]
                        },
                        {
                            "dimensions": ["T0002", "camera2"],
                            "metrics": [{"values": ["3"]}]
                        },
                        {
                            "dimensions": ["T0002", "Bad channel"],
                            "metrics": [{"values": ["3"]}]
                        },
                    ],
                    "totals": [{"values": ["30"]}]
                }
            }]
        }
        return parse_google_analytics_response(mock_response)
    except Exception as exc:
        raise GoogleAnalyticsException(
            'Could not parse analytics response') from exc
```
- Load the video detail page and click the analytics link. You should see a graph with data.
