### PR TITLE
views added for moira list and users

### DIFF
--- a/ui/urls.py
+++ b/ui/urls.py
@@ -37,4 +37,8 @@ urlpatterns = [
     url(r'^api/v0/upload_subtitles/$', views.UploadVideoSubtitle.as_view(),
         name='upload-subtitles'),
     url(r'^api/v0/', include((router.urls, 'models-api'))),
+
+    url(r'^api/v0/moira/user/(?P<username_or_email>[-\w]+$|[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)$',
+        views.MoiraListsForUser.as_view(), name='member-lists'),
+    url(r'^api/v0/moira/list/(?P<list_name>[-\w]+)$', views.UsersForMoiraList.as_view(), name='list-members'),
 ]

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
         name='upload-subtitles'),
     url(r'^api/v0/', include((router.urls, 'models-api'))),
 
-    url(r'^api/v0/moira/user/(?P<username_or_email>[-\w]+$|[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)$',
+    url(r'^api/v0/moira/user/(?P<username_or_email>[-\w]+$|.*@.*)$',
         views.MoiraListsForUser.as_view(), name='member-lists'),
     url(r'^api/v0/moira/list/(?P<list_name>[-\w]+)$', views.UsersForMoiraList.as_view(), name='list-members'),
 ]

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -360,3 +360,21 @@ def generate_mock_video_analytics_data(n=24, seed=42):
         'channels': sorted(list(channels)),
         'views_at_times': views_at_times,
     }
+
+
+def list_members(list_name):
+    """
+    Get a set of all moira users against given list name
+
+    Args:
+        list_name (str): name of list.
+
+    Returns:
+        list_users(list): A list of users
+    """
+    moira = get_moira_client()
+    try:
+        list_users = moira.list_members(list_name)
+        return list_users
+    except Exception as exc:  # pylint: disable=broad-except
+        raise MoiraException('Something went wrong with getting moira-users for %s' % list_name) from exc

--- a/ui/utils_test.py
+++ b/ui/utils_test.py
@@ -20,7 +20,7 @@ from ui.utils import (
     generate_google_analytics_query,
     parse_google_analytics_response,
     generate_mock_video_analytics_data,
-)
+    list_members)
 
 # pylint: disable=unused-argument, too-many-arguments
 
@@ -381,3 +381,12 @@ def test_generate_mock_video_analytics_data(n, seed, expected):
     """Test that returns expected result."""
     actual = generate_mock_video_analytics_data(n=n, seed=seed)
     assert actual == expected
+
+
+def test_list_members_exception(mock_moira_client):
+    """
+    Test that a Moira exception is raised if moira client call fails with anything other than a java NPE
+    """
+    mock_moira_client.return_value.list_members.side_effect = Exception("exception")
+    with pytest.raises(MoiraException):
+        list_members(factories.UserFactory())

--- a/ui/views.py
+++ b/ui/views.py
@@ -507,6 +507,7 @@ class MoiraListsForUser(APIView):
     permission_classes = (permissions.IsAdminUser,)
 
     def get(self, request, username_or_email):
+        """Get and return the list names"""
         regex = r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
 
         email = username_or_email
@@ -531,4 +532,5 @@ class UsersForMoiraList(APIView):
     permission_classes = (permissions.IsAdminUser,)
 
     def get(self, request, list_name):
+        """Get and return the users"""
         return Response(data={'users': list_members(list_name)})

--- a/ui/views.py
+++ b/ui/views.py
@@ -1,6 +1,5 @@
 """Views for ui app"""
 import json
-import re
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -508,12 +507,10 @@ class MoiraListsForUser(APIView):
 
     def get(self, request, username_or_email):
         """Get and return the list names"""
-        regex = r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
 
         email = username_or_email
-        if not username_or_email.endswith("@mit.edu"):
-            if not re.match(regex, username_or_email):
-                email = "{username}@mit.edu".format(username=username_or_email)
+        if '@' not in email:
+            email = "{username}@mit.edu".format(username=username_or_email)
 
         try:
             user = User.objects.get(Q(username=username_or_email) | Q(email=email))

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -1239,10 +1239,12 @@ def test_terms_of_service_for_logged_in_user(mock_user_moira_lists, owns_collect
         reverse('list-members', kwargs={'list_name': 'test_name'}),
     ]
 )
-def test_moira_list_views_permission(logged_in_apiclient, url):
+def test_moira_list_views_permission(logged_in_apiclient, mocker, url):
     """
     Tests that only authenticated users with admin permissions can call MoiraListsForUser and UsersForMoiraList
     """
+    mocker.patch('ui.views.list_members', return_value=[])
+
     client, user = logged_in_apiclient
     client.logout()
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -1288,11 +1288,15 @@ def test_users_moira_list(logged_in_apiclient, mock_moira_client):
         {'listName': list_name} for list_name in list_names
     ]
 
-    url = reverse('member-lists', kwargs={'username_or_email': user.username})
-    expected = {
-        "user_lists": list_names
-    }
-    response = client.get(url)
+    username_or_email = [user.username, user.email, UserFactory(email='username@mit.edu').email]
 
-    assert response.status_code == status.HTTP_200_OK
-    assert expected == response.data
+    for arg in username_or_email:
+        url = reverse('member-lists', kwargs={'username_or_email': arg})
+        expected = {
+            "user_lists": list_names
+        }
+
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert expected == response.data

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -1232,33 +1232,19 @@ def test_terms_of_service_for_logged_in_user(mock_user_moira_lists, owns_collect
     assert js_settings["editable"] == owns_collections or is_staff
 
 
-def test_moira_list_users_permission(logged_in_apiclient):
+@pytest.mark.parametrize(
+    'url',
+    [
+        reverse('member-lists', kwargs={'username_or_email': 'test_user'}),
+        reverse('list-members', kwargs={'list_name': 'test_name'}),
+    ]
+)
+def test_moira_list_views_permission(logged_in_apiclient, url):
     """
-    Tests that only authenticated users with admin permissions can call MoiraListsForUser
-    """
-    client, user = logged_in_apiclient
-    client.logout()
-    url = reverse('member-lists', kwargs={'username_or_email': 'test_user'})
-
-    # call with anonymous user
-    assert client.get(url).status_code == status.HTTP_403_FORBIDDEN
-    # call with another user not on admin list
-    client.force_login(user)
-    assert client.get(url).status_code == status.HTTP_403_FORBIDDEN
-    # call with user on admin list
-    user.is_staff = True
-    user.save()
-    client.force_login(user)
-    assert client.get(url).status_code == status.HTTP_200_OK
-
-
-def test_users_moira_lists_permission(logged_in_apiclient):
-    """
-    Tests that only authenticated users with admin permissions can call UsersForMoiraList
+    Tests that only authenticated users with admin permissions can call MoiraListsForUser and UsersForMoiraList
     """
     client, user = logged_in_apiclient
     client.logout()
-    url = reverse('list-members', kwargs={'list_name': 'test_name'})
 
     # call with anonymous user
     assert client.get(url).status_code == status.HTTP_403_FORBIDDEN

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -1230,3 +1230,43 @@ def test_terms_of_service_for_logged_in_user(mock_user_moira_lists, owns_collect
     assert response.status_code == status.HTTP_200_OK
     js_settings = json.loads(response.context_data["js_settings_json"])
     assert js_settings["editable"] == owns_collections or is_staff
+
+
+def test_moira_list_users_permission(logged_in_apiclient):
+    """
+    Tests that only authenticated users with admin permissions can call MoiraListsForUser
+    """
+    client, user = logged_in_apiclient
+    client.logout()
+    url = reverse('member-lists', kwargs={'username_or_email': 'test_user'})
+
+    # call with anonymous user
+    assert client.get(url).status_code == status.HTTP_403_FORBIDDEN
+    # call with another user not on admin list
+    client.force_login(user)
+    assert client.get(url).status_code == status.HTTP_403_FORBIDDEN
+    # call with user on admin list
+    user.is_staff = True
+    user.save()
+    client.force_login(user)
+    assert client.get(url).status_code == status.HTTP_200_OK
+
+
+def test_users_moira_lists_permission(logged_in_apiclient):
+    """
+    Tests that only authenticated users with admin permissions can call UsersForMoiraList
+    """
+    client, user = logged_in_apiclient
+    client.logout()
+    url = reverse('list-members', kwargs={'list_name': 'test_name'})
+
+    # call with anonymous user
+    assert client.get(url).status_code == status.HTTP_403_FORBIDDEN
+    # call with another user not on admin list
+    client.force_login(user)
+    assert client.get(url).status_code == status.HTTP_403_FORBIDDEN
+    # call with user on admin list
+    user.is_staff = True
+    user.save()
+    client.force_login(user)
+    assert client.get(url).status_code == status.HTTP_200_OK


### PR DESCRIPTION
#### What are the relevant tickets?
fixes #739 

#### What's this PR do?
Add following views
- The members of a moira list `/api/v0/moira/list/<list_name>`
- The moira lists a user belongs to `/api/v0/moira/user/<user_name or email>`

#### How should this be manually tested?
Test above views on your local.