### PR TITLE
Update django-hijack to 1.1.10

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -32,8 +32,8 @@ oauth2client==3.0.0
 google-api-python-client
 
 django-compat==1.0.15
-django-hijack==2.1.7
-django-hijack-admin==2.1.7
+django-hijack==2.1.10
+django-hijack-admin==2.1.10
 
 # Touchstone
 -e git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser==0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,8 +36,8 @@ defusedxml==0.5.0         # via zeep
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-compat==1.0.15
-django-hijack-admin==2.1.7
-django-hijack==2.1.7
+django-hijack-admin==2.1.10
+django-hijack==2.1.10
 django-redis==4.7.0
 django-server-status==0.5.0
 django-webpack-loader==0.5.0


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #759 

#### What's this PR do?
Updates django-hijack to version 1.1.10

#### How should this be manually tested?
Go to django admin users section, try to hijack another user.  It should load the collections page with no 500 errors.
