### PR TITLE
Changed edX auto-add to use edxval library endpoints

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,16 +33,12 @@
       "description": "Access token value for an edX admin user",
       "required": false
     },
-    "EDX_API_KEY": {
-      "description": "edX API key",
-      "required": false
-    },
     "EDX_BASE_URL": {
       "description": "Base URL for the edX API",
       "required": false
     },
     "EDX_HLS_API_URL": {
-      "default": "/api/course_videos/",
+      "default": "/api/val/v0/videos/",
       "description": "URL path for the HLS video endpoint on edX",
       "required": false
     },

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -541,6 +541,5 @@ HIJACK_ALLOW_GET_REQUESTS = True
 HIJACK_LOGOUT_REDIRECT_URL = '/admin/auth/user'
 
 EDX_ACCESS_TOKEN = get_string('EDX_ACCESS_TOKEN', None)
-EDX_API_KEY = get_string('EDX_API_KEY', None)
 EDX_BASE_URL = get_string('EDX_BASE_URL', None)
-EDX_HLS_API_URL = get_string('EDX_HLS_API_URL', '/api/course_videos/')
+EDX_HLS_API_URL = get_string('EDX_HLS_API_URL', '/api/val/v0/videos/')

--- a/odl_video/test_utils.py
+++ b/odl_video/test_utils.py
@@ -1,0 +1,24 @@
+"""Test suite utilities"""
+import abc
+
+
+def any_instance_of(*cls):
+    """
+    Returns a type that evaluates __eq__ in isinstance terms
+
+    Args:
+        cls (list of types): variable list of types to ensure equality against
+
+    Returns:
+        AnyInstanceOf: dynamic class type with the desired equality
+    """
+
+    class AnyInstanceOf(metaclass=abc.ABCMeta):
+        """Dynamic class type for __eq__ in terms of isinstance"""
+
+        def __eq__(self, other):
+            return isinstance(other, cls)
+
+    for c in cls:
+        AnyInstanceOf.register(c)
+    return AnyInstanceOf()

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -407,5 +407,4 @@ def edx_settings_configured():
         settings.EDX_BASE_URL,
         settings.EDX_HLS_API_URL,
         settings.EDX_ACCESS_TOKEN,
-        settings.EDX_API_KEY
     ))


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #765 

#### What's this PR do?
Changed edX auto-add to use `edx-val` library endpoints instead of using endpoints exposed by a new library

#### How should this be manually tested?
- Run devstack (the edX instance needs to have `edx-val` installed, and the `xpro/ironwood` branch already lists it as a requirement, so it should be ready to go)
- Add an access token for some edX admin user (Django admin path: `/admin/oauth2/accesstoken/`). **THINGS TO NOTE:** (1) edX has 2 different oauth libraries installed. This access token must be an object of the model represented by that Django admin path, and not the other access token model. (2) Feel free to create a new Client for this. The URLs don't matter.
- Add settings to your `.env`:
    ```
    EDX_ACCESS_TOKEN=<access token value for some admin user in edX>
    # OSX users
    EDX_BASE_URL=http://host.docker.internal:18000
    # Linux users
    EDX_BASE_URL=http://localhost:18000
    ```
- Set the `edx_course_id` value for some collection to a course id in your LMS instance (e.g.: `course-v1:edX+DemoX+Demo_Course`). This can be done in Django admin
- Add a video to that collection, wait it to transcode and for celery to process it once it finishes. If it's successful, you should see a celery log line for the successful request to, e.g.: `celery_1  | [2019-08-05 21:07:13,135: INFO/ForkPoolWorker-2] Task ui.tasks.post_hls_to_edx[4d4c0327-e272-4470-a984-9af23959f74f] succeeded in 0.1495262999960687s: 201` (the `201` is the response code)
