### PR TITLE
Updated Celery to 4.3.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 django==2.1.11
 boto3==1.4.4
-celery==4.2.0
-celery-redbeat==0.11.1
+celery==4.3.0
+celery-redbeat==0.13.0
 cryptography
 dj-database-url==0.3.0
 dj-static==0.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@
 #
 --no-binary psycopg2
 
-git+https://github.com/mitodl/pycaption.git#egg=pycaption
-amqp==2.2.1               # via kombu
+-e git+https://github.com/mitodl/pycaption.git#egg=pycaption
+amqp==2.5.2               # via kombu
 appdirs==1.4.3            # via fs, zeep
 appnope==0.1.0            # via ipython
 asn1crypto==0.22.0        # via cryptography
 beautifulsoup4==4.7.1
-billiard==3.5.0.3         # via celery
+billiard==3.6.1.0         # via celery
 bonobo==0.6.1
 boto3==1.4.4
 boto==2.48.0              # via smart-open
@@ -20,8 +20,8 @@ botocore==1.5.95          # via boto3, s3transfer
 bz2file==0.98             # via smart-open
 cached-property==1.3.0    # via zeep
 cachetools==2.0.1         # via google-auth
-celery-redbeat==0.11.1
-celery==4.2.0
+celery-redbeat==0.13.0
+celery==4.3.0
 certifi==2017.4.17        # via requests
 cffi==1.10.0              # via cryptography
 chardet==3.0.4            # via requests
@@ -58,17 +58,19 @@ graphviz==0.8.2           # via bonobo
 html5lib==0.999999999
 httplib2==0.10.3
 idna==2.5                 # via cryptography, requests
+importlib-metadata==0.23  # via kombu
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.1.0
 isodate==0.5.4            # via zeep
 jedi==0.10.2              # via ipython
 jinja2==2.10.1
 jmespath==0.9.3           # via boto3, botocore
-kombu==4.2.1              # via celery, django-server-status
+kombu==4.6.6              # via celery, django-server-status
 lxml==4.1.1               # via zeep
 markupsafe==1.0           # via jinja2
 git+https://github.com/mitodl/mit-moira.git#egg=mit-moira==0.0.4
 mondrian==0.8.0           # via bonobo
+more-itertools==7.2.0     # via zipp
 mysqlclient==1.3.12
 newrelic==4.2.0.100
 oauth2client==3.0.0
@@ -99,21 +101,23 @@ requests==2.21.0
 rsa==3.4.2                # via google-auth, google-auth-httplib2, oauth2client
 s3transfer==0.1.13        # via boto3
 simplegeneric==0.8.1      # via ipython
-six==1.10.0               # via cryptography, django-compat, django-server-status, dropbox, faker, fs, google-api-python-client, google-auth, google-auth-httplib2, html5lib, oauth2client, packaging, prompt-toolkit, pyopenssl, python-dateutil, stevedore, traitlets, zeep
+six==1.10.0               # via cryptography, django-compat, django-server-status, dropbox, faker, fs, google-api-python-client, google-auth, google-auth-httplib2, html5lib, oauth2client, packaging, prompt-toolkit, pyopenssl, python-dateutil, stevedore, tenacity, traitlets, zeep
 smart_open==1.5.7
 soupsieve==1.9.1          # via beautifulsoup4
 static3==0.7.0            # via dj-static
 stevedore==1.28.0         # via bonobo
+tenacity==6.0.0           # via celery-redbeat
 traitlets==4.3.2          # via ipython
 unidecode==1.0.22         # via python-slugify
 uritemplate==3.0.0        # via google-api-python-client
 urllib3==1.24.3
 uwsgi==2.0.15
-vine==1.1.4               # via amqp
+vine==1.3.0               # via amqp, celery
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via html5lib
 whistle==1.0.0            # via bonobo
 zeep==2.2.0
+zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via fs, html5lib, ipython
+# setuptools==41.6.0        # via fs, html5lib, ipython


### PR DESCRIPTION
#### What's this PR do?
Updates Celery from `4.2.0` to `4.3.0` along with dependencies

#### Any background context you want to provide?
It has been reported that some emails aren't being sent after a video is uploaded and transcoded. After some testing and looking at the logs, came across this error:

`[2019-11-21 13:25:21,649: ERROR/MainProcess] Control command error: ConnectionResetError(104, 'Connection reset by peer')
    Traceback (most recent call last):
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/celery/worker/pidbox.py", line 46, in on_message
        self.node.handle_message(body, message)
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/kombu/pidbox.py", line 129, in handle_message
        return self.dispatch(**body)
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/kombu/pidbox.py", line 112, in dispatch
        ticket=ticket)
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/kombu/pidbox.py", line 135, in reply
        serializer=self.mailbox.serializer)
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/kombu/pidbox.py", line 265, in _publish_reply
        **opts
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/kombu/messaging.py", line 181, in publish
        exchange_name, declare,
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/kombu/messaging.py", line 203, in _publish
        mandatory=mandatory, immediate=immediate,
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/amqp/channel.py", line 1748, in _basic_publish
        (0, exchange, routing_key, mandatory, immediate), msg
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/amqp/abstract_channel.py", line 64, in send_method
        conn.frame_writer(1, self.channel_id, sig, args, content)
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/amqp/method_framing.py", line 178, in write_frame
        write(view[:offset])
      File "/usr/local/pyenv/versions/3.6.8/lib/python3.6/site-packages/amqp/transport.py", line 272, in write
        self._write(s)
    ConnectionResetError: [Errno 104] Connection reset by peer`

Looking online, it appears to be an issue related to the `broker_pool_limit` which should be fixed in Celery 4.3.0 (https://github.com/celery/celery/issues/4226)


