### PR TITLE
Fix m3u8 reorder task

### DIFF
--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -364,7 +364,12 @@ def sort_transcoded_m3u8_files(self):
         for transcoded_video in video.transcoded_videos:
             s3_filename = transcoded_video.s3_object_key
             s3_client = boto3.client('s3')
-            file = s3_client.get_object(Bucket=settings.VIDEO_S3_TRANSCODE_BUCKET, Key=s3_filename)
+            try:
+                file = s3_client.get_object(Bucket=settings.VIDEO_S3_TRANSCODE_BUCKET, Key=s3_filename)
+            except ClientError:
+                log.error("Object not found on s3 for video id=%d", video.id)
+                continue
+
             file_content = file['Body'].read().decode()
 
             delimiter = '#EXT-X-STREAM-INF:'

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -690,6 +690,10 @@ video_1504127981867-06dkm6.m3u8
     s3c.put_object(Body=invalid_content_file_body, Bucket=bucket_name, Key=invalid_content_file_key)
     VideoFileFactory(s3_object_key=invalid_content_file_key, encoding='HLS')
 
+    # The task should not raise an error if a VideoFile hase a s3_object_key without a corresponding
+    # file on s3
+    VideoFileFactory(s3_object_key='not a valid key', encoding='HLS')
+
     sort_transcoded_m3u8_files()
 
     expected_file_body = """


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/odl-video-service/issues/810

#### What's this PR do?
This pr prevents the task from erroring if a `VideoFile` record has a `s3_object_key` that does not have a corresponding object on S3
#### How should this be manually tested?
Update the `s3_object_key` for a `VideoFile` record with `encoding=HLS` to a value that does not exist on s3

Run
```
from cloudsync.tasks import *
sort_transcoded_m3u8_files() 
```

The task should not break
#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
