### PR TITLE
Removed 'public' option for videos in front end

### DIFF
--- a/static/js/components/dialogs/EditVideoFormDialog.js
+++ b/static/js/components/dialogs/EditVideoFormDialog.js
@@ -15,7 +15,6 @@ import { getVideoWithKey } from "../../lib/collection"
 import {
   PERM_CHOICE_NONE,
   PERM_CHOICE_LISTS,
-  PERM_CHOICE_PUBLIC,
   PERM_CHOICE_COLLECTION,
   PERM_CHOICE_OVERRIDE
 } from "../../lib/dialog"
@@ -54,8 +53,6 @@ class EditVideoFormDialog extends React.Component<*, void> {
   determineViewChoice(video: Video) {
     if (video.is_private) {
       return PERM_CHOICE_NONE
-    } else if (video.is_public) {
-      return PERM_CHOICE_PUBLIC
     } else if (video.view_lists.length > 0) {
       return PERM_CHOICE_LISTS
     } else {
@@ -145,24 +142,23 @@ class EditVideoFormDialog extends React.Component<*, void> {
 
     const overridePerms = editVideoForm.overrideChoice === PERM_CHOICE_OVERRIDE
 
-    const patchData = {
+    let patchData = {
       title:       editVideoForm.title,
       description: editVideoForm.description
     }
 
     if (SETTINGS.FEATURES.ENABLE_VIDEO_PERMISSIONS) {
-      _.assign(patchData, {
+      patchData = {
+        ...patchData,
         view_lists: overridePerms
           ? calculateListPermissionValue(
             editVideoForm.viewChoice,
             editVideoForm.viewLists
           )
           : [],
-        is_public:
-          overridePerms && editVideoForm.viewChoice === PERM_CHOICE_PUBLIC,
         is_private:
           overridePerms && editVideoForm.viewChoice === PERM_CHOICE_NONE
-      })
+      }
     }
 
     try {
@@ -259,19 +255,6 @@ class EditVideoFormDialog extends React.Component<*, void> {
               validationMessage={errors ? errors.view_lists : ""}
             />
           </Radio>
-          <Radio
-            id="view-public"
-            label="Public - Subtitles are required for this option"
-            radioGroupName="video-view-perms"
-            value={PERM_CHOICE_PUBLIC}
-            selectedValue={editVideoForm.viewChoice}
-            onChange={this.handleVideoViewPermClick}
-            className="wideLabel"
-            // $FlowFixMe
-            disabled={
-              defaultPerms || (video && video.videosubtitle_set.length === 0)
-            }
-          />
         </section>
       </section>
     )

--- a/static/js/components/dialogs/EditVideoFormDialog_test.js
+++ b/static/js/components/dialogs/EditVideoFormDialog_test.js
@@ -17,14 +17,12 @@ import * as toastActions from "../../actions/toast"
 import { setSelectedVideoKey } from "../../actions/collectionUi"
 import { INITIAL_UI_STATE } from "../../reducers/videoUi"
 import * as api from "../../lib/api"
-import { makeVideo, makeVideoSubtitle } from "../../factories/video"
+import { makeVideo } from "../../factories/video"
 import { makeCollection } from "../../factories/collection"
-import { expect } from "../../util/test_utils"
 import {
   PERM_CHOICE_LISTS,
   PERM_CHOICE_NONE,
-  PERM_CHOICE_OVERRIDE,
-  PERM_CHOICE_PUBLIC
+  PERM_CHOICE_OVERRIDE
 } from "../../lib/dialog"
 
 const {
@@ -135,12 +133,6 @@ describe("EditVideoFormDialog", () => {
       PERM_CHOICE_OVERRIDE
     ],
     [
-      "#video-view-perms-view-public",
-      "viewChoice",
-      SET_VIEW_CHOICE,
-      PERM_CHOICE_PUBLIC
-    ],
-    [
       "#video-view-perms-view-only-me",
       "viewChoice",
       SET_VIEW_CHOICE,
@@ -174,25 +166,6 @@ describe("EditVideoFormDialog", () => {
       SETTINGS.FEATURES.ENABLE_VIDEO_PERMISSIONS = false
       const wrapper = await renderComponent()
       assert.equal(wrapper.find(selector).hostNodes().length, 0)
-    })
-  }
-
-  for (const [disabled, count] of [[true, 0], [false, 1]]) {
-    it(`public option ${expect(
-      disabled
-    )} be disabled because subtitle count is ${count}`, async () => {
-      SETTINGS.FEATURES.ENABLE_VIDEO_PERMISSIONS = true
-      video.is_private = true
-      video.videosubtitle_set = []
-      if (count === 1) {
-        video.videosubtitle_set.push(makeVideoSubtitle(video.key, "fr"))
-      }
-      const wrapper = await renderComponent()
-      const publicOption = wrapper
-        .find("#video-view-perms-view-public")
-        .hostNodes()
-        .props()
-      assert.equal(publicOption.disabled, disabled)
     })
   }
 
@@ -248,7 +221,6 @@ describe("EditVideoFormDialog", () => {
       title:       "New Title",
       description: "New Description",
       is_private:  false,
-      is_public:   false,
       view_lists:  ["my-moira-list1", "my-moira-list2"]
     }
     store.dispatch(setEditVideoTitle(newValues.title))

--- a/static/js/flow/videoTypes.js
+++ b/static/js/flow/videoTypes.js
@@ -46,12 +46,20 @@ export type Video = {
   videosubtitle_set:      Array<VideoSubtitle>,
   status:                 string,
   view_lists:             Array<string>,
-  collection_view_lists:   Array<string>,
+  collection_view_lists:  Array<string>,
   is_public:              boolean,
   is_private:             boolean,
   sources:                Array<VideoSource>,
-  youtube_id:            ?string,
-  cloudfront_url:          string
+  youtube_id:             ?string,
+  cloudfront_url:         string
+};
+
+export type VideoUpdatePayload = {
+  title: string,
+  description: string,
+  view_lists?: Array<string>,
+  is_private?: boolean,
+  is_public?: boolean,
 };
 
 export type VideoFormState = {
@@ -77,7 +85,7 @@ export type VideoSubtitleState = {
 export type VideoValidation = {
   title?:  string,
   view_lists?: string,
-}
+};
 
 export type VideoUiState = {
   editVideoForm: VideoFormState,

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -5,10 +5,7 @@ import {
   fetchWithCSRF
 } from "redux-hammock/django_csrf_fetch"
 import type { Collection } from "../flow/collectionTypes"
-
-export type VideoUpdatePayload = {
-  description?: string
-}
+import type { VideoUpdatePayload } from "../flow/videoTypes"
 
 export type PaginationParams = {
   page: string | number

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -84,7 +84,8 @@ describe("api", () => {
     fetchStub.returns(Promise.resolve(video))
 
     const payload = {
-      title: "new title"
+      title:       "new title",
+      description: "new description"
     }
     const result = await updateVideo(video.key, payload)
     sinon.assert.calledWith(fetchStub, `/api/v0/videos/${video.key}/`, {

--- a/static/js/reducers/videos.js
+++ b/static/js/reducers/videos.js
@@ -3,8 +3,7 @@ import { GET, PATCH, INITIAL_STATE } from "redux-hammock/constants"
 
 import * as api from "../lib/api"
 
-import type { VideoUpdatePayload } from "../lib/api"
-import type { Video } from "../flow/videoTypes"
+import type { Video, VideoUpdatePayload } from "../flow/videoTypes"
 
 export const videosEndpoint = {
   name:              "videos",


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/odl-video-service/issues/842

#### What's this PR do?
See title!

#### How should this be manually tested?
Edit all aspects of any video via the form in the front end and confirm that those updates are still working

#### Screenshots (if appropriate)
**OLD** 
![ss 2020-03-23 at 14 59 25 ](https://user-images.githubusercontent.com/14932219/77364092-41e80480-6d2a-11ea-8fa6-6be95f732c41.png)

**NEW**
![ss 2020-03-23 at 17 17 50 ](https://user-images.githubusercontent.com/14932219/77364134-4f9d8a00-6d2a-11ea-8b9e-44ec40b7890b.png)
