### PR TITLE
add youtube tos and google privacy policy links

### DIFF
--- a/static/js/containers/TermsPage.js
+++ b/static/js/containers/TermsPage.js
@@ -88,17 +88,20 @@ class TermsPage extends React.Component<*, void> {
                   </a>.
                 </li>
                 <li>
-                  <span className="terms-strong">Public videos are hosted on YouTube.</span>
-                  When you upload a video for public viewing, outside of MIT, we may upload it
-                  to YouTube in additoin to this site. In this case, you must accept
+                  <span className="terms-strong">
+                    Public videos are hosted on YouTube.
+                  </span>
+                  When you upload a video for public viewing, outside of MIT, we
+                  may upload it to YouTube in additoin to this site. In this
+                  case, you must accept{" "}
                   <a
                     target="_blank"
                     rel="noopener noreferrer"
                     href="https://www.youtube.com/t/terms"
                   >
                     YouTube's Terms of Service
-                  </a>
-                   as well.
+                  </a>{" "}
+                  as well.
                 </li>
               </ul>
               <h3 className="terms-subheading">User Obligation</h3>
@@ -110,14 +113,16 @@ class TermsPage extends React.Component<*, void> {
                 member. As part of the registration process, you will be asked
                 to ACCEPT these Terms of Use. On doing so, you will be deemed to
                 have consented to and you will be bound by these Terms of Use.
-                If you are uploading videos for public viewing, you must also accept the
-                  <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://www.youtube.com/t/terms"
-                  >
-                    YouTube Terms of Service
-                  </a>.
+                If you are uploading videos for public viewing, you must also
+                accept the{" "}
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://www.youtube.com/t/terms"
+                >
+                  {" "}
+                  YouTube Terms of Service
+                </a>.
               </div>
               <div className="terms-div">
                 Visitors to the site merely wishing to view content do not need
@@ -226,7 +231,7 @@ class TermsPage extends React.Component<*, void> {
                 parties without your express consent.
               </div>
               <div className="terms-div">
-                Public videos may be streamed from YouTube and are subject to
+                Public videos may be streamed from YouTube and are subject to{" "}
                 <a
                   href="https://policies.google.com/privacy"
                   target="_blank"

--- a/static/js/containers/TermsPage.js
+++ b/static/js/containers/TermsPage.js
@@ -87,6 +87,19 @@ class TermsPage extends React.Component<*, void> {
                     odl-video-support@mit.edu
                   </a>.
                 </li>
+                <li>
+                  <span className="terms-strong">Public videos are hosted on YouTube.</span>
+                  When you upload a video for public viewing, outside of MIT, we may upload it
+                  to YouTube in additoin to this site. In this case, you must accept
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://www.youtube.com/t/terms"
+                  >
+                    YouTube's Terms of Service
+                  </a>
+                   as well.
+                </li>
               </ul>
               <h3 className="terms-subheading">User Obligation</h3>
               <div className="terms-div">
@@ -97,6 +110,14 @@ class TermsPage extends React.Component<*, void> {
                 member. As part of the registration process, you will be asked
                 to ACCEPT these Terms of Use. On doing so, you will be deemed to
                 have consented to and you will be bound by these Terms of Use.
+                If you are uploading videos for public viewing, you must also accept the
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="https://www.youtube.com/t/terms"
+                  >
+                    YouTube Terms of Service
+                  </a>.
               </div>
               <div className="terms-div">
                 Visitors to the site merely wishing to view content do not need
@@ -203,6 +224,16 @@ class TermsPage extends React.Component<*, void> {
                 required by law. Otherwise, this information will be kept
                 private and confidential and will not be passed on to third
                 parties without your express consent.
+              </div>
+              <div className="terms-div">
+                Public videos may be streamed from YouTube and are subject to
+                <a
+                  href="https://policies.google.com/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Google's privacy policy
+                </a>.
               </div>
               <h3 className="terms-subheading">
                 Hold Harmless And Indemnification


### PR DESCRIPTION
#### What are the relevant tickets?

closes #844 

#### What's this PR do?

- meets requirements for use of the YouTube API
- adds links to YouTube's terms of service
- adds link to Google's Privacy Policy 

#### How should this be manually tested?

Take a look at `/terms/`

#### Where should the reviewer start?

- Build the app and take a look at how my HTML renders
- Please take a screenshot for me? 😉

#### Any background context you want to provide?

Without this, we won't be able to increase our API quota and we're currently limited to 6 video uploads per day. 

#### Screenshots (if appropriate)

Dear reviewer, please add screenshots for me? 😉

