### PR TITLE
fix typos in terms of service

### DIFF
--- a/static/js/containers/TermsPage.js
+++ b/static/js/containers/TermsPage.js
@@ -89,10 +89,10 @@ class TermsPage extends React.Component<*, void> {
                 </li>
                 <li>
                   <span className="terms-strong">
-                    Public videos are hosted on YouTube.
+                    Public videos are hosted on YouTube.{" "}
                   </span>
                   When you upload a video for public viewing, outside of MIT, we
-                  may upload it to YouTube in additoin to this site. In this
+                  may upload it to YouTube in addition to this site. In this
                   case, you must accept{" "}
                   <a
                     target="_blank"


### PR DESCRIPTION
#### What are the relevant tickets?

n/a

#### What's this PR do?

- fixes a typo 
- hopefully adds a space, between "YouTube." and "When you upload"

#### How should this be manually tested?

Take a look at `/terms/`

#### Screenshots (if appropriate)

I'd be obliged if the reviewer could add some, although it's not really necessary for a typo fix. 

