### PR TITLE
Fix video source switch failover

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -269,7 +269,7 @@ class VideoPlayer extends React.Component<*, void> {
   switchVideoSource = () => {
     const { video } = this.props
     if (video.sources.length > 0) {
-      this.player.reset().src(video.sources)
+      this.player.src(video.sources)
     }
   }
 

--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -465,7 +465,7 @@ describe("VideoPlayer", () => {
     })
   })
   ;[[makeVideoSource()], []].forEach(function(sources) {
-    it(`player.reset() ${expect(
+    it(`player.src() ${expect(
       sources.length > 0
     )} be called if video has ${sources.length} sources`, async () => {
       video.sources = sources
@@ -473,7 +473,7 @@ describe("VideoPlayer", () => {
       const wrapper = await renderPlayer().find("VideoPlayer")
       wrapper.instance().switchVideoSource()
       sinon.assert.callCount(
-        wrapper.instance().player.reset,
+        wrapper.instance().player.src,
         sources.length > 0 ? 1 : 0
       )
     })


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #857 

#### What's this PR do?
Modifies the `VideoPlayer.switchVideoSource` function to call `player.src()` instead of `player.reset().src()`

#### How should this be manually tested?
- Set up a video to play from Youtube:
  -  In django admin, create a new YoutubeVideo object, associate with an existing video, enter any valid Youtube video id, and set status to `processed`
  - Set the related video to `is_public=True`
- Go to the video detail page, it should play the Youtube video.
- Using an adblocker like uBlock, blacklist `*youtube.com`
- Go to the video detail page again, it should play the Cloudfront version.
