### PR TITLE
Force non-native HLS playback to fix quality selector in Edge, Safari

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -37,7 +37,7 @@ const makeConfigForVideo = (
   techOrder:   useYouTube ? ["youtube", "html5"] : ["html5"],
   html5:       {
     nativeTextTracks: false,
-    hls: {
+    hls:              {
       overrideNative: true
     }
   },

--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -36,7 +36,10 @@ const makeConfigForVideo = (
   playsinline: true,
   techOrder:   useYouTube ? ["youtube", "html5"] : ["html5"],
   html5:       {
-    nativeTextTracks: false
+    nativeTextTracks: false,
+    hls: {
+      overrideNative: true
+    }
   },
   playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 4.0],
   sources:       useYouTube

--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -107,7 +107,10 @@ describe("VideoPlayer", () => {
           playsinline: true,
           techOrder:   ["html5"],
           html5:       {
-            nativeTextTracks: false
+            nativeTextTracks: false,
+            hls: {
+              overrideNative: true
+            }
           },
           playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 4.0],
           plugins:       {

--- a/static/js/components/VideoPlayer_test.js
+++ b/static/js/components/VideoPlayer_test.js
@@ -108,7 +108,7 @@ describe("VideoPlayer", () => {
           techOrder:   ["html5"],
           html5:       {
             nativeTextTracks: false,
-            hls: {
+            hls:              {
               overrideNative: true
             }
           },


### PR DESCRIPTION
#### What are the relevant tickets?
- Fixes #859

#### What's this PR do?
Forces non-native HLS playback, because it is not supported by the videojs-hls-quality-selector plugin.  Edge and Safari will use native playback by default otherwise.

#### How should this be manually tested?
In Safari or Edge, open a video detail page.  The control bar should have a button to select different quality levels, and it should work.
Everything should remain normal in FF and Chrome.

#### Any background context you want to provide?
https://www.npmjs.com/package/videojs-hls-quality-selector
