### PR TITLE
Add videojs-annotation-comments plugin and put it behind a feature flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/mitodl/odl-video-service.git"
   },
   "dependencies": {
+    "@contently/videojs-annotation-comments": "^2.0.1",
     "@material/base": "^0.29.0",
     "@material/button": "^0.33.0",
     "@material/checkbox": "^0.33.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "fetch-mock": "^5.12.1",
     "flow-bin": "0.59.0",
     "isomorphic-fetch": "^2.2.1",
+    "jquery": "^3.4.1",
     "jsdom": "^11.6.2",
     "jsdom-global": "^3.0.2",
     "lodash": "4.17.13",

--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -391,6 +391,16 @@ class VideoPlayer extends React.Component<*, void> {
         }
       }
     )
+    if (SETTINGS.FEATURES.VIDEOJS_ANNOTATIONS) {
+      this.player.annotationComments({
+        annotationsObjects: [],
+        meta:               {
+          user_name: SETTINGS.user || null,
+          user_id:   SETTINGS.user || null
+        },
+        startInAnnotationMode: true
+      })
+    }
     if (useYouTube) {
       this.checkYouTube()
     }

--- a/static/js/lib/video.js
+++ b/static/js/lib/video.js
@@ -23,6 +23,12 @@ require("videojs-contrib-quality-levels")
 require("videojs-hls-quality-selector")
 require("videojs-youtube")
 
+if (SETTINGS.FEATURES.VIDEOJS_ANNOTATIONS) {
+  const AnnotationComments = require("@contently/videojs-annotation-comments")
+  _videojs.registerPlugin("annotationComments", AnnotationComments(_videojs))
+  require("@contently/videojs-annotation-comments/build/css/annotations.css")
+}
+
 // export here to allow mocking of videojs function
 export const videojs = _videojs
 require("@silvermine/videojs-quality-selector")(videojs)

--- a/static/js/lib/video.js
+++ b/static/js/lib/video.js
@@ -24,6 +24,7 @@ require("videojs-hls-quality-selector")
 require("videojs-youtube")
 
 if (SETTINGS.FEATURES.VIDEOJS_ANNOTATIONS) {
+  global.$ = require("jquery")
   const AnnotationComments = require("@contently/videojs-annotation-comments")
   _videojs.registerPlugin("annotationComments", AnnotationComments(_videojs))
   require("@contently/videojs-annotation-comments/build/css/annotations.css")

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -11,9 +11,6 @@
     {% load raven %}
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
-      {% if video_annotations %}
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-      {% endif %}
       <script type="text/javascript">
       var SETTINGS = {{ js_settings_json|safe }};
     </script>

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -11,7 +11,7 @@
     {% load raven %}
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
-      <script type="text/javascript">
+    <script type="text/javascript">
       var SETTINGS = {{ js_settings_json|safe }};
     </script>
     {% block prebundle %}

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -11,7 +11,8 @@
     {% load raven %}
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
-    <script type="text/javascript">
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+      <script type="text/javascript">
       var SETTINGS = {{ js_settings_json|safe }};
     </script>
     {% block prebundle %}

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -11,7 +11,9 @@
     {% load raven %}
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
+      {% if video_annotations %}
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+      {% endif %}
       <script type="text/javascript">
       var SETTINGS = {{ js_settings_json|safe }};
     </script>

--- a/ui/views.py
+++ b/ui/views.py
@@ -71,7 +71,8 @@ def default_js_settings(request):
         "support_email_address": settings.EMAIL_SUPPORT,
         "ga_dimension_camera": settings.GA_DIMENSION_CAMERA,
         "FEATURES": {
-            "ENABLE_VIDEO_PERMISSIONS": settings.ENABLE_VIDEO_PERMISSIONS
+            "ENABLE_VIDEO_PERMISSIONS": settings.ENABLE_VIDEO_PERMISSIONS,
+            "VIDEOJS_ANNOTATIONS": settings.FEATURES.get("VIDEOJS_ANNOTATIONS"),
         }
     }
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -72,7 +72,7 @@ def default_js_settings(request):
         "ga_dimension_camera": settings.GA_DIMENSION_CAMERA,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": settings.ENABLE_VIDEO_PERMISSIONS,
-            "VIDEOJS_ANNOTATIONS": settings.FEATURES.get("VIDEOJS_ANNOTATIONS"),
+            "VIDEOJS_ANNOTATIONS": settings.FEATURES.get("VIDEOJS_ANNOTATIONS", False),
         }
     }
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -54,7 +54,6 @@ from ui.utils import get_video_analytics, generate_mock_video_analytics_data, qu
 
 def default_js_settings(request):
     """Default JS settings for views"""
-    video_annotations_feature_flag = settings.FEATURES.get("VIDEOJS_ANNOTATIONS", False)
     return {
         "gaTrackingID": settings.GA_TRACKING_ID,
         "environment": settings.ENVIRONMENT,
@@ -71,10 +70,9 @@ def default_js_settings(request):
         ),
         "support_email_address": settings.EMAIL_SUPPORT,
         "ga_dimension_camera": settings.GA_DIMENSION_CAMERA,
-        "video_annotations": video_annotations_feature_flag,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": settings.ENABLE_VIDEO_PERMISSIONS,
-            "VIDEOJS_ANNOTATIONS": video_annotations_feature_flag,
+            "VIDEOJS_ANNOTATIONS": settings.FEATURES.get("VIDEOJS_ANNOTATIONS", False),
         }
     }
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -54,6 +54,7 @@ from ui.utils import get_video_analytics, generate_mock_video_analytics_data, qu
 
 def default_js_settings(request):
     """Default JS settings for views"""
+    video_annotations_feature_flag = settings.FEATURES.get("VIDEOJS_ANNOTATIONS", False)
     return {
         "gaTrackingID": settings.GA_TRACKING_ID,
         "environment": settings.ENVIRONMENT,
@@ -70,9 +71,10 @@ def default_js_settings(request):
         ),
         "support_email_address": settings.EMAIL_SUPPORT,
         "ga_dimension_camera": settings.GA_DIMENSION_CAMERA,
+        "video_annotations": video_annotations_feature_flag,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": settings.ENABLE_VIDEO_PERMISSIONS,
-            "VIDEOJS_ANNOTATIONS": settings.FEATURES.get("VIDEOJS_ANNOTATIONS", False),
+            "VIDEOJS_ANNOTATIONS": video_annotations_feature_flag,
         }
     }
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -136,6 +136,7 @@ def test_video_detail(logged_in_client, settings):
         "email": user.email,
         "support_email_address": settings.EMAIL_SUPPORT,
         "dropbox_key": "foo_dropbox_key",
+        "video_annotations": False,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": False,
             "VIDEOJS_ANNOTATIONS": False,
@@ -175,6 +176,7 @@ def test_video_embed(logged_in_client, settings):  # pylint: disable=redefined-o
         "email": user.email,
         "is_app_admin": False,
         "support_email_address": settings.EMAIL_SUPPORT,
+        'video_annotations': False,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": False,
             "VIDEOJS_ANNOTATIONS": False,
@@ -781,6 +783,7 @@ def test_page_not_found(url, logged_in_apiclient, settings):
         'email': user.email,
         'user': user.username,
         'is_app_admin': False,
+        'video_annotations': False,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": False,
             "VIDEOJS_ANNOTATIONS": False,

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -137,7 +137,8 @@ def test_video_detail(logged_in_client, settings):
         "support_email_address": settings.EMAIL_SUPPORT,
         "dropbox_key": "foo_dropbox_key",
         "FEATURES": {
-            "ENABLE_VIDEO_PERMISSIONS": False
+            "ENABLE_VIDEO_PERMISSIONS": False,
+            "VIDEOJS_ANNOTATIONS": False,
         },
         'is_video_admin': True
     }
@@ -175,7 +176,8 @@ def test_video_embed(logged_in_client, settings):  # pylint: disable=redefined-o
         "is_app_admin": False,
         "support_email_address": settings.EMAIL_SUPPORT,
         "FEATURES": {
-            "ENABLE_VIDEO_PERMISSIONS": False
+            "ENABLE_VIDEO_PERMISSIONS": False,
+            "VIDEOJS_ANNOTATIONS": False,
         }
     }
 
@@ -780,7 +782,8 @@ def test_page_not_found(url, logged_in_apiclient, settings):
         'user': user.username,
         'is_app_admin': False,
         "FEATURES": {
-            "ENABLE_VIDEO_PERMISSIONS": False
+            "ENABLE_VIDEO_PERMISSIONS": False,
+            "VIDEOJS_ANNOTATIONS": False,
         }
     }
 

--- a/ui/views_test.py
+++ b/ui/views_test.py
@@ -136,7 +136,6 @@ def test_video_detail(logged_in_client, settings):
         "email": user.email,
         "support_email_address": settings.EMAIL_SUPPORT,
         "dropbox_key": "foo_dropbox_key",
-        "video_annotations": False,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": False,
             "VIDEOJS_ANNOTATIONS": False,
@@ -176,7 +175,6 @@ def test_video_embed(logged_in_client, settings):  # pylint: disable=redefined-o
         "email": user.email,
         "is_app_admin": False,
         "support_email_address": settings.EMAIL_SUPPORT,
-        'video_annotations': False,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": False,
             "VIDEOJS_ANNOTATIONS": False,
@@ -783,7 +781,6 @@ def test_page_not_found(url, logged_in_apiclient, settings):
         'email': user.email,
         'user': user.username,
         'is_app_admin': False,
-        'video_annotations': False,
         "FEATURES": {
             "ENABLE_VIDEO_PERMISSIONS": False,
             "VIDEOJS_ANNOTATIONS": False,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4115,6 +4115,11 @@ istanbul-reports@^1.1.1:
   dependencies:
     handlebars "^4.0.3"
 
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+
 js-base64@^2.1.8:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,13 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@contently/videojs-annotation-comments@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@contently/videojs-annotation-comments/-/videojs-annotation-comments-2.0.1.tgz#a63d2adf55f2337e585fccb13b6a2842323b32cc"
+  integrity sha512-cVr9T1ZXvQhJzHglG5EXm+MhBUmiV0RQB50AjhvhYK+vIRILEkmapE0CoJYxgNIriM2an6AnebgLaCGUjVtKKQ==
+  dependencies:
+    mitt "^1.2.0"
+
 "@material/animation@^0.25.0":
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@material/animation/-/animation-0.25.0.tgz#b252ac3d0b628e79a79f0c406d7470fb56352a80"
@@ -4763,6 +4770,11 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
+
+mitt@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.2.0.tgz#cb24e6569c806e31bd4e3995787fe38a04fdf90d"
+  integrity sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==
 
 mixin-object@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
#### What are the relevant tickets?
https://trello.com/c/YlaO3AvR/25-annotation-research

#### What's this PR do?
Adds the videojs-annotation-comments plugin and put it behind a feature flag so that we can try it out

#### How should this be manually tested?
Nothing should break by default. Set `FEATURE_VIDEOJS_ANNOTATIONS=True` and you should see a simple annotations UI when you look at videos using videojs. You can make changes but they will not be persisted anywhere and will go away when the browser refreshes.
