### PR TITLE
Add structured logging with structlog

### DIFF
--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -1,7 +1,6 @@
 """
 Tasks for cloudsync app
 """
-import logging
 import os
 import re
 from urllib.parse import unquote
@@ -22,6 +21,7 @@ from ui.models import Video, YouTubeVideo, VideoSubtitle, Collection
 from ui.constants import VideoStatus, YouTubeStatus, StreamSource
 from ui.utils import get_bucket
 from ui.encodings import EncodingNames
+from odl_video import logging
 
 log = logging.getLogger(__name__)
 
@@ -51,10 +51,10 @@ class VideoTask(Task):
         if self.request.chain:
             try:
                 return self.request.chain[0]['options']['task_id']
-            except (IndexError, KeyError,) as exc:
+            except (IndexError, KeyError,):
                 # Log the error and continue, using self.request.id instead
                 # The worst that will happen is that progress bar won't work.
-                log.error("Could not find task_id in chain: %s", str(exc))
+                log.error("Could not find task_id in chain")
                 return
         return self.request.id
 
@@ -70,7 +70,8 @@ def stream_to_s3(self, video_id):
     try:
         video = Video.objects.get(id=video_id)
     except (Video.DoesNotExist, Video.MultipleObjectsReturned):
-        log.error("Exception retrieving video with id %d", video_id)
+        log.error("Exception retrieving video",
+                  video_id=video_id)
         raise
     video.update_status(VideoStatus.UPLOADING)
 
@@ -211,11 +212,14 @@ def update_video_statuses(self):
             refresh_status(video)
         except EncodeJob.DoesNotExist:
             # Log the exception but don't raise it so other videos can be checked.
-            log.exception("No EncodeJob object exists for video id %d", video.id)
+            log.exception("No EncodeJob object exists for video",
+                          video_id=video.id)
             video.update_status(error)
         except ClientError as exc:
             # Log the exception but don't raise it so other videos can be checked.
-            log.exception("AWS error when refreshing job status for video %d: %s", video.id, exc.response)
+            log.exception("AWS error when refreshing job status",
+                          video_id=video.id,
+                          response=exc.response)
             video.update_status(error)
 
 
@@ -236,11 +240,15 @@ def upload_youtube_videos():
             youtube_video.status = response['status']['uploadStatus']
             youtube_video.save()
         except HttpError as error:
-            log.exception("HttpError uploading video %s to Youtube: %s", video.hexkey, youtube_video.status)
+            log.exception("HttpError uploading video to Youtube",
+                          video_hexkey=video.hexkey,
+                          status=youtube_video.status)
             if API_QUOTA_ERROR_MSG in error.content.decode('utf-8'):
                 break
         except:  # pylint: disable=bare-except
-            log.exception("Error uploading video %s to Youtube: %s", video.hexkey, youtube_video.status)
+            log.exception("Error uploading video to Youtube",
+                          video_hexkey=video.hexkey,
+                          status=youtube_video.status)
         finally:
             # If anything went wrong with the upload, delete the YouTubeVideo object.
             # Another upload attempt will be made the next time the task is run.
@@ -257,7 +265,8 @@ def remove_youtube_video(self, video_id):
         YouTubeApi().delete_video(video_id)
     except HttpError as error:
         if error.resp.status == 404:
-            log.info('Not found on Youtube, already deleted? %s', video_id)
+            log.info('Not found on Youtube, already deleted?',
+                     video_id=video_id)
         else:
             raise
 
@@ -302,7 +311,9 @@ def update_youtube_statuses(self):
             # Video might be a dupe or deleted, mark it as failed and continue to next one.
             yt_video.status = YouTubeStatus.FAILED
             yt_video.save()
-            log.exception('Status of YoutubeVideo %s for Video %s not found.', yt_video.id, yt_video.video_id)
+            log.exception('Status of YoutubeVideo not found.',
+                          youtubevideo_id=yt_video.id,
+                          youtubevideo_video_id=yt_video.video_id)
         except HttpError as error:
             if API_QUOTA_ERROR_MSG in error.content.decode('utf-8'):
                 # Don't raise the error, task will try on next run until daily quota is reset
@@ -322,10 +333,13 @@ def monitor_watch_bucket(self):
             process_watch_file(key.key)
         except ClientError as exc:
             # Log ClientError, raise later so other files can be processed.
-            log.exception("AWS error when ingesting file from watch bucket %s: %s", key.key, exc.response)
+            log.exception("AWS error when ingesting file from watch bucket",
+                          s3_object_key=key.key,
+                          response=exc.response)
         except Exception as exc:  # pylint: disable=broad-except
             # Log any other exception, raise later so other files can be processed.
-            log.exception("AWS error when ingesting file from watch bucket %s: %s", key.key, str(exc))
+            log.exception("AWS error when ingesting file from watch bucket",
+                          s3_object_key=key.key)
 
 
 def parse_content_metadata(response):
@@ -367,7 +381,7 @@ def sort_transcoded_m3u8_files(self):
             try:
                 file = s3_client.get_object(Bucket=settings.VIDEO_S3_TRANSCODE_BUCKET, Key=s3_filename)
             except ClientError:
-                log.error("Object not found on s3 for video id=%d", video.id)
+                log.error("Object not found on s3", video_id=video.id)
                 continue
 
             file_content = file['Body'].read().decode()
@@ -377,7 +391,8 @@ def sort_transcoded_m3u8_files(self):
             header = lines.pop(0)
 
             if str.strip(header) != "#EXTM3U":
-                log.error("Unexpected format for transcoded video file for video id=%d", video.id)
+                log.error("Unexpected format for transcoded video file",
+                          video_id=video.id)
                 continue
 
             try:
@@ -388,7 +403,8 @@ def sort_transcoded_m3u8_files(self):
                     ]
                 )
             except AttributeError:
-                log.error("Unexpected format for transcoded video file for video id=%d", video.id)
+                log.error("Unexpected format for transcoded video file",
+                          video_id=video.id)
                 continue
 
             lines.insert(0, header)

--- a/cloudsync/youtube.py
+++ b/cloudsync/youtube.py
@@ -2,7 +2,6 @@
 import http
 import re
 import time
-import logging
 from tempfile import NamedTemporaryFile
 
 import boto3
@@ -14,6 +13,7 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload, MediaIoBaseUpload
 from smart_open.s3 import SeekableBufferedInputBase
+from odl_video import logging
 
 log = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def resumable_upload(request, max_retries=10):
         if error is not None:
             retry += 1
             if retry > max_retries:
-                log.error('Final upload failure', exc_info=error)
+                log.error('Final upload failure')
                 raise YouTubeUploadException('Retried YouTube upload 10x, giving up') from error
             sleep_time = 2 ** retry
             time.sleep(sleep_time)

--- a/mail/api.py
+++ b/mail/api.py
@@ -1,7 +1,6 @@
 """
 Provides functions for sending and retrieving data about in-app email
 """
-import logging
 import json
 
 import requests
@@ -11,6 +10,7 @@ from rest_framework import status
 
 from mail.exceptions import SendBatchException
 from mail.utils import chunks
+from odl_video import logging
 
 
 log = logging.getLogger(__name__)

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -1,5 +1,4 @@
 """Tasks for mail app"""
-import logging
 import textwrap
 from urllib.parse import urljoin
 
@@ -11,6 +10,7 @@ from mail import api
 from mail.models import NotificationEmail
 from ui.constants import VideoStatus
 from ui.utils import has_common_lists, get_moira_client
+from odl_video import logging
 
 log = logging.getLogger(__name__)
 
@@ -61,18 +61,20 @@ def send_notification_email(video):
         video (ui.models.Video): a video object
     """
     if video.status not in STATUS_TO_NOTIFICATION.keys():
-        log.error("Tried to send notifications for video %s with status %s", video.hexkey, video.status)
+        log.error("Unexpected video status",
+                  video_hexkey=video.hexkey, video_status=video.status)
         return
     # get the list of emails
     recipients = _get_recipients_for_video(video)
     if not recipients:
-        log.error("No email was sent because there were no "
-                  "valid recipient emails for video %s with status %s", video.hexkey, video.status)
+        log.error("No email sent, no valid recipient emails",
+                  video_hexkey=video.hexkey, video_status=video.status)
         return
     try:
         email_template = NotificationEmail.objects.get(notification_type=STATUS_TO_NOTIFICATION[video.status])
     except NotificationEmail.DoesNotExist:
-        log.error("No template found for error %s", STATUS_TO_NOTIFICATION[video.status])
+        log.error("No template found",
+                  status=STATUS_TO_NOTIFICATION[video.status])
         return
 
     try:
@@ -97,7 +99,9 @@ def send_notification_email(video):
         if video.status in STATUSES_THAT_TRIGGER_DEBUG_EMAIL:
             _send_debug_email(video=video, email_kwargs=email_kwargs)
     except:  # pylint: disable=bare-except
-        log.exception('Impossible to send notification for video %s with status %s', video.hexkey, video.status)
+        log.exception('Impossible to send notification',
+                      video_hexkey=video.hexkey,
+                      video_status=video.status)
 
 
 @shared_task(bind=True)
@@ -110,7 +114,8 @@ def async_send_notification_email(self, video_id):  # pylint: disable=unused-arg
     try:
         video = Video.objects.get(id=video_id)
     except Video.DoesNotExist:
-        log.error('tried to send notification for non existing video with id=%s', video_id)
+        log.error('Can not send notification for nonexistant video',
+                  video_id=video_id)
         return
     send_notification_email(video)
 

--- a/mail/utils.py
+++ b/mail/utils.py
@@ -1,8 +1,8 @@
 """
 General bootcamp utility functions
 """
-import logging
 from itertools import islice
+from odl_video import logging
 
 
 log = logging.getLogger(__name__)

--- a/odl_video/celery.py
+++ b/odl_video/celery.py
@@ -1,15 +1,13 @@
 """
 Celery configuration
 """
-
 import os
-
 from celery import Celery
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'odl_video.settings')
 
-from django.conf import settings  # noqa pylint: disable=wrong-import-position
+from django.conf import settings  # noqa pylint: disable=wrong-import-order,wrong-import-position
 
 app = Celery('odl_video')
 

--- a/odl_video/logging.py
+++ b/odl_video/logging.py
@@ -1,0 +1,51 @@
+"""Configure structured logging for our application"""
+import logging
+from structlog_sentry import SentryJsonProcessor
+import structlog
+from odl_video import settings
+
+
+logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL),
+                    format='%(message)s')
+
+structlog_processors_per_debug = {
+    True: [
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+
+        structlog.processors.StackInfoRenderer(),
+        structlog.dev.set_exc_info,
+        structlog.processors.format_exc_info,
+        structlog.processors.TimeStamper(fmt='iso'),
+        structlog.dev.ConsoleRenderer()
+    ],
+    False: [
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper(),
+        SentryJsonProcessor(level=logging.ERROR,
+                            tag_keys=['environment', 'level', 'logger',
+                                      'runtime', 'server_name', 'video_id',
+                                      'video_hexkey', 's3_object_key',
+                                      'filename', 'youtubevideo_id',
+                                      'youtubevideo_video_id', 'video_status'],
+                            as_extra=False),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.JSONRenderer()
+    ]
+}
+
+structlog.configure(
+    processors=structlog_processors_per_debug[settings.DEBUG],
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger
+)
+
+
+def getLogger(name):
+    """Return a logger with the given name"""
+    return structlog.get_logger(name)

--- a/odl_video/utils.py
+++ b/odl_video/utils.py
@@ -3,9 +3,8 @@ from enum import (
     auto,
     Flag,
 )
-import logging
-
 from django.conf import settings
+from odl_video import logging
 
 
 log = logging.getLogger(__name__)

--- a/requirements.in
+++ b/requirements.in
@@ -21,6 +21,8 @@ pytz
 redis==3.2.1
 requests>=2.20.0
 sentry-sdk==0.14.3
+structlog==20.1.0
+structlog-sentry==1.2.2
 urllib3>=1.24.2
 uwsgi==2.0.18
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,27 +6,28 @@
 #
 amqp==2.5.2               # via kombu
 appdirs==1.4.3            # via fs, zeep
-asn1crypto==0.22.0        # via cryptography
+appnope==0.1.0            # via ipython
+attrs==19.3.0             # via zeep
 backcall==0.1.0           # via ipython
-beautifulsoup4==4.7.1     # via pycaption
-billiard==3.6.1.0         # via celery
+beautifulsoup4==4.9.0     # via pycaption
+billiard==3.6.3.0         # via celery
 bonobo==0.6.4             # via -r requirements.in
 boto3==1.12.26            # via -r requirements.in, django-elastic-transcoder, smart-open
-boto==2.48.0              # via smart-open
-botocore==1.15.26         # via boto3, s3transfer
+boto==2.49.0              # via smart-open
+botocore==1.15.39         # via boto3, s3transfer
 bz2file==0.98             # via smart-open
-cached-property==1.3.0    # via zeep
-cachetools==2.0.1         # via google-auth
+cached-property==1.5.1    # via zeep
+cachetools==4.1.0         # via google-auth
 celery-redbeat==0.13.0    # via -r requirements.in
 celery==4.3.0             # via -r requirements.in, celery-redbeat, django-server-status
-certifi==2017.4.17        # via requests, sentry-sdk
-cffi==1.10.0              # via cryptography
+certifi==2020.4.5.1       # via requests, sentry-sdk
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 colorama==0.3.9           # via mondrian
-cryptography==2.3.1       # via -r requirements.in, pyopenssl
+cryptography==2.9         # via -r requirements.in, pyopenssl
 cssutils==1.0.2           # via pycaption
 decorator==4.4.2          # via ipython, traitlets
-defusedxml==0.5.0         # via zeep
+defusedxml==0.6.0         # via zeep
 dj-database-url==0.3.0    # via -r requirements.in
 dj-static==0.0.6          # via -r requirements.in
 django-compat==1.0.15     # via -r requirements.in, django-hijack, django-hijack-admin
@@ -39,84 +40,89 @@ git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git
 django-webpack-loader==0.5.0  # via -r requirements.in
 django==2.2.10            # via -r requirements.in, django-elastic-transcoder
 djangorestframework==3.9.1  # via -r requirements.in
-docutils==0.13.1          # via botocore
+docutils==0.15.2          # via botocore
 dropbox==9.0.0            # via -r requirements.in
-elasticsearch==5.4.0      # via django-server-status
-enum34==1.1.6             # via pycaption
-factory-boy==2.8.1        # via -r requirements.in
-faker==0.7.17             # via -r requirements.in, factory-boy
-fs==2.0.18                # via bonobo
-future==0.16.0            # via pycaption
-google-api-python-client==1.6.4  # via -r requirements.in
-google-auth-httplib2==0.0.2  # via -r requirements.in
-google-auth-oauthlib==0.1.1  # via -r requirements.in
-google-auth==1.2.0        # via -r requirements.in, google-auth-httplib2, google-auth-oauthlib
-graphviz==0.8.2           # via bonobo
+elasticsearch==7.6.0      # via django-server-status
+enum34==1.1.10            # via pycaption
+factory-boy==2.12.0       # via -r requirements.in
+faker==4.0.3              # via -r requirements.in, factory-boy
+fs==2.4.11                # via bonobo
+future==0.18.2            # via pycaption
+google-api-core==1.16.0   # via google-api-python-client
+google-api-python-client==1.8.0  # via -r requirements.in
+google-auth-httplib2==0.0.3  # via -r requirements.in, google-api-python-client
+google-auth-oauthlib==0.4.1  # via -r requirements.in
+google-auth==1.13.1       # via -r requirements.in, google-api-core, google-api-python-client, google-auth-httplib2, google-auth-oauthlib
+googleapis-common-protos==1.51.0  # via google-api-core
+graphviz==0.8.4           # via bonobo
 html5lib==0.999999999     # via -r requirements.in
-httplib2==0.10.3          # via -r requirements.in, google-api-python-client, oauth2client
-idna==2.5                 # via cryptography, requests
-importlib-metadata==0.23  # via kombu
+httplib2==0.17.2          # via -r requirements.in, google-api-python-client, google-auth-httplib2, oauth2client
+idna==2.9                 # via requests
+importlib-metadata==1.6.0  # via kombu
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.13.0           # via -r requirements.in
-isodate==0.5.4            # via zeep
+isodate==0.6.0            # via zeep
 jedi==0.16.0              # via ipython
 jinja2==2.11.1            # via -r requirements.in, bonobo
-jmespath==0.9.3           # via boto3, botocore
-kombu==4.6.6              # via celery, django-server-status
-lxml==4.1.1               # via pycaption, zeep
+jmespath==0.9.5           # via boto3, botocore
+kombu==4.6.8              # via celery, django-server-status
+lxml==4.5.0               # via pycaption, zeep
 markupsafe==1.1.1         # via -r requirements.in, jinja2
 git+https://github.com/mitodl/mit-moira.git#egg=mit-moira==0.0.4  # via -r requirements.in
 mondrian==0.8.0           # via bonobo
-more-itertools==7.2.0     # via zipp
-mysqlclient==1.3.12       # via -r requirements.in
-newrelic==4.2.0.100       # via -r requirements.in
-oauth2client==3.0.0       # via -r requirements.in, google-api-python-client
-oauthlib==2.0.6           # via requests-oauthlib
+mysqlclient==1.4.6        # via -r requirements.in
+newrelic==5.12.0.140      # via -r requirements.in
+oauth2client==3.0.0       # via -r requirements.in
+oauthlib==3.1.0           # via requests-oauthlib
 packaging==19.2           # via bonobo
-parso==0.6.2              # via jedi
-pbr==3.1.1                # via stevedore
+parso==0.7.0              # via jedi
+pbr==5.4.5                # via stevedore
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
-prompt-toolkit==3.0.4     # via ipython
+prompt-toolkit==3.0.5     # via ipython
+protobuf==3.11.3          # via google-api-core, googleapis-common-protos
 psutil==5.6.6             # via -r requirements.in, bonobo
 psycopg2==2.7.3.2         # via -r requirements.in, django-server-status
 ptyprocess==0.6.0         # via pexpect
-pyasn1-modules==0.1.5     # via google-auth, google-auth-httplib2, oauth2client
-pyasn1==0.3.7             # via google-auth, google-auth-httplib2, oauth2client, pyasn1-modules, rsa
+pyasn1-modules==0.2.8     # via google-auth, oauth2client
+pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
 git+https://github.com/mitodl/pycaption.git#egg=pycaption  # via -r requirements.in
-pycountry==17.5.14        # via -r requirements.in
-pycparser==2.18           # via cffi
+pycountry==19.8.18        # via -r requirements.in
+pycparser==2.20           # via cffi
 pygments==2.6.1           # via ipython
 pyopenssl==17.5.0         # via django-server-status
-pyparsing==2.2.0          # via packaging
+pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via -r requirements.in, botocore, celery-redbeat, faker
-python-slugify==1.2.4     # via bonobo
-pytz==2017.2              # via -r requirements.in, celery, django, fs, zeep
+python-slugify==1.2.6     # via bonobo
+pytz==2019.3              # via -r requirements.in, celery, django, fs, google-api-core, zeep
 redis==3.2.1              # via -r requirements.in, celery-redbeat, django-redis, django-server-status
-requests-oauthlib==0.8.0  # via google-auth-oauthlib
-requests-toolbelt==0.8.0  # via zeep
-requests==2.21.0          # via -r requirements.in, bonobo, dropbox, requests-oauthlib, requests-toolbelt, smart-open, zeep
-rsa==3.4.2                # via google-auth, google-auth-httplib2, oauth2client
+requests-oauthlib==1.3.0  # via google-auth-oauthlib
+requests-toolbelt==0.9.1  # via zeep
+requests==2.23.0          # via -r requirements.in, bonobo, dropbox, google-api-core, requests-oauthlib, requests-toolbelt, smart-open, zeep
+rsa==4.0                  # via google-auth, oauth2client
 s3transfer==0.3.3         # via boto3
-sentry-sdk==0.14.3        # via -r requirements.in
-six==1.10.0               # via cryptography, django-compat, django-server-status, dropbox, faker, fs, google-api-python-client, google-auth, google-auth-httplib2, html5lib, oauth2client, packaging, pycaption, pyopenssl, python-dateutil, stevedore, tenacity, traitlets, zeep
+sentry-sdk==0.14.3        # via -r requirements.in, structlog-sentry
+six==1.14.0               # via cryptography, django-compat, django-server-status, dropbox, fs, google-api-core, google-api-python-client, google-auth, html5lib, isodate, oauth2client, packaging, protobuf, pycaption, pyopenssl, python-dateutil, stevedore, structlog, tenacity, traitlets, zeep
 smart_open==1.5.7         # via -r requirements.in
-soupsieve==1.9.1          # via beautifulsoup4
+soupsieve==2.0            # via beautifulsoup4
 sqlparse==0.3.1           # via django
 static3==0.7.0            # via dj-static
-stevedore==1.28.0         # via bonobo
-tenacity==6.0.0           # via celery-redbeat
+stevedore==1.32.0         # via bonobo
+structlog-sentry==1.2.2   # via -r requirements.in
+structlog==20.1.0         # via -r requirements.in
+tenacity==6.1.0           # via celery-redbeat
+text-unidecode==1.3       # via faker
 traitlets==4.3.3          # via ipython
-unidecode==1.0.22         # via python-slugify
-uritemplate==3.0.0        # via google-api-python-client
-urllib3==1.24.3           # via -r requirements.in, botocore, elasticsearch, requests, sentry-sdk
+unidecode==1.1.1          # via python-slugify
+uritemplate==3.0.1        # via google-api-python-client
+urllib3==1.25.8           # via -r requirements.in, botocore, elasticsearch, requests, sentry-sdk
 uwsgi==2.0.18             # via -r requirements.in
 vine==1.3.0               # via amqp, celery
 wcwidth==0.1.9            # via prompt-toolkit
 webencodings==0.5.1       # via html5lib
-whistle==1.0.0            # via bonobo
-zeep==2.2.0               # via mit-moira
-zipp==0.6.0               # via importlib-metadata
+whistle==1.0.1            # via bonobo
+zeep==3.4.0               # via mit-moira
+zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/techtv2ovs/tasks.py
+++ b/techtv2ovs/tasks.py
@@ -1,5 +1,4 @@
 """ Celery tasks for techtv2ovs """
-import logging
 from os.path import splitext
 
 import boto3
@@ -9,6 +8,7 @@ from django.conf import settings
 from techtv2ovs.constants import TTV_VIDEO_BUCKET, ImportStatus
 from techtv2ovs.models import TechTVVideo
 from ui.models import VideoFile
+from odl_video import logging
 
 log = logging.getLogger(__name__)
 
@@ -71,7 +71,9 @@ def process_videofiles(self, ttv_id, files, run_copy):
                 }
             )
         except Exception as exc:
-            log.exception("Error processing video file %s for ttv video %s", s3file['Key'], ttv_video.id)
+            log.exception("Error processing video file for ttv video",
+                          s3_object_key=s3file['Key'],
+                          ttv_video_id=ttv_video.id)
             ttv_video.status = ImportStatus.ERROR
             ttv_video.videofile_status = ImportStatus.ERROR
             ttv_video.errors += '{}\n\n'.format(str(exc))

--- a/ui/api.py
+++ b/ui/api.py
@@ -1,7 +1,6 @@
 """
 API methods
 """
-import logging
 from uuid import uuid4
 
 import requests
@@ -14,6 +13,8 @@ from django.shortcuts import get_object_or_404
 from cloudsync import tasks
 from ui import models
 from ui.utils import get_error_response_summary_dict
+from odl_video import logging
+
 
 log = logging.getLogger(__name__)
 
@@ -75,7 +76,9 @@ def post_hls_to_edx(video_file):
         Q(collections__id__in=[video_file.video.collection_id]) | Q(is_global_default=True)
     )
     if not edx_endpoints.exists():
-        log.error("Trying to post HLS to edX endpoints, but no endpoints exist (%d, %s)", video_file.pk, video_file)
+        log.error("Trying to post HLS to edX endpoints, but no endpoints exist",
+                  videofile_id=video_file.pk,
+                  videofile=video_file)
 
     responses = {}
     for edx_endpoint in edx_endpoints:
@@ -110,9 +113,9 @@ def post_hls_to_edx(video_file):
             else:
                 response_summary_dict = {"exception": str(exc)}
             log.error(
-                "Request to add HLS video to edX failed - VideoFile: %d, API response: %s",
-                video_file.pk,
-                response_summary_dict,
+                "Can not add HLS video to edX",
+                videofile_id=video_file.pk,
+                response=str(response_summary_dict),
             )
             resp = exc.response
         responses[edx_endpoint] = resp

--- a/ui/api_test.py
+++ b/ui/api_test.py
@@ -217,5 +217,5 @@ def test_post_hls_to_edx_bad_resp(mocker, reqmocker, edx_api_scenario):
     for mocked_post in mocked_posts:
         assert mocked_post.call_count == 1
     patched_log_error.assert_called_once()
-    assert "Request to add HLS video to edX failed" in patched_log_error.call_args[0][0]
+    assert "Can not add HLS video to edX" in patched_log_error.call_args[0][0]
     assert len(responses) == 2

--- a/ui/permissions.py
+++ b/ui/permissions.py
@@ -1,7 +1,6 @@
 """
 Permissions for ui app
 """
-import logging
 import uuid
 
 from django.contrib.auth import get_user_model
@@ -14,6 +13,7 @@ from rest_framework.permissions import (
 
 from ui.models import Collection
 from ui.utils import has_common_lists
+from odl_video import logging
 
 log = logging.getLogger(__name__)
 

--- a/ui/tasks.py
+++ b/ui/tasks.py
@@ -1,13 +1,13 @@
 """
 ui celery tasks
 """
-import logging
+from odl_video import logging
 
 from odl_video.celery import app
 from ui.models import VideoFile
 from ui import api as ovs_api
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 @app.task
@@ -15,7 +15,7 @@ def post_hls_to_edx(video_file_id):
     """Loads a VideoFile and calls our API method to add it to edX"""
     video_file = VideoFile.objects.filter(id=video_file_id).select_related("video__collection").first()
     if not video_file:
-        log.error("VideoFile with id %s doesn't exist", video_file_id)
+        log.error("VideoFile doesn't exist", videofile_id=video_file_id)
         return
     response_dict = ovs_api.post_hls_to_edx(video_file)
     return [

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -1,6 +1,5 @@
 """Utils for ui app"""
 import itertools
-import logging
 import os
 from collections import namedtuple
 from functools import lru_cache
@@ -18,6 +17,7 @@ from oauth2client.service_account import ServiceAccountCredentials
 from mit_moira import Moira
 
 from ui.exceptions import MoiraException, GoogleAnalyticsException
+from odl_video import logging
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/ngDv49Sm/79-investigate-structlog-for-cleaning-logs-improving-observability

#### What's this PR do?

It introduces [structlog](https://www.structlog.org/en/stable/index.html), which wraps `logging` to provide some formatting conveniences. The most important improvement is creating structured, JSON-formatted messages that are easier for our log aggregators to parse, for us to monitor with Elastalert, and for us to analyze in Kibana.

I took the liberty in commit 4b74272 of changing some of the log messages. This commit can be backed out if this is too much at the moment.

#### How should this be manually tested?

If you have the `DEBUG` environment variable set, you should observe nicer human-readable log messages. (If you optionally install the `colorama` package, they will be color-coded.) Without the `DEBUG` flag, the messages will be JSON-encoded with UNIX timestamps.

