### PR TITLE
Remove py-call-osafterfork uWSGI setting

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,7 +1,6 @@
 [uwsgi]
 strict = true
 need-app = true
-py-call-osafterfork = true
 auto-procname = true
 if-env = DEV_ENV
 socket = :$(PORT)


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/upfutK0A/44-update-all-uwsgi-configs-with-recommendations-from-bloomberg-article

#### What's this PR do?

Remove the py-call-osafterfork setting from uwsgi.ini. This is about to be deprecated, and is buggy with Python 3.7.

References:

- https://github.com/mitodl/micromasters/pull/4569
- https://github.com/unbit/uwsgi/issues/1978
- https://github.com/unbit/uwsgi/pull/1995


#### How should this be manually tested?

I believe that you will want to do this:
```
docker-compose build
docker-compose up -d
docker logs -f odl-video-service_python
```
... And the log output should not contain any exception saying, "cannot release un-acquired lock."

I don't have my dev environment set up, so it errors out because it can't load the application. If it can load the application, it should launch a couple of uWSGI workers and there should be no exception regarding an un-acquired lock.
