### PR TITLE
Email templates

### DIFF
--- a/mail/constants.py
+++ b/mail/constants.py
@@ -1,0 +1,19 @@
+""" Constants for mail """
+from ui.constants import VideoStatus
+
+EMAIL_SUCCESS = "success"
+EMAIL_INVALID_FORMAT = "invalid_format_error"
+EMAIL_OTHER_ERROR = "other_error"
+
+STATUS_TO_NOTIFICATION = {
+    VideoStatus.COMPLETE: EMAIL_SUCCESS,
+    VideoStatus.TRANSCODE_FAILED_INTERNAL: EMAIL_OTHER_ERROR,
+    VideoStatus.TRANSCODE_FAILED_VIDEO: EMAIL_INVALID_FORMAT,
+    VideoStatus.UPLOAD_FAILED: EMAIL_OTHER_ERROR,
+}
+
+STATUSES_THAT_TRIGGER_DEBUG_EMAIL = set([
+    VideoStatus.TRANSCODE_FAILED_INTERNAL,
+    VideoStatus.TRANSCODE_FAILED_VIDEO,
+    VideoStatus.UPLOAD_FAILED,
+])

--- a/mail/tasks_test.py
+++ b/mail/tasks_test.py
@@ -1,16 +1,15 @@
 """
 Tests for Task module
 """
-from urllib.parse import urljoin
 from collections import defaultdict
 import textwrap
 
 import pytest
 from django.conf import settings
-from django.urls import reverse
 
 from mail import tasks
-from mail.models import NotificationEmail
+from mail.api import render_email_templates, context_for_video
+from mail.constants import STATUS_TO_NOTIFICATION, STATUSES_THAT_TRIGGER_DEBUG_EMAIL
 from ui.constants import VideoStatus
 from ui.factories import VideoFactory, MoiraListFactory
 
@@ -52,7 +51,7 @@ def test_send_notification_email_wrong_status(mocker):
     """
     mocked_mailgun = mocker.patch('mail.api.MailgunClient', autospec=True)
     mocked__get_recipients_for_video = mocker.patch('mail.tasks._get_recipients_for_video', autospec=True)
-    assert VideoStatus.UPLOADING not in tasks.STATUS_TO_NOTIFICATION
+    assert VideoStatus.UPLOADING not in STATUS_TO_NOTIFICATION
     video = VideoFactory(status=VideoStatus.UPLOADING)
     tasks.send_notification_email(video)
     assert mocked_mailgun.send_individual_email.call_count == 0
@@ -69,7 +68,7 @@ def test_send_notification_email_no_recipients(mocker):
         autospec=True,
         return_value=[]
     )
-    assert VideoStatus.COMPLETE in tasks.STATUS_TO_NOTIFICATION
+    assert VideoStatus.COMPLETE in STATUS_TO_NOTIFICATION
     video = VideoFactory(status=VideoStatus.COMPLETE)
     tasks.send_notification_email(video)
     assert mocked_mailgun.send_individual_email.call_count == 0
@@ -81,12 +80,15 @@ def test_send_notification_email_no_mail_template(mocker):
     Tests send_notification_email for a video with a status not correspondent to a email template
     """
     mocked_mailgun = mocker.patch('mail.api.MailgunClient', autospec=True)
-    assert VideoStatus.COMPLETE in tasks.STATUS_TO_NOTIFICATION
-    video = VideoFactory(status=VideoStatus.COMPLETE)
-    NotificationEmail.objects.filter(
-        notification_type=tasks.STATUS_TO_NOTIFICATION[VideoStatus.COMPLETE]).delete()
+    mock_log = mocker.patch('mail.tasks.log.error')
+    video = VideoFactory(status=VideoStatus.RETRANSCODING)
     tasks.send_notification_email(video)
     assert mocked_mailgun.send_individual_email.call_count == 0
+    mock_log.assert_called_once_with(
+        "Tried to send notifications for video %s with status %s",
+        video.hexkey,
+        video.status
+    )
 
 
 def test_send_notification_email_happy_path(mocker):
@@ -94,26 +96,19 @@ def test_send_notification_email_happy_path(mocker):
     Tests send_notification_email with happy path
     """
     mocked_mailgun = mocker.patch('mail.api.MailgunClient', autospec=True)
-    assert VideoStatus.COMPLETE in tasks.STATUS_TO_NOTIFICATION
+    assert VideoStatus.COMPLETE in STATUS_TO_NOTIFICATION
     video = VideoFactory(status=VideoStatus.COMPLETE)
+    subject, text, html = render_email_templates(
+        STATUS_TO_NOTIFICATION[VideoStatus.COMPLETE],
+        context_for_video(video)
+    )
     tasks.send_notification_email(video)
-    email_template = NotificationEmail.objects.get(
-        notification_type=tasks.STATUS_TO_NOTIFICATION[VideoStatus.COMPLETE])
-    mocked_mailgun.send_individual_email.assert_called_once_with(**{
-        'subject': email_template.email_subject.format(
-            collection_title=video.collection.title,
-            video_title=video.title
-        ),
-        'body': email_template.email_body.format(
-            collection_title=video.collection.title,
-            video_title=video.title,
-            video_url=urljoin(
-                settings.ODL_VIDEO_BASE_URL,
-                reverse('video-detail', kwargs={'video_key': video.hexkey})
-            ),
-            support_email=settings.EMAIL_SUPPORT
-        ),
-        'recipient': video.collection.owner.email,
+    mocked_mailgun.send_batch.assert_called_once_with(**{
+        'subject': subject,
+        'html_body': html,
+        'text_body': text,
+        'recipients': [(video.collection.owner.email, {})],
+        'sender_address': settings.EMAIL_SUPPORT,
         'raise_for_status': True,
     })
 
@@ -138,7 +133,7 @@ def test_async_send_notification_email_happy_path(mocker):
     mocked_send_email.assert_called_once_with(video)
 
 
-@pytest.mark.parametrize("status", tasks.STATUSES_THAT_TRIGGER_DEBUG_EMAIL)
+@pytest.mark.parametrize("status", STATUSES_THAT_TRIGGER_DEBUG_EMAIL)
 def test_sends_debug_emails(mocker, status):
     """
     Tests send_notification_email with statuses that should trigger sending a
@@ -150,7 +145,7 @@ def test_sends_debug_emails(mocker, status):
     tasks.send_notification_email(video)
     mocked_send_debug_email.assert_called_once_with(
         video=video,
-        email_kwargs=mocked_mailgun.send_individual_email.call_args[1]
+        email_kwargs=mocked_mailgun.send_batch.call_args[1]
     )
 
 
@@ -169,7 +164,8 @@ def test_send_debug_email(mocker):
     )
     mocked_mailgun.send_individual_email.assert_called_once_with(**{
         'subject': 'DEBUG:{}'.format(mock_email_kwargs['subject']),
-        'body': mocked_generate_debug_email_body.return_value,
+        'html_body': None,
+        'text_body': mocked_generate_debug_email_body.return_value,
         'recipient': settings.EMAIL_SUPPORT,
     })
 
@@ -205,9 +201,9 @@ def test_generate_debug_email_body(mocker):
         video=video,
         collection=video.collection,
         owner=video.collection.owner,
-        recipient=email_kwargs['recipient'],
+        recipient=email_kwargs['recipients'],
         subject=email_kwargs['subject'],
-        body=email_kwargs['body'],
+        body=email_kwargs['text_body'],
     )
     actual_body = tasks._generate_debug_email_body(
         video=video,

--- a/mail/tasks_test.py
+++ b/mail/tasks_test.py
@@ -51,7 +51,7 @@ def test_send_notification_email_wrong_status(mocker):
     """
     mocked_mailgun = mocker.patch('mail.api.MailgunClient', autospec=True)
     mocked__get_recipients_for_video = mocker.patch('mail.tasks._get_recipients_for_video', autospec=True)
-    assert VideoStatus.UPLOADING not in STATUS_TO_NOTIFICATION
+    assert VideoStatus.UPLOADING not in tasks.STATUS_TO_NOTIFICATION
     video = VideoFactory(status=VideoStatus.UPLOADING)
     tasks.send_notification_email(video)
     assert mocked_mailgun.send_individual_email.call_count == 0
@@ -68,7 +68,7 @@ def test_send_notification_email_no_recipients(mocker):
         autospec=True,
         return_value=[]
     )
-    assert VideoStatus.COMPLETE in STATUS_TO_NOTIFICATION
+    assert VideoStatus.COMPLETE in tasks.STATUS_TO_NOTIFICATION
     video = VideoFactory(status=VideoStatus.COMPLETE)
     tasks.send_notification_email(video)
     assert mocked_mailgun.send_individual_email.call_count == 0
@@ -85,9 +85,9 @@ def test_send_notification_email_no_mail_template(mocker):
     tasks.send_notification_email(video)
     assert mocked_mailgun.send_individual_email.call_count == 0
     mock_log.assert_called_once_with(
-        "Tried to send notifications for video %s with status %s",
-        video.hexkey,
-        video.status
+        "Unexpected video status",
+        video_hexkey=video.hexkey,
+        video_status='Retranscoding'
     )
 
 
@@ -96,7 +96,7 @@ def test_send_notification_email_happy_path(mocker):
     Tests send_notification_email with happy path
     """
     mocked_mailgun = mocker.patch('mail.api.MailgunClient', autospec=True)
-    assert VideoStatus.COMPLETE in STATUS_TO_NOTIFICATION
+    assert VideoStatus.COMPLETE in tasks.STATUS_TO_NOTIFICATION
     video = VideoFactory(status=VideoStatus.COMPLETE)
     subject, text, html = render_email_templates(
         STATUS_TO_NOTIFICATION[VideoStatus.COMPLETE],

--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -1,0 +1,283 @@
+{% load i18n static %}
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8"> <!-- utf-8 works for most cases -->
+    <meta name="viewport" content="width=device-width"> <!-- Forcing initial-scale shouldn't be necessary -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"> <!-- Use the latest (edge) version of IE rendering engine -->
+    <meta name="x-apple-disable-message-reformatting">  <!-- Disable auto-scale in iOS 10 Mail entirely -->
+    <title>{{ video_title }}</title> <!-- The title tag shows in email notifications, like Android 4.4. -->
+
+    <!-- Web Font / @font-face : BEGIN -->
+    <!-- NOTE: If web fonts are not required, lines 10 - 27 can be safely removed. -->
+
+    <!-- Desktop Outlook chokes on web font references and defaults to Times New Roman, so we force a safe fallback font. -->
+    <!--[if mso]>
+        <style>
+            * {
+                font-family: sans-serif !important;
+            }
+        </style>
+    <![endif]-->
+
+    <!-- All other clients get the webfont reference; some will render the font and others will silently fail to the fallbacks. More on that here: http://stylecampaign.com/blog/2015/02/webfont-support-in-email/ -->
+    <!--[if !mso]><!-->
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" />
+    <!--<![endif]-->
+
+    <!-- Web Font / @font-face : END -->
+
+    <!-- CSS Reset : BEGIN -->
+    <style>
+
+        /* What it does: Remove spaces around the email design added by some email clients. */
+        /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
+        html,
+        body {
+            margin: 0 auto !important;
+            padding: 0 !important;
+            height: 100% !important;
+            width: 100% !important;
+        }
+
+        /* What it does: Stops email clients resizing small text. */
+        * {
+            -ms-text-size-adjust: 100%;
+            -webkit-text-size-adjust: 100%;
+        }
+
+        /* What it does: Centers email on Android 4.4 */
+        div[style*="margin: 16px 0"] {
+            margin: 0 !important;
+        }
+
+        /* What it does: Stops Outlook from adding extra spacing to tables. */
+        table,
+        td {
+            mso-table-lspace: 0pt !important;
+            mso-table-rspace: 0pt !important;
+        }
+
+        /* What it does: Fixes webkit padding issue. Fix for Yahoo mail table alignment bug. Applies table-layout to the first 2 tables then removes for anything nested deeper. */
+        table {
+            border-spacing: 0 !important;
+            border-collapse: collapse !important;
+            table-layout: fixed !important;
+            margin: 0 auto !important;
+        }
+        table table table {
+            table-layout: auto;
+        }
+
+        /* What it does: Uses a better rendering method when resizing images in IE. */
+        img {
+            -ms-interpolation-mode:bicubic;
+        }
+
+        /* What it does: Prevents Windows 10 Mail from underlining links despite inline CSS. Styles for underlined links should be inline. */
+        a {
+            text-decoration: none;
+        }
+
+        /* What it does: A work-around for email clients meddling in triggered links. */
+        *[x-apple-data-detectors],  /* iOS */
+        .unstyle-auto-detected-links *,
+        .aBn {
+            border-bottom: 0 !important;
+            cursor: default !important;
+            color: inherit !important;
+            text-decoration: none !important;
+            font-size: inherit !important;
+            font-family: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+        }
+
+        /* What it does: Prevents Gmail from displaying a download button on large, non-linked images. */
+        .a6S {
+            display: none !important;
+            opacity: 0.01 !important;
+        }
+        /* If the above doesn't work, add a .g-img class to any image in question. */
+        img.g-img + div {
+            display: none !important;
+        }
+
+        /* What it does: Removes right gutter in Gmail iOS app: https://github.com/TedGoas/Cerberus/issues/89  */
+        /* Create one of these media queries for each additional viewport size you'd like to fix */
+
+        /* iPhone 4, 4S, 5, 5S, 5C, and 5SE */
+        @media only screen and (min-device-width: 320px) and (max-device-width: 374px) {
+            .email-container {
+                min-width: 320px !important;
+            }
+        }
+        /* iPhone 6, 6S, 7, 8, and X */
+        @media only screen and (min-device-width: 375px) and (max-device-width: 413px) {
+            .email-container {
+                min-width: 375px !important;
+            }
+        }
+        /* iPhone 6+, 7+, and 8+ */
+        @media only screen and (min-device-width: 414px) {
+            .email-container {
+                min-width: 414px !important;
+            }
+        }
+    </style>
+    <!-- CSS Reset : END -->
+	<!-- Reset list spacing because Outlook ignores much of our inline CSS. -->
+	<!--[if mso]>
+	<style type="text/css">
+		ul,
+		ol {
+			margin: 0 !important;
+		}
+		li {
+			margin-left: 30px !important;
+		}
+		li.list-item-first {
+			margin-top: 0 !important;
+		}
+		li.list-item-last {
+			margin-bottom: 10px !important;
+		}
+	</style>
+	<![endif]-->
+
+    <!-- Progressive Enhancements : BEGIN -->
+    <style>
+
+	    /* What it does: Hover styles for buttons */
+	    .button-td,
+	    .button-a {
+	        transition: all 100ms ease-in;
+	    }
+	    .button-td-primary:hover,
+	    .button-a-primary:hover {
+	        background: #ffffff !important;
+	        border-color: #a31f34 !important;
+	    }
+
+	    /* Media Queries */
+	    @media screen and (max-width: 480px) {
+
+	        /* What it does: Forces elements to resize to the full width of their container. Useful for resizing images beyond their max-width. */
+	        .fluid {
+	            width: 100% !important;
+	            max-width: 100% !important;
+	            height: auto !important;
+	            margin-left: auto !important;
+	            margin-right: auto !important;
+	        }
+
+	        /* What it does: Forces table cells into full-width rows. */
+	        .stack-column,
+	        .stack-column-center {
+	            display: block !important;
+	            width: 100% !important;
+	            max-width: 100% !important;
+	            direction: ltr !important;
+	        }
+	        /* And center justify these ones. */
+	        .stack-column-center {
+	            text-align: center !important;
+	        }
+
+	        /* What it does: Generic utility class for centering. Useful for images, buttons, and nested tables. */
+	        .center-on-narrow {
+	            text-align: center !important;
+	            display: block !important;
+	            margin-left: auto !important;
+	            margin-right: auto !important;
+	            float: none !important;
+	        }
+	        table.center-on-narrow {
+	            display: inline-block !important;
+	        }
+
+	        /* What it does: Adjust typography on small screens to improve readability */
+	        .email-container p {
+	            font-size: 17px !important;
+	        }
+	    }
+
+        .link-button {
+            height: 40px;
+            width: 158px;
+            border-radius: 4px;
+            background-color: #007EE5;
+            color: #ffffff;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-family: Roboto;
+            font-size: 16px;
+            font-weight: 500;
+            letter-spacing: 0.13px;
+            line-height: 19px;
+        }
+
+    </style>
+    <!-- Progressive Enhancements : END -->
+
+    <!-- What it does: Makes background images in 72ppi Outlook render at correct size. -->
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+
+</head>
+<body width="100%" style="margin: 0; padding: 0 !important; mso-line-height-rule: exactly; background-color: #ffffff;">
+	<center style="width: 100%; background-color: #ffffff;">
+    <!--[if mso | IE]>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #ffffff;">
+    <tr>
+    <td>
+    <![endif]-->
+
+        <div style="max-width: 680px; margin: 0 auto;" class="email-container">
+            <!--[if mso]>
+            <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="680">
+            <tr>
+            <td>
+            <![endif]-->
+
+	        <!-- Email Body : BEGIN -->
+	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 auto;">
+            {% block content %}{% endblock %}
+
+            <!-- Clear Spacer : BEGIN -->
+              <tr>
+                  <td aria-hidden="true" height="40" style="font-size: 0px; line-height: 0px;">
+                      &nbsp;
+                  </td>
+              </tr>
+            <!-- Clear Spacer : END -->
+
+            <tr>
+              <td style="padding: 0 20px; text-align: left;">--</td>
+            </tr>
+
+          </table>
+          <!-- Email Body : END -->
+
+        <!--[if mso]>
+        </td>
+        </tr>
+        </table>
+        <![endif]-->
+        </div>
+
+    <!--[if mso | IE]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+    </center>
+</body>
+</html>

--- a/mail/templates/email_base.html
+++ b/mail/templates/email_base.html
@@ -155,8 +155,7 @@
 	    }
 	    .button-td-primary:hover,
 	    .button-a-primary:hover {
-	        background: #ffffff !important;
-	        border-color: #a31f34 !important;
+	        background: #007EE5 !important;
 	    }
 
 	    /* Media Queries */
@@ -202,22 +201,6 @@
 	        }
 	    }
 
-        .link-button {
-            height: 40px;
-            width: 158px;
-            border-radius: 4px;
-            background-color: #007EE5;
-            color: #ffffff;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            font-family: Roboto;
-            font-size: 16px;
-            font-weight: 500;
-            letter-spacing: 0.13px;
-            line-height: 19px;
-        }
-
     </style>
     <!-- Progressive Enhancements : END -->
 
@@ -250,7 +233,12 @@
 	        <!-- Email Body : BEGIN -->
 	        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 auto;">
             {% block content %}{% endblock %}
-
+              <tr>
+                <td style="padding: 0 20px 20px;">
+                    Thank you,<br />
+                    Open Learning Video Service
+                </td>
+              </tr>
             <!-- Clear Spacer : BEGIN -->
               <tr>
                   <td aria-hidden="true" height="40" style="font-size: 0px; line-height: 0px;">

--- a/mail/templates/invalid_format_error/body.html
+++ b/mail/templates/invalid_format_error/body.html
@@ -1,10 +1,10 @@
 {% extends "email_base.html" %}
 {% block content %}
   <tr>
-      <td style="background-color: #ffffff;">
+      <td style="padding: 0 20px 20px;">
         <p>We’re sorry, there was a problem processing your video</p>
-        <p>Video: <a href={{ video_url }}>{{video_title}}</a></p>
-        <p>Collection: <a href={{ collection_url }}>{{collection_title}}</a></p>
+        <p>Video: <a href="{{ video_url }}">{{video_title}}</a></p>
+        <p>Collection: <a href="{{ collection_url }}">{{collection_title}}</a></p>
         <p>Please check if the file you uploaded is an actual video and you can play it.
             If you think it should work, please contact us at {{support_email}}
         </p>

--- a/mail/templates/invalid_format_error/body.html
+++ b/mail/templates/invalid_format_error/body.html
@@ -1,0 +1,13 @@
+{% extends "email_base.html" %}
+{% block content %}
+  <tr>
+      <td style="background-color: #ffffff;">
+        <p>We’re sorry, there was a problem processing your video</p>
+        <p>Video: <a href={{ video_url }}>{{video_title}}</a></p>
+        <p>Collection: <a href={{ collection_url }}>{{collection_title}}</a></p>
+        <p>Please check if the file you uploaded is an actual video and you can play it.
+            If you think it should work, please contact us at {{support_email}}
+        </p>
+      </td>
+  </tr>
+{%  endblock %}

--- a/mail/templates/invalid_format_error/subject.txt
+++ b/mail/templates/invalid_format_error/subject.txt
@@ -1,0 +1,1 @@
+Error posting your video "{{video_title}}"

--- a/mail/templates/other_error/body.html
+++ b/mail/templates/other_error/body.html
@@ -1,0 +1,11 @@
+{% extends "email_base.html" %}
+{% block content %}
+  <tr>
+      <td style="background-color: #ffffff;">
+        <p>We’re sorry, there was a problem processing your video</p>
+        <p>Video: <a href={{ video_url }}>{{video_title}}</a></p>
+        <p>Collection: <a href={{ collection_url }}>{{collection_title}}</a></p>
+        <p>Someone on the engineering team has been notified and will contact you shortly.</p>
+      </td>
+  </tr>
+{%  endblock %}

--- a/mail/templates/other_error/body.html
+++ b/mail/templates/other_error/body.html
@@ -1,10 +1,10 @@
 {% extends "email_base.html" %}
 {% block content %}
   <tr>
-      <td style="background-color: #ffffff;">
+      <td style="padding: 0 20px 20px;">
         <p>We’re sorry, there was a problem processing your video</p>
-        <p>Video: <a href={{ video_url }}>{{video_title}}</a></p>
-        <p>Collection: <a href={{ collection_url }}>{{collection_title}}</a></p>
+        <p>Video: <a href="{{ video_url }}">{{video_title}}</a></p>
+        <p>Collection: <a href="{{ collection_url }}">{{collection_title}}</a></p>
         <p>Someone on the engineering team has been notified and will contact you shortly.</p>
       </td>
   </tr>

--- a/mail/templates/other_error/subject.txt
+++ b/mail/templates/other_error/subject.txt
@@ -1,0 +1,1 @@
+Error posting your video "{{video_title}}"

--- a/mail/templates/sample/body.html
+++ b/mail/templates/sample/body.html
@@ -1,0 +1,6 @@
+<style type="text/css">
+a {
+  color: red;
+}
+</style>
+<a href="{{ video_url }}">html link</a>

--- a/mail/templates/sample/subject.txt
+++ b/mail/templates/sample/subject.txt
@@ -1,0 +1,1 @@
+Your video "{{ video_title }}" is ready

--- a/mail/templates/success/body.html
+++ b/mail/templates/success/body.html
@@ -1,0 +1,16 @@
+{% extends "email_base.html" %}
+{% block content %}
+  <tr>
+      <td style="background-color: #ffffff;">
+        <p>Hello, your video is now available on the OVS web site.</p>
+
+        <p>Video: <a href={{ video_url }}>{{video_title}}</a></p>
+        <p>Collection: <a href={{ collection_url }}>{{collection_title}}</a></p>
+        <p>
+            <a class="link-button" href={{ video_url }}>
+                <span>View Your Video</span>
+            </a>
+        </p>
+      </td>
+  </tr>
+{%  endblock %}

--- a/mail/templates/success/body.html
+++ b/mail/templates/success/body.html
@@ -1,16 +1,17 @@
 {% extends "email_base.html" %}
 {% block content %}
   <tr>
-      <td style="background-color: #ffffff;">
-        <p>Hello, your video is now available on the OVS web site.</p>
+      <td style="padding: 0 20px 20px;">
+        <p>Hello, your video has finished processing and is ready!</p>
 
-        <p>Video: <a href={{ video_url }}>{{video_title}}</a></p>
-        <p>Collection: <a href={{ collection_url }}>{{collection_title}}</a></p>
-        <p>
-            <a class="link-button" href={{ video_url }}>
-                <span>View Your Video</span>
-            </a>
-        </p>
+        <p>Video: <a href="{{ video_url }}">{{video_title}}</a></p>
+        <p>Collection: <a href="{{ collection_url }}">{{collection_title}}</a></p>
+         <table align="left" role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: auto;">
+          <tr>
+              <td class="button-td button-td-primary" style="border-radius: 4px; background: #ffffff;"><a class="button-a button-a-primary" style="background: #007EE5; font-family: Roboto; font-size: 16px; line-height: 19px; text-decoration: none; padding: 13px 28px; color: #ffffff; display: block; border-radius: 4px;" href="{{ video_url }}"><span>View Your Video</span></a>
+              </td>
+          </tr>
+         </table>
       </td>
   </tr>
 {%  endblock %}

--- a/mail/templates/success/subject.txt
+++ b/mail/templates/success/subject.txt
@@ -1,0 +1,1 @@
+Video "{{video_title}}" is ready in collection "{{collection_title}}"

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ cryptography
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-redis==4.7.0
-djangorestframework==3.9.1
+djangorestframework==3.11.0
 django-server-status==0.6.0
 django-webpack-loader==0.5.0
 factory_boy

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@
 #
 amqp==2.5.2               # via kombu
 appdirs==1.4.3            # via fs, zeep
-appnope==0.1.0            # via ipython
 attrs==19.3.0             # via zeep
 backcall==0.1.0           # via ipython
 beautifulsoup4==4.9.0     # via pycaption
@@ -38,8 +37,8 @@ django-redis==4.7.0       # via -r requirements.in
 django-server-status==0.6.0  # via -r requirements.in
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git#egg=django-shibboleth-remoteuser==0.9  # via -r requirements.in
 django-webpack-loader==0.5.0  # via -r requirements.in
-django==2.2.10            # via -r requirements.in, django-elastic-transcoder
-djangorestframework==3.9.1  # via -r requirements.in
+django==2.2.10            # via -r requirements.in, django-elastic-transcoder, djangorestframework
+djangorestframework==3.11.0  # via -r requirements.in
 docutils==0.15.2          # via botocore
 dropbox==9.0.0            # via -r requirements.in
 elasticsearch==7.6.0      # via django-server-status


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://trello.com/c/ch9rjBlN/28-update-notification-email-when-video-is-ready

#### What's this PR do?
- Adds HTML email templates to OVS
- Does not yet remove the `NotificationEmail` model - my thought is that it should be removed in a subsequent PR in case this one needs to be reverted.

#### How should this be manually tested?
- Set `MAILGUN_RECIPIENT_OVERRIDE=<your_email>` and other MAILGUN .env variables (you can get them from CI)
- Set `ODL_VIDEO_FROM_EMAIL=MIT ODL Video <odl-video-support@mit.edu>`
- Set `ODL_VIDEO_SUPPORT_EMAIL=MIT ODL Video <odl-video-support@mit.edu>`
- Run the following, you should get 3 emails afterward:
```
from mail.tasks import *
from ui.models import *
video = Video.objects.order_by("-created_at").first()
for status in [VideoStatus.COMPLETE, VideoStatus.TRANSCODE_FAILED_VIDEO, VideoStatus.UPLOAD_FAILED]:
    video.status = status
    send_notification_email(video)
```


#### Screenshots (if appropriate)

SUCCESS:

<img width="1004" alt="Screen Shot 2020-04-23 at 1 43 21 PM" src="https://user-images.githubusercontent.com/187676/80131657-8dc7dc80-8568-11ea-99d2-79587ef50d14.png">



ERROR LIKELY DUE TO INVALID FORMAT:

<img width="1009" alt="Screen Shot 2020-04-23 at 1 43 36 PM" src="https://user-images.githubusercontent.com/187676/80131643-87d1fb80-8568-11ea-9d43-c023bcc6d4b5.png">



OTHER ERRORS:

<img width="721" alt="Screen Shot 2020-04-23 at 1 24 09 PM" src="https://user-images.githubusercontent.com/187676/80131085-b1d6ee00-8567-11ea-85a2-824f78d9013b.png">


