### PR TITLE
Fix TechTV embed URLs

### DIFF
--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -57,6 +57,11 @@ class App extends React.Component<*, void> {
           path={`${match.url}videos/:videoKey/embed/`}
           component={this.renderVideoEmbedPage}
         />
+        <Route
+          exact
+          path={`${match.url}embeds/:videoKey/`}
+          component={this.renderVideoEmbedPage}
+        />
         <Route exact path={`${match.url}help/`} component={HelpPage} />
         <Route exact path={`${match.url}terms/`} component={TermsPage} />
       </div>

--- a/static/js/containers/App.js
+++ b/static/js/containers/App.js
@@ -49,6 +49,11 @@ class App extends React.Component<*, void> {
         />
         <Route
           exact
+          path={`${match.url}collections/:collectionKey/videos/:videoKey/`}
+          component={this.renderVideoDetailPage}
+        />
+        <Route
+          exact
           path={`${match.url}videos/:videoKey/`}
           component={this.renderVideoDetailPage}
         />


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes Techtv embed URL's

#### How should this be manually tested?
```Python
from ui.models import *
from techtv2ovs.models import *
ttc = TechTVCollection.objects.create(id=123, collection=Collection.objects.first())
ttv = TechTVVideo.objects.create(ttv_id=987, ttv_collection=ttc, video=Video.objects.last(), video_status='Complete', status = "Complete", title="TTV Video")
```
 - Go to `http://localhost:8089/embeds/987/`, it should load the video embed page
- Go to `http://localhost:8089/collections/123/videos/987/`, it should load the video detail page