### PR TITLE
Add optional logging to file, not stdio

### DIFF
--- a/odl_video/logging.py
+++ b/odl_video/logging.py
@@ -4,9 +4,15 @@ from structlog_sentry import SentryJsonProcessor
 import structlog
 from odl_video import settings
 
+log_config_args = {
+    'level': getattr(logging, settings.LOG_LEVEL),
+    'format': '%(message)s'
+}
 
-logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL),
-                    format='%(message)s')
+if settings.LOG_FILE:
+    log_config_args['filename'] = settings.LOG_FILE
+
+logging.basicConfig(**log_config_args)
 
 structlog_processors_per_debug = {
     True: [

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -234,6 +234,7 @@ else:
 # Logging configuration
 LOG_LEVEL = get_string('ODL_VIDEO_LOG_LEVEL', 'INFO')
 DJANGO_LOG_LEVEL = get_string('DJANGO_LOG_LEVEL', 'INFO')
+LOG_FILE = get_string('ODL_VIDEO_LOG_FILE', None)
 
 # For logging to a remote syslog host
 LOG_HOST = get_string('ODL_VIDEO_LOG_HOST', 'localhost')


### PR DESCRIPTION

#### What are the relevant tickets?

https://trello.com/c/qEbo79DI/78-add-odl-video-service-uwsgi-log-to-fluentd

#### What's this PR do?

Add an optional file destination for logging, instead of the default stderr stream. This can be used to keep app log messages separate from uWSGI middleware log messages, which gives us better control over the formatting of the lines that we want to have JSON-formatted in production. The messages coming from uWSGI itself can continue to have their own particular format.

#### How should this be manually tested?

There should be no change in behavior if you change nothing in your configuration. If you define the `ODL_VIDEO_LOG_FILE` environment variable, you should see a log getting written out that contains only the messages from our application's `logger` calls, not mixed in with the uWSGI messages.
