### PR TITLE
Add ODL_VIDEO_LOG_FILE to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -121,6 +121,10 @@
       "description": "Application base URL",
       "required": true
     },
+    "ODL_VIDEO_LOG_FILE": {
+      "description": "Log file for Django application messages, as alternative to default stderr",
+      "required": false
+    },
     "ODL_VIDEO_LOG_LEVEL": {
       "description": "Logging level for the application",
       "required": true,


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/qEbo79DI/78-add-odl-video-service-uwsgi-log-to-fluentd
and this PR: https://github.com/mitodl/odl-video-service/pull/883

#### What's this PR do?

It adds the variable `ODL_VIDEO_LOG_FILE` to `app.json`, per [Matt's comment](https://github.com/mitodl/odl-video-service/pull/883#pullrequestreview-403043848).

#### How should this be manually tested?

?
