### PR TITLE
With log file specified, force logger to write to file

### DIFF
--- a/odl_video/logging.py
+++ b/odl_video/logging.py
@@ -4,15 +4,8 @@ from structlog_sentry import SentryJsonProcessor
 import structlog
 from odl_video import settings
 
-log_config_args = {
-    'level': getattr(logging, settings.LOG_LEVEL),
-    'format': '%(message)s'
-}
-
-if settings.LOG_FILE:
-    log_config_args['filename'] = settings.LOG_FILE
-
-logging.basicConfig(**log_config_args)
+logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL),
+                    format='%(message)s')
 
 structlog_processors_per_debug = {
     True: [
@@ -54,4 +47,7 @@ structlog.configure(
 
 def getLogger(name):
     """Return a logger with the given name"""
-    return structlog.get_logger(name)
+    logger = structlog.get_logger(name)
+    if settings.LOG_FILE:
+        logger.addHandler(logging.FileHandler(settings.LOG_FILE))
+    return logger


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/qEbo79DI/78-add-odl-video-service-uwsgi-log-to-fluentd

#### What's this PR do?

When a log file destination is specified in the `ODL_VIDEO_LOG_FILE` variable, ensure that Django does not override the handlers that we want, by explicitly adding a `FileHandler` to the logger in `odl_video.logging.get_logger()`.

Although https://docs.python.org/3.6/library/logging.html#logging.basicConfig says that the `filename` parameter to `basicConfig` "Specifies that a FileHandler be created, using the specified filename, rather than a StreamHandler," this is either misleading -- or else some magic from elsewhere in the application or its frameworks is jumping in and foiling my expectations.

I have found through manual experimentation that overriding the handler _after_ the getLogger() call successfully creates the log that I want. (I've reverted my temporary change.)

After my change, on the RC server:

```
$ cat  /var/log/odl-video/django.log
{"video_id": 123456, "event": "Exception retrieving video", "logger": "cloudsync.tasks", "level": "error", "timestamp": 1588359803.8356478, "sentry": "sent", "sentry_id": "c3888048c6d6469a83745a7972cbab37"}
```

Although this does still show up in the uWSGI log:

```
[2020-05-01 19:03:23,846: ERROR/ForkPoolWorker-2] {"video_id": 123456, "event": "Exception retrieving video", "logger": "cloudsync.tasks", "level": "error", "timestamp": 1588359803.8356478, "sentry": "sent", "sentry_id": "c3888048c6d6469a83745a7972cbab37"}
```

... I'm not sure if this is a problem. What do you think? (@blarghmatey ?) Is a redundant log line in the uWSGI log something we can deal with? At least the message is written out to `/var/log/odl-video/django.log` so that FluentD can make use of it now.


