### PR TITLE
Add url links to video/collection admin

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,6 +3,7 @@ codecov
 ddt==1.3.1
 django-debug-toolbar
 ipdb
+isort==4.3.21
 nplusone
 pdbpp
 pip-tools

--- a/ui/admin.py
+++ b/ui/admin.py
@@ -1,10 +1,16 @@
 """
 Admin for UI app
 """
+from urllib.parse import urljoin
+
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
 
 from dj_elastictranscoder.models import EncodeJob
+from django.urls import reverse
+from django.utils.html import format_html
+
 from ui import models
 
 
@@ -37,9 +43,26 @@ class CollectionEdxEndpointInlineAdmin(admin.StackedInline):
 
 class CollectionAdmin(admin.ModelAdmin):
     """Customized collection admin model"""
+
+    def show_url(self, obj):
+        """ Display the collection URL"""
+        url = urljoin(
+            settings.ODL_VIDEO_BASE_URL,
+            reverse('collection-react-view', kwargs={'collection_key': obj.hexkey})
+        )
+        return format_html("<a href='{url}'>{url}</a>", url=url)
+
+    def get_fields(self, request, obj):
+        """ Add show_url to the beginning of model fields"""
+        return ['show_url'] + super().get_fields(request, obj)
+
+    show_url.short_description = "URL"
+    show_url.mark_safe = True
+
     date_hierarchy = 'created_at'
-    readonly_fields = ['created_at']
+    readonly_fields = ['show_url', 'created_at']
     list_filter = ['stream_source']
+    list_display = ['title', 'show_url']
     autocomplete_fields = ['owner', 'view_lists', 'admin_lists']
     search_fields = (
         'title',
@@ -115,6 +138,22 @@ class VideoEncodeJobsInline(GenericTabularInline):
 
 class VideoAdmin(admin.ModelAdmin):
     """Customized Video admin model"""
+
+    def show_url(self, obj):
+        """ Display the video URL"""
+        url = urljoin(
+            settings.ODL_VIDEO_BASE_URL,
+            reverse('video-detail', kwargs={'video_key': obj.hexkey})
+        )
+        return format_html("<a href='{url}'>{url}</a>", url=url)
+
+    def get_fields(self, request, obj):
+        """ Add show_url to the beginning of model fields"""
+        return ['show_url'] + super().get_fields(request, obj)
+
+    show_url.short_description = "URL"
+    show_url.mark_safe = True
+
     model = models.Video
     inlines = [
         VideoEncodeJobsInline,
@@ -126,10 +165,11 @@ class VideoAdmin(admin.ModelAdmin):
     list_display = (
         'title',
         'created_at',
+        'show_url',
     )
     list_filter = ['encode_jobs__state', 'status']
     date_hierarchy = 'created_at'
-    readonly_fields = ['created_at']
+    readonly_fields = ['show_url', 'created_at']
     search_fields = (
         'title',
         'description',

--- a/ui/admin.py
+++ b/ui/admin.py
@@ -6,10 +6,10 @@ from urllib.parse import urljoin
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
-
-from dj_elastictranscoder.models import EncodeJob
 from django.urls import reverse
 from django.utils.html import format_html
+
+from dj_elastictranscoder.models import EncodeJob
 
 from ui import models
 
@@ -52,7 +52,7 @@ class CollectionAdmin(admin.ModelAdmin):
         )
         return format_html("<a href='{url}'>{url}</a>", url=url)
 
-    def get_fields(self, request, obj):
+    def get_fields(self, request, obj=None):
         """ Add show_url to the beginning of model fields"""
         return ['show_url'] + super().get_fields(request, obj)
 
@@ -147,7 +147,7 @@ class VideoAdmin(admin.ModelAdmin):
         )
         return format_html("<a href='{url}'>{url}</a>", url=url)
 
-    def get_fields(self, request, obj):
+    def get_fields(self, request, obj=None):
         """ Add show_url to the beginning of model fields"""
         return ['show_url'] + super().get_fields(request, obj)
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #897 
pegs `isort` to stop build errors on travis

#### What's this PR do?
Adds collection/video URL links for videos and collections on the django admin pages.

#### How should this be manually tested?
Go to collection/video list and detail pages in django admin, there should be links to each object's detail page and the links should work properly.

#### Screenshots (if appropriate)
<img width="1029" alt="Screen Shot 2020-07-10 at 10 28 51 AM" src="https://user-images.githubusercontent.com/187676/87165965-de61f280-c298-11ea-91ea-9bba089300ea.png">

<img width="1033" alt="Screen Shot 2020-07-10 at 10 29 01 AM" src="https://user-images.githubusercontent.com/187676/87165981-e3bf3d00-c298-11ea-9df6-cbe34cba49c0.png">

<img width="1157" alt="Screen Shot 2020-07-10 at 10 29 17 AM" src="https://user-images.githubusercontent.com/187676/87165988-e6ba2d80-c298-11ea-9f4e-2709fc032649.png">

<img width="1163" alt="Screen Shot 2020-07-10 at 10 29 25 AM" src="https://user-images.githubusercontent.com/187676/87166000-e9b51e00-c298-11ea-85fa-9256f565e76d.png">
