### PR TITLE
API request to EDX: use JWT token

### DIFF
--- a/ui/api.py
+++ b/ui/api.py
@@ -105,7 +105,7 @@ def post_hls_to_edx(video_file):
                     "duration": 0.0,
                 },
                 headers={
-                    "Authorization": "Bearer {}".format(edx_endpoint.access_token),
+                    "Authorization": "JWT {}".format(edx_endpoint.access_token),
                 },
             )
             resp.raise_for_status()


### PR DESCRIPTION
#### Pre-Flight checklist


- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fix #927

#### What's this PR do?
Update the header in an API request to edX to JWT instead of Bearer.

#### How should this be manually tested?
on RC
related documentation https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/#using-an-access-token-to-make-rest-requests

