### PR TITLE
Limit number of redis connections if an env variable is set

### DIFF
--- a/app.json
+++ b/app.json
@@ -169,6 +169,10 @@
     "PGBOUNCER_MIN_POOL_SIZE": {
       "value": "5"
     },
+    "REDIS_MAX_CONNECTIONS": {
+      "description": "Max number of connections to allow to redis",
+      "required": "false"
+    },
     "SCHEDULE_RETRANSCODE_FREQUENCY": {
       "description": "How often to check for scheduled retranscodes",
       "required": "false"

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -436,6 +436,7 @@ REST_FRAMEWORK = {
 # Celery
 # http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
 REDIS_URL = get_string("REDIS_URL", None)
+REDIS_MAX_CONNECTIONS = get_int("REDIS_MAX_CONNECTIONS", 2147483648)
 USE_CELERY = True
 CELERY_BROKER_URL = get_string("CELERY_BROKER_URL", REDIS_URL)
 CELERY_RESULT_BACKEND = REDIS_URL
@@ -477,7 +478,10 @@ CACHES = {
     "redis": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URL,
-        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "CONNECTION_POOL_KWARGS": {"max_connections": REDIS_MAX_CONNECTIONS},
+        },
     },
 }
 

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -436,7 +436,7 @@ REST_FRAMEWORK = {
 # Celery
 # http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
 REDIS_URL = get_string("REDIS_URL", None)
-REDIS_MAX_CONNECTIONS = get_int("REDIS_MAX_CONNECTIONS", 2147483648)
+REDIS_MAX_CONNECTIONS = get_int("REDIS_MAX_CONNECTIONS", 65000)
 USE_CELERY = True
 CELERY_BROKER_URL = get_string("CELERY_BROKER_URL", REDIS_URL)
 CELERY_RESULT_BACKEND = REDIS_URL


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Hopefully closes #936 

#### What's this PR do?
Limits the number of max redis connections to `REDIS_MAX_CONNECTIONS` if set, or 2147483648 otherwise (the default).

#### How should this be manually tested?
If you don't set `REDIS_MAX_CONNECTIONS`, the output of this command should be 2147483648, otherwise it should be equal to `REDIS_MAX_CONNECTIONS`:

```
from django_redis import get_redis_connection
r = get_redis_connection("redis")
r.connection_pool.max_connections
```

Set `REDIS_MAX_CONNECTIONS` to 10, then run 20 tasks, they should all complete without errors:
```
from cloudsync.tasks import update_video_statuses
for i in range(20):
    update_video_statuses.delay()
```
