### PR TITLE
The schedule_retranscodes task shouldn't replace itself if there's nothing to do

### DIFF
--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -758,6 +758,14 @@ def test_schedule_retranscodes(
     assert Collection.objects.get(id=collection.id).schedule_retranscode is False
 
 
+def test_no_scheduled_retranscodes(mocked_celery):
+    """
+    Test that schedule_retranscodes doesn't raise a replacement if no videos need a retranscode
+    """
+    schedule_retranscodes.delay()
+    assert mocked_celery.group.call_count == 0
+
+
 def test_schedule_retranscodes_error(mocker, mocked_celery):
     """
     Test that schedule_retranscodes logs an error if it occurs


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Might be relevant to #936 

#### What's this PR do?
Fixes an inefficiency in the `schedule_retranscodes` task

#### How should this be manually tested?
Tests should pass, you should be able to run `schedule_retranscodes.delay()` in a shell without error.
