### PR TITLE
Make env parsing forgiving of blank lines and unset vars

### DIFF
--- a/odl_video/envs.py
+++ b/odl_video/envs.py
@@ -178,7 +178,10 @@ def parse_env(env_file):
     try:
         with open(env_file, encoding="utf-8") as envsettings:
             for line in envsettings:
-                k, v = line.rstrip("\n").lstrip("export ").split("=", maxsplit=1)
-                os.environ.setdefault(k, v)
+                try:
+                    k, v = line.rstrip("\n").lstrip("export ").split("=", maxsplit=1)
+                    os.environ.setdefault(k, v)
+                except ValueError:
+                    continue
     except FileNotFoundError:
         pass

--- a/odl_video/envs_test.py
+++ b/odl_video/envs_test.py
@@ -166,7 +166,7 @@ def test_parse_env():
     try:
         testpath = "testenv.txt"
         with open(testpath, "w", encoding="utf-8") as testfile:
-            testfile.write("FOO_VAR=bar=var\nexport FOO_NUM=42\n\nNULL_VAR=\n\n\n")
+            testfile.write("FOO_VAR=bar=var\n\nNULL_VAR=\n\n\nexport FOO_NUM=42\n")
         parse_env(testpath)
         assert get_string("FOO_VAR", "") == "bar=var"
         assert get_int("FOO_NUM", 0) == 42

--- a/odl_video/envs_test.py
+++ b/odl_video/envs_test.py
@@ -166,7 +166,7 @@ def test_parse_env():
     try:
         testpath = "testenv.txt"
         with open(testpath, "w", encoding="utf-8") as testfile:
-            testfile.write("FOO_VAR=bar=var\nexport FOO_NUM=42\n")
+            testfile.write("FOO_VAR=bar=var\nexport FOO_NUM=42\n\nNULL_VAR=\n\n\n")
         parse_env(testpath)
         assert get_string("FOO_VAR", "") == "bar=var"
         assert get_int("FOO_NUM", 0) == 42


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #994 

#### What's this PR do?
Catches and ignores any `ValueErrors` raised while parsing the .env file

#### How should this be manually tested?
- Add some blank lines and some blank values for variables in your .env file, in addition to all the usual ones needed for OVS:
   ```
   MY_ENV_1=
   
   MY_ENV_2=
   
   ```
- Run `docker-compose up`, the app should start successfully
