### PR TITLE
Dockerfile restructuring and enable multi-stage builds. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,5 @@ FROM production AS development
 USER root
 COPY test_requirements.txt /tmp/test_requirements.txt
 RUN pip install -r /tmp/requirements.txt -r /tmp/test_requirements.txt
+RUN chown -R mitodl:mitodl /tmp/.cache
 USER mitodl

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,10 @@ ENV PORT 8089
 CMD uwsgi uwsgi.ini
 
 # Second stage build installs reqs needed only for develoment envs
-# Invoke 'requirements.txt' again because 'test_requirements.txt' doesn't 
-# like to run alone for some reason
+# Invoke 'requirements.txt' again because 'test_requirements.txt' doesn't
+# like to run alone for some reasont
 FROM production AS development
+USER root
 COPY test_requirements.txt /tmp/test_requirements.txt
-RUN pip install -r requirements.txt -r test_requirements.txt
+RUN pip install -r /tmp/requirements.txt -r /tmp/test_requirements.txt
+USER mitodl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.13
+FROM python:3.9.13 AS production
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
@@ -6,12 +6,14 @@ WORKDIR /tmp
 
 # Install packages
 COPY apt.txt /tmp/apt.txt
-RUN apt-get update
-RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
+RUN apt-get update && \
+    apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ") && \
+    apt-get update && \
+    apt-get install libpq-dev postgresql-client -y && \
+    apt-get clean && \
+    apt-get purge
 
-RUN apt-get update && apt-get install libpq-dev postgresql-client -y
-
-# pip
+# Install pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -
 
 # Add, and run as, non-root user.
@@ -21,15 +23,13 @@ RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 
 # Install project packages
 COPY requirements.txt /tmp/requirements.txt
-COPY test_requirements.txt /tmp/test_requirements.txt
-RUN pip install -r requirements.txt -r test_requirements.txt
+RUN pip install -r requirements.txt
 
 # Add project
 COPY . /src
 WORKDIR /src
 RUN chown -R mitodl:mitodl /src
 
-RUN apt-get clean && apt-get purge
 USER mitodl
 
 # Set pip cache folder, as it is breaking pip when it is on a shared volume
@@ -38,3 +38,10 @@ ENV XDG_CACHE_HOME /tmp/.cache
 EXPOSE 8089
 ENV PORT 8089
 CMD uwsgi uwsgi.ini
+
+# Second stage build installs reqs needed only for develoment envs
+# Invoke 'requirements.txt' again because 'test_requirements.txt' doesn't 
+# like to run alone for some reason
+FROM production AS development
+COPY test_requirements.txt /tmp/test_requirements.txt
+RUN pip install -r requirements.txt -r test_requirements.txt


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/1099

#### What's this PR do?
Converted the docker file to a multistage build so we can create a smaller image for production. I also reorganized a few things and combined a few steps into one to promote a smaller image, as well. 


#### How should this be manually tested?
`docker compose build`
and 
`docker compose up`
Still work as expected.

This will allow us to build an image that drops the `test_requirements.txt` pip step for production (makes it a bit smaller). 

We will do that with something like `docker build . --target production`

Calling just `docker build .` builds the whole dockerfile still. 
