### PR TITLE
Adjustments to allow for Redis+TLS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ celery==4.3.0
     # via
     #   -r requirements.in
     #   celery-redbeat
-celery-redbeat==0.13.0
+celery-redbeat==2.0.0
     # via -r requirements.in
 certifi==2020.4.5.1
     # via


### PR DESCRIPTION
Tweaking the application settings to allow celery and redbeat to use TLS when connecting to Redis/Elasticache.

#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/1099

#### What's this PR do?
Documents an explicit distinction between REDIS_URL and CELERY_BROKER_URL and when they can be same (no TLS) and when the must diverge (using TLS) as well as the nature of that divergence. 

Additionally updates celery-redbeat from a really old version to just an old version (but the newest available...) 

#### How should this be manually tested?
... Might be tricky without REDIS+TLS. It would be good to verify that non-TLS setups continue to work by setting REDIS_URL.

 TLS is straight forward and the default in AWS and it comes with a verifiable certificate. I can do a screenshare on a new QA environment that has REDIS+TLS if you want to see it in action. 

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
