### PR TITLE
Use from_service_account_info instead of from_json_keyfile_dict for google credentials

### DIFF
--- a/ui/utils.py
+++ b/ui/utils.py
@@ -267,14 +267,14 @@ def get_google_analytics_client():
         analytics_client: An analytics client
     """
     try:
-        credentials = ServiceAccountCredentials.from_json_keyfile_dict(
+        credentials = ServiceAccountCredentials.from_service_account_info(
             json.loads(settings.GA_KEYFILE_JSON)
         )
         analytics_client = build("analyticsreporting", "v4", credentials=credentials)
         return analytics_client
     except Exception as exc:  # pylint: disable=broad-except
         raise GoogleAnalyticsException(
-            "Something went wrong with creating a GoogleAnaltics client"
+            "Something went wrong with creating a GoogleAnalytics client"
         ) from exc
 
 

--- a/ui/utils_test.py
+++ b/ui/utils_test.py
@@ -196,10 +196,10 @@ def test_get_google_analytics_client_success(ga_client_mocks, settings):
     settings.GA_KEYFILE_JSON = '{"some": "json"}'
     result = get_google_analytics_client()
     assert (
-        ga_client_mocks["ServiceAccountCredentials"].from_json_keyfile_dict
+        ga_client_mocks["ServiceAccountCredentials"].from_service_account_info
     ).called_once_with(json.loads(settings.GA_KEYFILE_JSON))
     assert ga_client_mocks["build"].called_once_with(
-        ga_client_mocks["ServiceAccountCredentials"].from_json_keyfile_dict.return_value
+        ga_client_mocks["ServiceAccountCredentials"].from_service_account_info.return_value
     )
     assert result is ga_client_mocks["build"].return_value
 

--- a/ui/utils_test.py
+++ b/ui/utils_test.py
@@ -199,7 +199,9 @@ def test_get_google_analytics_client_success(ga_client_mocks, settings):
         ga_client_mocks["ServiceAccountCredentials"].from_service_account_info
     ).called_once_with(json.loads(settings.GA_KEYFILE_JSON))
     assert ga_client_mocks["build"].called_once_with(
-        ga_client_mocks["ServiceAccountCredentials"].from_service_account_info.return_value
+        ga_client_mocks[
+            "ServiceAccountCredentials"
+        ].from_service_account_info.return_value
     )
     assert result is ga_client_mocks["build"].return_value
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Closes #1007 

#### What's this PR do?
Switches from `ServiceAccountCredentials.from_json_keyfile_dict` (no longer supported) to `ServiceAccountCredentials.from_service_account_info`

#### How should this be manually tested?
- Ask me for the `GA_*` settings
- Change the UUID for one of your videos to `3c142cf25d1a4933be574d2695e34338`
- While logged in as someone allowed to view that video, go to http://localhost:8089/api/v0/videos/3c142cf25d1a4933be574d2695e34338/analytics/ and you should get JSON back, not a 500 error 
