### PR TITLE
Update add_hls_video_to_edx

### DIFF
--- a/ui/management/commands/add_hls_video_to_edx.py
+++ b/ui/management/commands/add_hls_video_to_edx.py
@@ -2,7 +2,7 @@
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 
-from ui.api import post_hls_to_edx
+from ui.api import post_video_to_edx
 from ui.encodings import EncodingNames
 from ui.models import VideoFile
 from ui.utils import get_error_response_summary_dict
@@ -64,7 +64,7 @@ class Command(BaseCommand):
 
         self.stdout.write("Attempting to post video(s) to edX...")
         for video_file in video_files:
-            response_dict = post_hls_to_edx(video_file)
+            response_dict = post_video_to_edx(video_file)
             good_responses = {
                 endpoint: resp
                 for endpoint, resp in response_dict.items()

--- a/ui/management/commands/add_hls_video_to_edx.py
+++ b/ui/management/commands/add_hls_video_to_edx.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
 
         self.stdout.write("Attempting to post video(s) to edX...")
         for video_file in video_files:
-            response_dict = post_video_to_edx(video_file)
+            response_dict = post_video_to_edx([video_file])
             good_responses = {
                 endpoint: resp
                 for endpoint, resp in response_dict.items()


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested


#### What's this PR do?
Update the HLS video command to call `post_video_to_edx` instead of `post_hls_to_edx` which does not exist anymore. 

#### How should this be manually tested?
1. Have OVS running and configured.
2. Add a video to OVS in a collection that is associated with an edx course.
3. Run `docker-compose run web python ./manage.py add_hls_video_to_edx --edx-course-id <COURSE_ID>`
4. Verify that the video is configured in edx as part of the course's assets: http://localhost:18010/assets/<COURSE_ID>/

