### PR TITLE
Fix OVS to Edx profile

### DIFF
--- a/ui/api.py
+++ b/ui/api.py
@@ -78,7 +78,7 @@ def post_video_to_edx(video_files):
                 "url": video_file.cloudfront_url,
                 "file_size": 0,
                 "bitrate": 0,
-                "profile": video_file.encoding,
+                "profile": video_file.encoding.lower(),
             }
         )
     edx_endpoints = models.EdxEndpoint.objects.filter(

--- a/ui/api_test.py
+++ b/ui/api_test.py
@@ -167,7 +167,7 @@ def test_post_video_to_edx(mocker, reqmocker, edx_api_scenario):
                     "url": edx_api_scenario.video_file_hls.cloudfront_url,
                     "file_size": 0,
                     "bitrate": 0,
-                    "profile": "HLS",
+                    "profile": "hls",
                 },
                 {
                     "url": edx_api_scenario.video_file_mp4.cloudfront_url,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What's this PR do?
Converts the OVS uppercase video profile ("HLS") to the video profile required by edX ("hls").  This appears to only occur when uploading to xpro and not mitxonline.

#### How should this be manually tested?

1. Tests should run correctly.
2. When uploading a video, the hls video should be created on the edx side when the profile is "hls".
