### PR TITLE
Only upload videos to edx if the collection defines course ID

### DIFF
--- a/ui/signals.py
+++ b/ui/signals.py
@@ -93,7 +93,7 @@ def add_video_to_edx(sender, instance, created, **kwargs):
     """
     If a Video was updated with a status of COMPLETE, we can now upload the related VideoFiles.
     """
-    if instance.status == VideoStatus.COMPLETE and instance.collection.edx_course_id is not None:
+    if instance.status == VideoStatus.COMPLETE and instance.collection.edx_course_id != '':
         ovs_tasks.post_video_to_edx.delay(instance.id)
 
 

--- a/ui/signals.py
+++ b/ui/signals.py
@@ -93,7 +93,7 @@ def add_video_to_edx(sender, instance, created, **kwargs):
     """
     If a Video was updated with a status of COMPLETE, we can now upload the related VideoFiles.
     """
-    if instance.status == VideoStatus.COMPLETE:
+    if instance.status == VideoStatus.COMPLETE and instance.collection.edx_course_id is not None:
         ovs_tasks.post_video_to_edx.delay(instance.id)
 
 

--- a/ui/signals.py
+++ b/ui/signals.py
@@ -93,7 +93,10 @@ def add_video_to_edx(sender, instance, created, **kwargs):
     """
     If a Video was updated with a status of COMPLETE, we can now upload the related VideoFiles.
     """
-    if instance.status == VideoStatus.COMPLETE and instance.collection.edx_course_id != '':
+    if (
+        instance.status == VideoStatus.COMPLETE
+        and instance.collection.edx_course_id != ""
+    ):
         ovs_tasks.post_video_to_edx.delay(instance.id)
 
 

--- a/ui/signals.py
+++ b/ui/signals.py
@@ -91,12 +91,9 @@ def update_video_youtube(sender, **kwargs):
 @receiver(post_save, sender=Video)
 def add_video_to_edx(sender, instance, created, **kwargs):
     """
-    If a Video was updated with a status of COMPLETE, we can now upload the related VideoFiles.
+    If a Video was updated with a status of COMPLETE, we can now post the video to edx if configured.
     """
-    if (
-        instance.status == VideoStatus.COMPLETE
-        and instance.collection.edx_course_id != ""
-    ):
+    if instance.status == VideoStatus.COMPLETE and instance.collection.edx_course_id:
         ovs_tasks.post_video_to_edx.delay(instance.id)
 
 

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -91,9 +91,8 @@ def test_youtube_sync_redo_failed(mocker, video_with_file, status):
     expected_count = 0 if status == YouTubeStatus.UPLOADED else 1
     assert mock_delete.call_count == expected_count
 
-@pytest.mark.parametrize(
-    "edx_course_id", ['123', '']
-)
+
+@pytest.mark.parametrize("edx_course_id", ["123", ""])
 def test_edx_video_file_signal(mocker, edx_course_id):
     """When a Video is saved with the status of COMPLETE, a task to add the video to edX should be called"""
     patched_edx_task = mocker.patch("ui.signals.ovs_tasks.post_video_to_edx.delay")

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -92,7 +92,7 @@ def test_youtube_sync_redo_failed(mocker, video_with_file, status):
     assert mock_delete.call_count == expected_count
 
 
-@pytest.mark.parametrize("edx_course_id", ["123", ""])
+@pytest.mark.parametrize("edx_course_id", ["123", "", None])
 def test_edx_video_file_signal(mocker, edx_course_id):
     """When a Video is saved with the status of COMPLETE, a task to add the video to edX should be called"""
     patched_edx_task = mocker.patch("ui.signals.ovs_tasks.post_video_to_edx.delay")
@@ -109,7 +109,7 @@ def test_edx_video_file_signal(mocker, edx_course_id):
     )
     video.status = VideoStatus.COMPLETE
     video.save()
-    if edx_course_id == "":
+    if edx_course_id:
         patched_edx_task.assert_not_called()
     else:
         patched_edx_task.assert_called_once_with(video.id)

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -109,7 +109,7 @@ def test_edx_video_file_signal(mocker, edx_course_id):
     )
     video.status = VideoStatus.COMPLETE
     video.save()
-    if edx_course_id is "":
+    if edx_course_id == "":
         patched_edx_task.assert_not_called()
     else:
         patched_edx_task.assert_called_once_with(video.id)

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -109,7 +109,7 @@ def test_edx_video_file_signal(mocker, edx_course_id):
     )
     video.status = VideoStatus.COMPLETE
     video.save()
-    if edx_course_id is None:
+    if edx_course_id is '':
         patched_edx_task.assert_not_called()
     else:
         patched_edx_task.assert_called_once_with(video.id)

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -92,7 +92,7 @@ def test_youtube_sync_redo_failed(mocker, video_with_file, status):
     assert mock_delete.call_count == expected_count
 
 @pytest.mark.parametrize(
-    "edx_course_id", ['123', None]
+    "edx_course_id", ['123', '']
 )
 def test_edx_video_file_signal(mocker, edx_course_id):
     """When a Video is saved with the status of COMPLETE, a task to add the video to edX should be called"""

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -109,7 +109,7 @@ def test_edx_video_file_signal(mocker, edx_course_id):
     )
     video.status = VideoStatus.COMPLETE
     video.save()
-    if edx_course_id:
+    if not edx_course_id:
         patched_edx_task.assert_not_called()
     else:
         patched_edx_task.assert_called_once_with(video.id)

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -109,7 +109,7 @@ def test_edx_video_file_signal(mocker, edx_course_id):
     )
     video.status = VideoStatus.COMPLETE
     video.save()
-    if edx_course_id is '':
+    if edx_course_id is "":
         patched_edx_task.assert_not_called()
     else:
         patched_edx_task.assert_called_once_with(video.id)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What's this PR do?
Fixes an issue where OVS would attempt to register videos with edx even if the collection the video was uploaded to did not define a course ID.

#### How should this be manually tested?

1. Follow the readme to setup OVS and edx locally.
2. Create a collection but do not define a course ID for the collection.
3. Upload a video to the collection.
4. Verify that the logs for OVS do not show "This video file cannot be added to edX".

It is also worth confirming that you can reproduce the error locally by taking the master branch of OVS and repeating the steps above in order to verify that is  "This video file cannot be added to edX" is output to the OVS logs. 

Also verify that, with a course ID defined for the collection, uploaded videos are registered with edx.
