### PR TITLE
call the celery task as async

### DIFF
--- a/ui/api.py
+++ b/ui/api.py
@@ -47,14 +47,13 @@ def process_dropbox_data(dropbox_upload_data):
                 bucket_name=settings.VIDEO_S3_BUCKET,
             )
         # Kick off chained async celery tasks to transfer file to S3, then start a transcode job
-        task_result = chain(
+        chain(
             tasks.stream_to_s3.s(video.id), tasks.transcode_from_s3.si(video.id)
-        )()
+        ).delay()
 
         response_data[video.hexkey] = {
             "s3key": video.get_s3_key(),
             "title": video.title,
-            "task": task_result.id,
         }
     return response_data
 

--- a/ui/signals.py
+++ b/ui/signals.py
@@ -81,11 +81,12 @@ def update_collection_retranscodes(sender, **kwargs):
 
 
 @receiver(post_save, sender=Video)
-def update_video_youtube(sender, **kwargs):
+def update_video_youtube(sender, instance, **kwargs):
     """
     If a video's is_public field is changed, sync associated YoutubeVideo object
     """
-    sync_youtube(kwargs["instance"])
+    if instance.status == VideoStatus.COMPLETE:
+        sync_youtube(instance)
 
 
 @receiver(post_save, sender=Video)

--- a/ui/signals.py
+++ b/ui/signals.py
@@ -85,8 +85,7 @@ def update_video_youtube(sender, instance, **kwargs):
     """
     If a video's is_public field is changed, sync associated YoutubeVideo object
     """
-    if instance.status == VideoStatus.COMPLETE:
-        sync_youtube(instance)
+    sync_youtube(instance)
 
 
 @receiver(post_save, sender=Video)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested
 
#### What are the relevant tickets?
https://github.com/mitodl/odl-video-service/issues/1027

#### What's this PR do?
This PR changes the chain of celery tasks, that are called when adding videos, to be asynchronous.  It also removes any dependency on those tasks in the returned response in order to (hopefully) speed up the response from the `upload` endpoint.

#### How should this be manually tested?

1. Have OVS running locally.
2. Have a large number of videos and an empty collection created in OVS.
3. In one operation, select all of your videos from dropbox and add them to your collection.
4. Verify that all of the videos are added to the collection and encoded properly.

#### Any background context you want to provide?
I was not able to reproduce the error from the issue when testing locally.  Using the same files I use locally, I can reproduce the error consistently in RC.  I would expect that testing this PR locally should be limited to just ensuring that nothing is broken.  Testing to see whether this change resolves the issue seen in RC and Production will need to wait until this is deployed to those environments.
