### PR TITLE
Disable notification to application admin email for corrupt videos

### DIFF
--- a/mail/constants.py
+++ b/mail/constants.py
@@ -15,7 +15,6 @@ STATUS_TO_NOTIFICATION = {
 STATUSES_THAT_TRIGGER_DEBUG_EMAIL = set(
     [
         VideoStatus.TRANSCODE_FAILED_INTERNAL,
-        VideoStatus.TRANSCODE_FAILED_VIDEO,
         VideoStatus.UPLOAD_FAILED,
     ]
 )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/odl-video-service/issues/1039

#### What's this PR do?
Changes the application so that if AWS elastic encoder fails due to the video being corrupt, the application admin email is not sent a notification of the failure.

#### How should this be manually tested?
1. Setup OVS locally.
2. Comment out https://github.com/mitodl/odl-video-service/blob/5c432b6c4f83b3394a89b00bc46ffb845921ebd5/mail/tasks.py#L78 .
3. Attempt to add a corrupt video (I used a text file that I gave an `.mp4` extension to) to a video collection.
4. Watch the logs and you should see `Transcoding failed` but you should not experience any mailgun errors since the following line was skipped: https://github.com/mitodl/odl-video-service/blob/5c432b6c4f83b3394a89b00bc46ffb845921ebd5/mail/tasks.py#L80
