### PR TITLE
Populate video duration to edx call

### DIFF
--- a/ui/api.py
+++ b/ui/api.py
@@ -1,6 +1,7 @@
 """
 API methods
 """
+from ast import literal_eval
 from uuid import uuid4
 
 import requests
@@ -13,7 +14,7 @@ from django.shortcuts import get_object_or_404
 from cloudsync import tasks
 from odl_video import logging
 from ui import models
-from ui.utils import get_error_response_summary_dict, get_et_job
+from ui.utils import get_error_response_summary_dict
 
 log = logging.getLogger(__name__)
 
@@ -99,8 +100,12 @@ def post_video_to_edx(video_files):
             )
             duration = 0.0
             if submitted_encode_job:
-                et_job = get_et_job(submitted_encode_job.id)
-                duration = et_job["Output"].get("Duration")
+                duration = (
+                    literal_eval(submitted_encode_job.message)
+                    .get("Output", {})
+                    .get("Duration", 0.0)
+                    or 0.0
+                )
 
             resp = requests.post(
                 edx_endpoint.full_api_url,

--- a/ui/api.py
+++ b/ui/api.py
@@ -38,8 +38,8 @@ def process_dropbox_data(dropbox_upload_data):
             video = models.Video.objects.create(
                 source_url=dropbox_link["link"],
                 title=dropbox_link["name"][
-                      : models.Video._meta.get_field("title").max_length
-                      ],
+                    : models.Video._meta.get_field("title").max_length
+                ],
                 collection=collection,
             )
             models.VideoFile.objects.create(
@@ -95,10 +95,14 @@ def post_video_to_edx(video_files):
     for edx_endpoint in edx_endpoints:
         try:
             edx_endpoint.refresh_access_token()
-            submitted_encode_job = video_files[0].video.encode_jobs.filter(state='Submitted').first()
+            submitted_encode_job = (
+                video_files[0].video.encode_jobs.filter(state="Submitted").first()
+            )
             duration = 0.0
             if submitted_encode_job:
-                duration = json.loads(submitted_encode_job.message)['Output'].get('Duration')
+                duration = json.loads(submitted_encode_job.message)["Output"].get(
+                    "Duration"
+                )
             resp = requests.post(
                 edx_endpoint.full_api_url,
                 json={
@@ -107,7 +111,7 @@ def post_video_to_edx(video_files):
                     "encoded_videos": encoded_videos,
                     "courses": [{video_files[0].video.collection.edx_course_id: None}],
                     "status": "file_complete",
-                    "duration": duration
+                    "duration": duration,
                 },
                 headers={
                     "Authorization": "JWT {}".format(edx_endpoint.access_token),

--- a/ui/api.py
+++ b/ui/api.py
@@ -3,6 +3,7 @@ API methods
 """
 from uuid import uuid4
 
+import json
 import requests
 from celery import chain
 from django.conf import settings
@@ -37,8 +38,8 @@ def process_dropbox_data(dropbox_upload_data):
             video = models.Video.objects.create(
                 source_url=dropbox_link["link"],
                 title=dropbox_link["name"][
-                    : models.Video._meta.get_field("title").max_length
-                ],
+                      : models.Video._meta.get_field("title").max_length
+                      ],
                 collection=collection,
             )
             models.VideoFile.objects.create(
@@ -94,6 +95,10 @@ def post_video_to_edx(video_files):
     for edx_endpoint in edx_endpoints:
         try:
             edx_endpoint.refresh_access_token()
+            submitted_encode_job = video_files[0].video.encode_jobs.filter(state='Submitted').first()
+            duration = 0.0
+            if submitted_encode_job:
+                duration = json.loads(submitted_encode_job.message)['Output'].get('Duration')
             resp = requests.post(
                 edx_endpoint.full_api_url,
                 json={
@@ -102,7 +107,7 @@ def post_video_to_edx(video_files):
                     "encoded_videos": encoded_videos,
                     "courses": [{video_files[0].video.collection.edx_course_id: None}],
                     "status": "file_complete",
-                    "duration": 0.0,
+                    "duration": duration
                 },
                 headers={
                     "Authorization": "JWT {}".format(edx_endpoint.access_token),

--- a/ui/api.py
+++ b/ui/api.py
@@ -3,7 +3,6 @@ API methods
 """
 from uuid import uuid4
 
-import json
 import requests
 from celery import chain
 from django.conf import settings
@@ -72,7 +71,7 @@ def post_video_to_edx(video_files):
     """
     encoded_videos = []
     for video_file in video_files:
-        # assert video_file.can_add_to_edx, "This video file cannot be added to edX"
+        assert video_file.can_add_to_edx, "This video file cannot be added to edX"
         encoded_videos.append(
             {
                 "url": video_file.cloudfront_url,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/3402

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adding functionality to populating duration when posting video to open edx. Duration can be found in EncodeJob json response (see https://video-rc.odl.mit.edu/admin/ui/video/165/change/)


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
To test this, you will need a working OVS and open edx (tutur or devstack) instances locally. For OVS setup, follow README instruction, you may need to ask for AWS and CloudFront env variables from devops.

**In your local edx instance**. e.g. tutor
- Go to http://local.overhang.io/admin/oauth2_provider/application/ to add OVS application
![image](https://github.com/mitodl/odl-video-service/assets/3138890/33e5edc7-808f-4823-bd0a-19fa76b8906b)
Make a note of `Client id` and `Client secret`
- Go to http://local.overhang.io/admin/oauth2_provider/accesstoken/ to add access token for OVS application created above
![image](https://github.com/mitodl/odl-video-service/assets/3138890/0769409e-173b-4d23-a1a2-d29f163d734d)
Token can be populated with anything. Make a note of that 

**In your OVS instance**
 - Add a edx endpoint to http://ovs.odl.local:8089/admin/ui/edxendpoint/
![image](https://github.com/mitodl/odl-video-service/assets/3138890/86b03840-f041-4a2d-b403-834f7a9aa156)
`Access Token`, `Client id` and `Secret Key` should match the ones you generated above in edx instance

- Add a collection to your local OVS http://ovs.odl.local:8089/admin/ui/collection/ 
    - populate `Edx course id` with course-v1:edX+DemoX+Demo_Course 
    - select the edx endpoint you just added from above step 
- Add video from dropbox from http://ovs.odl.local:8089/collections/ 
- Once video is uploaded to S3 successfully, you can view it from http://ovs.odl.local:8089/admin/ui/video/
- At this point, you should be able to see the video posting to your local edx instance http://local.overhang.io/admin/edxval/video/ with duration populated. 
- Or you can run `docker-compose run web ./manage.py add_hls_video_to_edx --video-file-id <YOUR VIDEO FILE ID>` 
But I had no luck getting it posted to my tutor as I keep getting the following error, so maybe I am missing something.
```
HTTPConnectionPool(host='local.overhang.io', port=80): Max retries exceeded with url: /oauth2/access_token/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffff7e982b50>: Failed to establish a new connection: [Errno 111] Connection refused'))
```
I was able to modify `post_video_to_edx` to test the code I added to make sure duration is returned correctly.