### PR TITLE
Create management command to backfill video duration on edx

### DIFF
--- a/ui/api_test.py
+++ b/ui/api_test.py
@@ -1,7 +1,6 @@
 """
 Tests for ui/api.py
 """
-import ast
 from types import SimpleNamespace
 
 # pylint: disable=unused-argument,redefined-outer-name

--- a/ui/api_test.py
+++ b/ui/api_test.py
@@ -1,6 +1,7 @@
 """
 Tests for ui/api.py
 """
+import ast
 from types import SimpleNamespace
 
 # pylint: disable=unused-argument,redefined-outer-name

--- a/ui/management/commands/update_video_on_edx.py
+++ b/ui/management/commands/update_video_on_edx.py
@@ -1,0 +1,76 @@
+"""Management command to update video to edX via API call"""
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from ui.constants import VideoStatus
+from ui.models import CollectionEdxEndpoint, Video
+from ui.tasks import batch_update_video_on_edx, batch_update_video_on_edx_chunked
+from ui.utils import now_in_utc
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """Update video to edX via API call"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+
+        parser.add_argument(
+            "--video-key",
+            type=str,
+            help="The UUID key of the Video that you want to update on its configured edX endpoint",
+        )
+        parser.add_argument(
+            "--chunk-size",
+            type=int,
+            default=1000,
+            help="specify the chunk size in a batch API call, default to 1000",
+        )
+        parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Update all of videos to their configured edX endpoints (this may take a long time)",
+        )
+
+    def handle(self, *args, **options):
+        if not options["video_key"] and not options["all"]:
+            raise CommandError("Please provide either --video-id or --all")
+
+        if options["video_key"]:
+            video_key = options["video_key"]
+            video = Video.objects.filter(key=video_key).first()
+            if video is None:
+                raise CommandError("This video key doesn't exist")
+            response = batch_update_video_on_edx_chunked([video_key])
+            self.stdout.write(
+                "Video updated to edX {} - edx url: {} \n".format(
+                    list(response.values())[0], list(response.keys())[0]
+                )
+            )
+        elif options["all"]:
+            collection_ids = CollectionEdxEndpoint.objects.values_list("id", flat=True)
+            video_keys = list(
+                Video.objects.filter(
+                    collection__id__in=collection_ids, status=VideoStatus.COMPLETE
+                ).values_list("key", flat=True)
+            )
+
+            self.stdout.write("Updating video(s) to edX...\n")
+            task = batch_update_video_on_edx.delay(video_keys, options["chunk_size"])
+            start = now_in_utc()
+
+            self.stdout.write(f"Started celery task {task} to update videos on edx")
+
+            result = task.get()
+            if "failed" in list(result["kwargs"]["tasks"][0].values()):
+                self.stderr.write(f"Result: {result}")
+                raise CommandError("Failed to update some video(s) to edX")
+
+            total_seconds = (now_in_utc() - start).total_seconds()
+            self.stdout.write(
+                "Updating video(s) to edX finished, took {} seconds.....\n".format(
+                    total_seconds
+                )
+            )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/3896

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a new management command to backfill all the video duration to their associated edx endpoints
  - API used in this PR is https://courses-qa.mitxonline.mit.edu/api-docs/#/val/val_v0_videos_partial_update 
  ```
  PATCH to val/v0/videos/{edx_video_id}

   {
      "edx_video_id": "5ef286e8-8e15-4b9c-a02c-f41cd38cb0b6",
      "client_video_id": "Semantics 1.2b.mp4",
      "duration": 17,
      "status": "updated"
}
 ```

**12114** videos will be updated on production https://bi.odl.mit.edu/queries/1365

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run  `docker compose run web ./manage.py update_video_on_edx --all --chunk-size 1000` to backfill all the videos in chunks default to 1000
Run `docker compose run web ./manage.py update_video_on_edx --video-key <UUID>` to backfill a specific video's duration to edx
