### PR TITLE
Revert "Update python Docker tag to v3.12.3"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 RUN yarn install --frozen-lockfile --ignore-engines --prefer-offline && \
     node node_modules/webpack/bin/webpack.js --config  webpack.config.prod.js --bail
 
-FROM python:3.12.3-bullseye AS base
+FROM python:3.9.19-bullseye AS base
 # Add package files, install updated node and pip
 WORKDIR /tmp
 


### PR DESCRIPTION
This reverts commit f85e18f2f93be7f0f7cb59286070a06ba3382d9c.

### What are the relevant tickets?
N/A, OVS is not ready for this update.

### Description (What does it do?)
Reverts the renovate PR bumping python to 3.12 in the docker container.


### How can this be tested?
```
docker compose build --no-cache web celery
docker compose up
```
The app should function locally.

