### PR TITLE
Fix how Ramda imports are being made based on usage >0.25

### DIFF
--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -2,7 +2,7 @@
 /* global videojs: true */
 /* global SETTINGS: false */
 import React from "react"
-import R from "ramda"
+import * as R from "ramda"
 import _ from "lodash"
 import type { Dispatch } from "redux"
 import { makeVideoSubtitleUrl } from "../lib/urls"

--- a/static/js/components/dialogs/hoc.js
+++ b/static/js/components/dialogs/hoc.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import R from "ramda"
+import * as R from "ramda"
 import type { Dispatch } from "redux"
 
 import * as commonUiActions from "../../actions/commonUi"

--- a/static/js/components/dialogs/hoc_test.js
+++ b/static/js/components/dialogs/hoc_test.js
@@ -4,7 +4,7 @@ import { assert } from "chai"
 import { mount } from "enzyme"
 import { Provider } from "react-redux"
 import configureTestStore from "redux-asserts"
-import R from "ramda"
+import * as R from "ramda"
 import { connect } from "react-redux"
 
 import Dialog from "../material/Dialog"

--- a/static/js/components/material/Textfield.js
+++ b/static/js/components/material/Textfield.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react"
-import R from "ramda"
+import * as R from "ramda"
 
 export default class Textfield extends React.Component<*, void> {
   props: {

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -3,7 +3,7 @@
 import React from "react"
 import { connect } from "react-redux"
 import type { Dispatch } from "redux"
-import R from "ramda"
+import * as R from "ramda"
 import _ from "lodash"
 import DocumentTitle from "react-document-title"
 

--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -2,7 +2,7 @@
 /* global SETTINGS: false */
 
 import React from "react"
-import R from "ramda"
+import * as R from "ramda"
 import { connect } from "react-redux"
 import type { Dispatch } from "redux"
 import { Link } from "react-router-dom"

--- a/static/js/containers/HelpPage.js
+++ b/static/js/containers/HelpPage.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react"
 import { connect } from "react-redux"
-import R from "ramda"
+import * as R from "ramda"
 
 import WithDrawer from "./WithDrawer"
 import FAQ from "../components/FAQ"

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -4,7 +4,7 @@ import React from "react"
 import { connect } from "react-redux"
 import moment from "moment"
 import type { Dispatch } from "redux"
-import R from "ramda"
+import * as R from "ramda"
 import _ from "lodash"
 import DocumentTitle from "react-document-title"
 

--- a/static/js/containers/WithDrawer.js
+++ b/static/js/containers/WithDrawer.js
@@ -1,7 +1,7 @@
 // @flow
 /* global SETTINGS: false */
 import React from "react"
-import R from "ramda"
+import * as R from "ramda"
 import { connect } from "react-redux"
 
 import * as commonUiActions from "../actions/commonUi"

--- a/static/js/containers/withPagedCollections.js
+++ b/static/js/containers/withPagedCollections.js
@@ -1,6 +1,6 @@
 import React from "react"
 import _ from "lodash"
-import R from "ramda"
+import * as R from "ramda"
 import { connect } from "react-redux"
 import type { Dispatch } from "redux"
 

--- a/static/js/containers/withVideoAnalytics.js
+++ b/static/js/containers/withVideoAnalytics.js
@@ -1,6 +1,6 @@
 import React from "react"
 import _ from "lodash"
-import R from "ramda"
+import * as R from "ramda"
 import { connect } from "react-redux"
 import type { Dispatch } from "redux"
 

--- a/static/js/lib/collection.js
+++ b/static/js/lib/collection.js
@@ -1,5 +1,5 @@
 // @flow
-import R from "ramda"
+import * as R from "ramda"
 import _ from "lodash"
 
 import {

--- a/static/js/lib/dialog.js
+++ b/static/js/lib/dialog.js
@@ -1,5 +1,5 @@
 // @flow
-import R from "ramda"
+import * as R from "ramda"
 
 export const PERM_CHOICE_NONE: string = "none"
 export const PERM_CHOICE_PUBLIC: string = "public"

--- a/static/js/lib/sanctuary.js
+++ b/static/js/lib/sanctuary.js
@@ -1,5 +1,5 @@
 // @flow
-import R from "ramda"
+import * as R from "ramda"
 import { create, env } from "sanctuary"
 
 export const S = create({ checkTypes: false, env: env })

--- a/static/js/lib/sanctuary_test.js
+++ b/static/js/lib/sanctuary_test.js
@@ -1,6 +1,6 @@
 // @flow
 import { assert } from "chai"
-import R from "ramda"
+import * as R from "ramda"
 
 import {
   S,

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -1,5 +1,5 @@
 // @flow
-import R from "ramda"
+import * as R from "ramda"
 
 import { S } from "./sanctuary"
 

--- a/static/js/lib/video.js
+++ b/static/js/lib/video.js
@@ -1,6 +1,6 @@
 // @flow
 /* global SETTINGS: false */
-import R from "ramda"
+import * as R from "ramda"
 
 import {
   VIDEO_STATUS_CREATED,

--- a/static/js/reducers/collections.js
+++ b/static/js/reducers/collections.js
@@ -1,6 +1,6 @@
 // @flow
 import { GET, PATCH, POST, INITIAL_STATE } from "redux-hammock/constants"
-import R from "ramda"
+import * as R from "ramda"
 
 import * as api from "../lib/api"
 import type { Collection, CollectionList } from "../flow/collectionTypes"

--- a/static/js/util/google_analytics.js
+++ b/static/js/util/google_analytics.js
@@ -1,7 +1,7 @@
 // @flow
 /* global SETTINGS:false */
 import ga from "react-ga"
-import R from "ramda"
+import * as R from "ramda"
 
 const makeGAEvent = (category, action, label, value) => ({
   category: category,

--- a/static/js/util/test_utils.js
+++ b/static/js/util/test_utils.js
@@ -2,7 +2,7 @@
 // @flow
 import { assert } from "chai"
 import _ from "lodash"
-import R from "ramda"
+import * as R from "ramda"
 
 import type { Action } from "../flow/reduxTypes"
 import type { Store } from "redux"

--- a/static/js/util/util.js
+++ b/static/js/util/util.js
@@ -1,6 +1,6 @@
 // @flow
 import { PERM_CHOICE_LISTS } from "../lib/dialog"
-import R from "ramda"
+import * as R from "ramda"
 
 export function getDisplayName(WrappedComponent: any) {
   return WrappedComponent.displayName || WrappedComponent.name || "Component"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The usage instructions say that the import needs to be done as `import * as R from "ramda"` https://github.com/ramda/ramda?tab=readme-ov-file#usage
