### PR TITLE
Re-transcoding fixed for duplicate videos on edX

### DIFF
--- a/ui/management/commands/sync_video_key_with_edx.py
+++ b/ui/management/commands/sync_video_key_with_edx.py
@@ -1,0 +1,69 @@
+"""Management command to sync video keys with edX"""
+from urllib.parse import urlencode
+import requests
+from django.core.management.base import BaseCommand
+
+from ui.models import Collection, Video
+
+
+class Command(BaseCommand):
+    """Sync video keys with edX"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--collection_ids",
+            type=int,
+            nargs="*",
+            help="The ids of the Collections that you want to sync video keys with edX",
+        )
+
+    def handle(self, *args, **options):
+        collection_ids = options["collection_ids"]
+        collections = Collection.objects.all()
+        if collection_ids:
+            collections = collections.filter(id__in=collection_ids)
+
+        for collection in collections:
+            course_videos = []
+            for edx_endpoint in collection.edx_endpoints.all():
+                edx_endpoint.refresh_access_token()
+                course_videos_query = urlencode(
+                    {
+                        "course": collection.edx_course_id,
+                    }
+                )
+                try:
+                    resp = requests.get(
+                        edx_endpoint.full_api_url + f"?{course_videos_query}",
+                        headers={
+                            "Authorization": f"JWT {edx_endpoint.access_token}",
+                        },
+                    )
+                    resp.raise_for_status()
+                    course_videos.extend(resp.json().get("results", []))
+                    while resp.json().get("next"):
+                        resp = requests.get(
+                            resp.json().get("next"),
+                            headers={
+                                "Authorization": f"JWT {edx_endpoint.access_token}",
+                            },
+                        )
+                        course_videos.extend(resp.json().get("results", []))
+                except requests.exceptions.RequestException as exc:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Can not get videos from edX for collection {collection.title}"
+                        )
+                    )
+                    self.stdout.write(self.style.ERROR(str(exc)))
+
+            for vid in course_videos:
+                Video.objects.filter(title=vid.get("client_video_id")).update(
+                    key=vid.get("edx_video_id")
+                )
+
+            self.stdout.write(
+                f"Synced video keys for collection {collection.title} with edX"
+            )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5334
https://github.com/mitodl/hq/issues/6530


### Description (What does it do?)
This PR:
1. Adds Management command to sync edX video ids back into OVS using client_video_id(edX side) and title(OVS side)
2. Uses video key as edx-video-id to keep them both sync'd
3. Updates the video on edX if it already exists
4. Test cases added


### How can this be tested?
1. Make sure your setup is complete and integrated with edX

**Management Command**
1. Replace [Line](https://github.com/mitodl/odl-video-service/blob/marlan/5334-fix-retranscoding/ui/api.py#L106) with `"edx_video_id": str(uuid4(),` make sure to import `uuid4`
3. Upload video --  Verify from edX. you can also use API `/api/val/v0/videos/` to get the list of videos from edX
4. OVS video key and edX video id should be different
5. Run the management command `python manage.py sync_video_key_with_edx`
6. Validate that now edX and OVS have same keys

**Overall Testing**
1. Please follow the steps from above till you have different keys on both systems
2. Run re-transcode on the Video to verify if everything is working fine
3. Run Management command to sync the keys
4. Run re-transcode again to see if everything is working as expected.
