### PR TITLE
Add the path param for current dir

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -62,6 +62,7 @@ module.exports = Object.assign(prodConfig, {
       'typeof global': JSON.stringify('undefined')
     }),
     new BundleTracker({
+      path: __dirname,
       filename: 'webpack-stats.json'
     }),
     new webpack.LoaderOptionsPlugin({


### PR DESCRIPTION
### What are the relevant ~~tickets~~Slack?
https://mitodl.slack.com/archives/C5T80SA7L/p1742839844592139

### Description (What does it do?)
This PR adds path params for production webpack build

### How can this be tested?
1. Shell into node/watch container
2. Run `node node_modules/webpack/bin/webpack.js --config webpack.config.prod.js --bail`

### Additional Context
This [build](https://cicd.odl.mit.edu/teams/infrastructure/pipelines/docker-packer-pulumi-ovs/jobs/build-ovs-image-from-rc/builds/8) is failing due to webpack file not found. This might be due to recent [upgrade in webpack](https://github.com/mitodl/odl-video-service/pull/1152) 
