### PR TITLE
SECURE_CROSS_ORIGIN_OPENER_POLICY setting added

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ SENTRY_DSN=
 STATUS_TOKEN=
 USE_SHIBBOLETH=False
 VIDEO_CLOUDFRONT_DIST=
+SECURE_CROSS_ORIGIN_OPENER_POLICY=same-origin-allow-popups
 # IMPORTANT: you MUST have a proper configuration for an elastic transcoder pipeline using the following 3 buckets names
 VIDEO_S3_BUCKET=
 VIDEO_S3_SUBTITLE_BUCKET=

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -572,7 +572,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 SECURE_CROSS_ORIGIN_OPENER_POLICY = get_string(
     "SECURE_CROSS_ORIGIN_OPENER_POLICY",
-    "same-origin",
+    "same-origin-allow-popups",
 )
 
 # Hijack

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -570,5 +570,10 @@ OPENEDX_API_CLIENT_SECRET = get_string("OPENEDX_API_CLIENT_SECRET", "")
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
+SECURE_CROSS_ORIGIN_OPENER_POLICY = get_string(
+    "SECURE_CROSS_ORIGIN_OPENER_POLICY",
+    "same-origin",
+)
+
 # Hijack
 HIJACK_INSERT_BEFORE = "</body>"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7110#issuecomment-2801529301

### Description (What does it do?)
This PR:
1. Adds `SECURE_CROSS_ORIGIN_OPENER_POLICY` in settings
2. And make it configureable via environment

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c1e6274f-107b-4018-b307-83c7686602ab)


### How can this be tested?
1. Checkout to this branch
2. run `docker-compose up --build -d`
3. Check network calls and verify if the response headers have `cross-origin-opener-policy` header and it is set to the value you provided

