### PR TITLE
Video matching from edX to OVS fixed

### DIFF
--- a/ui/management/commands/sync_video_key_with_edx.py
+++ b/ui/management/commands/sync_video_key_with_edx.py
@@ -61,8 +61,14 @@ class Command(BaseCommand):
                     self.stdout.write(self.style.ERROR(str(exc)))
 
             for vid in course_videos:
-                Video.objects.filter(title=vid.get("client_video_id")).update(
-                    key=vid.get("edx_video_id")
+                vid_key = (
+                    vid.get("encoded_videos", [{}])[0].get("url", "").split("/")[-2]
+                )
+                Video.objects.filter(
+                    title=vid.get("client_video_id"), key=vid_key
+                ).update(key=vid.get("edx_video_id"))
+                self.stdout.write(
+                    f"Updated video key for {vid.get('client_video_id')} to {vid.get('edx_video_id')}"
                 )
 
             self.stdout.write(

--- a/ui/management/commands/sync_video_key_with_edx.py
+++ b/ui/management/commands/sync_video_key_with_edx.py
@@ -60,10 +60,17 @@ class Command(BaseCommand):
                     )
                     self.stdout.write(self.style.ERROR(str(exc)))
 
-            for vid in course_videos:
-                vid_key = (
-                    vid.get("encoded_videos", [{}])[0].get("url", "").split("/")[-2]
-                )
+            group_by_key = {}
+            for video in course_videos:
+                key = video.get("encoded_videos", [{}])[0].get("url", "").split("/")[-2]
+                group_by_key.setdefault(key, []).append(video)
+
+            latest_videos_by_created_at = {
+                key: max(videos, key=lambda x: x.get("created", "1970-01-01"))
+                for key, videos in group_by_key.items()
+            }
+
+            for vid_key, vid in latest_videos_by_created_at.items():
                 Video.objects.filter(
                     title=vid.get("client_video_id"), key=vid_key
                 ).update(key=vid.get("edx_video_id"))

--- a/ui/management/commands/sync_video_key_with_edx.py
+++ b/ui/management/commands/sync_video_key_with_edx.py
@@ -63,12 +63,16 @@ class Command(BaseCommand):
 
             latest_videos_by_created_at = {}
             for video in course_videos:
-                key = video.get("encoded_videos", [{}])[0].get("url", "").split("/")[-2]
+                key = (
+                    video.get("encoded_videos", [{}])[0].get("url", "/").split("/")[-2]
+                )
                 created = datetime.fromisoformat(video.get("created", "1970-01-01"))
-                if (
-                    key and key not in latest_videos_by_created_at
-                ) or created > datetime.fromisoformat(
-                    latest_videos_by_created_at[key].get("created", "1970-01-01")
+                if key and (
+                    key not in latest_videos_by_created_at
+                    or created
+                    > datetime.fromisoformat(
+                        latest_videos_by_created_at[key].get("created", "1970-01-01")
+                    )
                 ):
                     latest_videos_by_created_at[key] = video
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5334

### Description (What does it do?)
This PR:
1. Fix the matching query to find videos

### How can this be tested?
1. Make sure your setup is complete and integrated with edX

**Management Command**
1. Replace [Line](https://github.com/mitodl/odl-video-service/blob/master/ui/api.py#L106) with `"edx_video_id": str(uuid4(),` make sure to import `uuid4`
3. Upload video --  Verify from edX. you can also use API `/api/val/v0/videos/` to get the list of videos from edX
4. OVS video key and edX video id should be different
5. Run the management command `python manage.py sync_video_key_with_edx`
6. Validate that now edX and OVS have same keys

**Overall Testing**
1. Please follow the steps from above till you have different keys on both systems
2. Run re-transcode on the Video to verify if everything is working fine
3. Run Management command to sync the keys
4. Run re-transcode again to see if everything is working as expected.

