### PR TITLE
Tests upgraded from elasticTranscoder to mediaConvert

### DIFF
--- a/cloudsync/api.py
+++ b/cloudsync/api.py
@@ -6,6 +6,7 @@ import re
 from collections import namedtuple
 from datetime import datetime
 from urllib.parse import quote
+from uuid import uuid4
 
 import boto3
 import pytz
@@ -76,6 +77,8 @@ def process_transcode_results(results: dict) -> None:
             process_hls_outputs(group.get("playlistFilePaths", []), video)
         elif "FILE_GROUP" in group_type:
             process_mp4_outputs(group.get("outputDetails", []), video)
+
+    video.update_status(VideoStatus.COMPLETE)
 
     # Ensure content_type and object_id are set for the EncodeJob
     content_type = ContentType.objects.get_for_model(video)
@@ -189,7 +192,6 @@ def refresh_status(video: Video, encode_job: EncodeJob = None) -> None:
             with open("./config/results.json", encoding="utf-8") as f:
                 results = prepare_results(video, encode_job, f.read())
             process_transcode_results(results)
-            video.update_status(VideoStatus.COMPLETE)
         elif mc_job["Job"]["Status"].lower() == VideoStatus.ERROR.lower():
             if video.status == VideoStatus.RETRANSCODING:
                 video.update_status(VideoStatus.RETRANSCODE_FAILED)
@@ -292,7 +294,8 @@ def transcode_video(
     else:
         prefix = TRANSCODE_PREFIX
 
-    job = {}
+    job_id = str(uuid4())
+    err_msg = {"Job": {"Status": "Error", "Id": job_id}}
     try:
         # Start the MediaConvert job
         job = media_convert_job(
@@ -303,25 +306,27 @@ def transcode_video(
                 "exclude_thumbnail": exclude_thumbnail,
             },
         )
-    except ClientError:
+        job_id = job.get("Job", {}).get("Id", job_id)
+    except ClientError as exc:
         log.error("Transcode job creation failed", video_id=video.id)
         if video.status == VideoStatus.RETRANSCODE_SCHEDULED:
             video.update_status(VideoStatus.RETRANSCODE_FAILED)
         else:
             video.update_status(VideoStatus.TRANSCODE_FAILED_INTERNAL)
+        if hasattr(exc, "response"):
+            err_msg = exc.response
+            job_id = err_msg["Job"].get("Id", job_id) if "Job" in err_msg else job_id
         raise
     finally:
         # Get the content type for the Video model
         content_type = ContentType.objects.get_for_model(video)
-        job_id = job.get("Job", {}).get("Id", None)
         # Create or update the EncodeJob instance
         EncodeJob.objects.get_or_create(
             id=job_id,
             defaults={
-                "id": None,
                 "content_type": content_type,
                 "object_id": video.pk,
-                "message": {},
+                "message": err_msg,
             },
         )
 

--- a/cloudsync/conftest.py
+++ b/cloudsync/conftest.py
@@ -63,7 +63,7 @@ def youtube_mock(mocker):
     )
 
 
-class MockClientET:
+class MockClientMC:
     """
     Mock boto3 ElasticTranscoder client, because ElasticTranscode isn't supported by moto yet
     """
@@ -77,17 +77,11 @@ class MockClientET:
         if "error" in kwargs:
             self.error = kwargs["error"]
 
-    def read_job(self, **kwargs):  # pylint: disable=unused-argument
-        """Mock read_job method"""
+    def get_job(self, **kwargs):  # pylint: disable=unused-argument
+        """Mock get_job method"""
         if self.error:
             raise self.error
         return self.job
-
-    def read_preset(self, *args, **kwargs):  # pylint: disable=unused-argument
-        """Mock read_preset method"""
-        if self.error:
-            raise self.error
-        return self.preset
 
 
 class MockBoto:
@@ -99,8 +93,8 @@ class MockBoto:
         *args, **kwargs
     ):  # pylint: disable=unused-argument,no-method-argument,no-self-argument
         """Return a mock client"""
-        if args[0] == "elastictranscoder":
-            return MockClientET()
+        if args[0] == "mediaconvert":
+            return MockClientMC()
 
 
 class MockHttpErrorResponse:

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -124,15 +124,14 @@ def mock_failed_encode_job(mocker):
         "cloudsync.api.VideoTranscoder.encode",
         side_effect=ClientError(error_response=job_result, operation_name="ReadJob"),
     )
-    mocker.patch("cloudsync.api.get_et_job", return_value=job_result["Job"])
+    mocker.patch("cloudsync.api.media_convert_job", return_value=job_result["Job"])
 
 
 @pytest.fixture()
 def mock_successful_encode_job(mocker):
     """Mock everything required for a successful transcode"""
-    mocker.patch("cloudsync.api.VideoTranscoder.encode")
     mocker.patch(
-        "cloudsync.api.get_et_job",
+        "cloudsync.api.media_convert_job",
         return_value={"Id": "1498220566931-qtmtcu", "Status": "Complete"},
     )
 

--- a/ui/api_test.py
+++ b/ui/api_test.py
@@ -381,16 +381,18 @@ def test_get_duration_from_encode_job():
     """
     video = VideoFactory(status="Complete")
     encode_job = EncodeJobFactory(video=video)
-    encode_job.message = str(
-        {
-            "id": "1711563064503-e5qdnh",
-            "Output": {
-                "id": "1",
-                "Status": "Complete",
-                "Duration": 10.0,
-            },
-        }
-    )
+    encode_job.message = {
+        "id": "1711563064503-e5qdnh",
+        "outputGroupDetails": [
+            {
+                "outputDetails": [
+                    {
+                        "durationInMs": 10000.0,
+                    }
+                ]
+            }
+        ],
+    }
     duration = api.get_duration_from_encode_job(encode_job)
     assert duration == 10.0
 

--- a/ui/factories.py
+++ b/ui/factories.py
@@ -7,7 +7,15 @@ import pytz
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from factory import Faker, LazyAttribute, Sequence, SubFactory, Trait, post_generation
+from factory import (
+    Faker,
+    LazyAttribute,
+    LazyFunction,
+    Sequence,
+    SubFactory,
+    Trait,
+    post_generation,
+)
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyInteger, FuzzyText
 
@@ -198,6 +206,7 @@ class EncodeJobFactory(DjangoModelFactory):
     content_type = LazyAttribute(
         lambda obj: ContentType.objects.get_for_model(obj.video)
     )
+    message = LazyFunction(lambda: {})
 
     class Meta:
         model = EncodeJob

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -173,34 +173,6 @@ def has_common_lists(user, list_names):
     return not user_lists.isdisjoint(list_names)
 
 
-def get_et_job(job_id):
-    """
-    Get the status of an ElasticTranscode job
-
-    Args:
-        job_id (str): ID of ElasticTranscode Job
-
-    Returns:
-        dict: JSON representation of job status/details
-    """
-    et = get_transcoder_client()
-    job = et.read_job(Id=job_id)
-    return job["Job"]
-
-
-def get_et_preset(preset_id):
-    """
-    Get the JSON configuration of an ElasticTranscode preset
-    Args:
-        preset_id (str): A preset id
-
-    Returns:
-        dict: Preset configuration
-    """
-    et = get_transcoder_client()
-    return et.read_preset(Id=preset_id)["Preset"]
-
-
 def get_bucket(bucket_name):
     """
     Get an S3 bucket by name
@@ -213,17 +185,6 @@ def get_bucket(bucket_name):
     """
     s3 = boto3.resource("s3")
     return s3.Bucket(bucket_name)
-
-
-def get_transcoder_client():
-    """
-    Get an ElasticTranscoder client object
-
-    Returns:
-        botocore.client.ElasticTranscoder:
-            An ElasticTranscoder client object
-    """
-    return boto3.client("elastictranscoder", settings.AWS_REGION)
 
 
 def write_to_file(filename, contents):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7169

### Description (What does it do?)
This PR:
1. Fixes tests after upgraded from elasticTranscoder to MediaConvert

### How to test ?
- Shell into web container `docker-compose exec -it web bash`
- Run test `poetry run pytest`
- Verify that all tests are green
