### PR TITLE
Fix empty video list from edX

### DIFF
--- a/ui/management/commands/sync_video_key_with_edx.py
+++ b/ui/management/commands/sync_video_key_with_edx.py
@@ -64,7 +64,9 @@ class Command(BaseCommand):
             latest_videos_by_created_at = {}
             for video in course_videos:
                 key = (
-                    video.get("encoded_videos", [{}])[0].get("url", "/").split("/")[-2]
+                    (video.get("encoded_videos") or [{}])[0]
+                    .get("url", "/")
+                    .split("/")[-2]
                 )
                 created = datetime.fromisoformat(video.get("created", "1970-01-01"))
                 if key and (


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5334

### Description (What does it do?)
This PR:
1. Fix the matching query to find videos

### How can this be tested?
1. Make sure your setup is complete and integrated with edX

**Management Command**
1. Replace [Line](https://github.com/mitodl/odl-video-service/blob/master/ui/api.py#L106) with `"edx_video_id": str(uuid4(),` make sure to import `uuid4`
3. Upload video --  Verify from edX. you can also use API `/api/val/v0/videos/` to get the list of videos from edX
4. OVS video key and edX video id should be different
5. Run the management command `python manage.py sync_video_key_with_edx`
6. Validate that now edX and OVS have same keys

**Overall Testing**
1. Please follow the steps from above till you have different keys on both systems
2. Run re-transcode on the Video to verify if everything is working fine
3. Run Management command to sync the keys
4. Run re-transcode again to see if everything is working as expected.

