### PR TITLE
Updated transcoding app in OVS

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3371,4 +3371,4 @@ xmlsec = ["xmlsec (>=0.6.1)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "fe27f2d99451911b81f9577907d06869218a6776cfa974465d3b76b73ba42eb0"
+content-hash = "c2deba9cc780b58ee60a48b798b5f06cbf495194a575d34d08f916ad11e645e0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1902,14 +1902,14 @@ typing-extensions = "*"
 
 [[package]]
 name = "mitol-django-transcoding"
-version = "2025.5.9"
+version = "2025.5.21"
 description = "MIT Open Learning Django app extension for Transcoding jobs"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mitol_django_transcoding-2025.5.9-py3-none-any.whl", hash = "sha256:b437eddc193c97968e600a75f8fcc10ff0cb49db6c43ef7a9437ede801c9aa38"},
-    {file = "mitol_django_transcoding-2025.5.9.tar.gz", hash = "sha256:af2529703472547f2fcc1672e266761667e01d6896ca2edd3ee782befa210d7d"},
+    {file = "mitol_django_transcoding-2025.5.21-py3-none-any.whl", hash = "sha256:0bf29ca82adf059c66def1841b55bd117d9ce5e35b0db6a7bd30647880c24baa"},
+    {file = "mitol_django_transcoding-2025.5.21.tar.gz", hash = "sha256:456b444f606d7bad032a1249fd4c8789a3c5c08f15e72353bb00b8878cbe487f"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ structlog = "^20.1.0"
 structlog-sentry = "^1.2.2"
 urllib3 = "^1.24.2"
 uwsgi = "2.0.29"
-mitol-django-transcoding = "^2025.5.9"
+mitol-django-transcoding = "^2025.5.21"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### What are the relevant tickets?
part of https://github.com/mitodl/hq/issues/7328

### Description (What does it do?)
This update transcoding app to latest version that does not supresss client errors

### How can this be tested?
1. Switch to this branch and spin up containers
2. Add a video via Dropbox and wait for it to complete
3. Smoke test the transcoding workflow 