### PR TITLE
feat: Collection search support added

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -72,6 +72,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "django_filters",
     "hijack",
     "hijack.contrib.admin",
     "encrypted_model_fields",

--- a/poetry.lock
+++ b/poetry.lock
@@ -874,6 +874,21 @@ cryptography = ">=3.4"
 Django = ">=2.2"
 
 [[package]]
+name = "django-filter"
+version = "25.1"
+description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "django_filter-25.1-py3-none-any.whl", hash = "sha256:4fa48677cf5857b9b1347fed23e355ea792464e0fe07244d1fdfb8a806215b80"},
+    {file = "django_filter-25.1.tar.gz", hash = "sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153"},
+]
+
+[package.dependencies]
+Django = ">=4.2"
+
+[[package]]
 name = "django-hijack"
 version = "3.7.1"
 description = "Enable users to hijack (=login as) and work on behalf of another user."
@@ -3191,4 +3206,4 @@ xmlsec = ["xmlsec (>=0.6.1)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "9b3ddeeb49c195402ef437ab7d88b9bbec7eaecb1860b4730981743d41c16d88"
+content-hash = "d0a9f3e2307cbc8d3cb24d2c87eb50fb5b0db62d469317230f5e64bcd9806898"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ structlog-sentry = "^1.2.2"
 urllib3 = "^1.24.2"
 uwsgi = "2.0.29"
 mitol-django-transcoding = "^2025.5.21"
+django-filter = "^25.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/static/js/actions/collectionsPagination.js
+++ b/static/js/actions/collectionsPagination.js
@@ -23,9 +23,16 @@ actionCreators.receiveGetPageFailure = createAction(
 actionCreators.getPage = (opts: { page: number }) => {
   const { page } = opts
   const thunk = async (dispatch: Dispatch) => {
+    // Get filters from URL parameters
+    const params = new URLSearchParams(window.location.search)
+    const searchQuery = params.get('search')
+    // Construct query parameters
+    const queryParams = { page }
+    if (searchQuery) queryParams.search = searchQuery
+
     dispatch(actionCreators.requestGetPage({ page }))
     try {
-      const response = await api.getCollections({ pagination: { page } })
+      const response = await api.getCollections({ pagination: queryParams })
       // @TODO: ideally we would dispatch an action here to save collections to
       // a single place in state (e.g. state.collections).
       // However, it take a non-trivial refactor to implement this schema

--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -9,6 +9,7 @@ import { Link } from "react-router-dom"
 
 import { DIALOGS } from "../constants"
 import * as collectionUiActions from "../actions/collectionUi"
+import { actions } from "../actions"
 import WithDrawer from "./WithDrawer"
 import CollectionFormDialog from "../components/dialogs/CollectionFormDialog"
 import { withDialogs } from "../components/dialogs/hoc"
@@ -34,6 +35,7 @@ export class CollectionListPage extends React.Component<*, void> {
       <div className="collection-list-content">
         <div className="card centered-content">
           <h1 className="mdc-typography--title">My Collections</h1>
+          {this.renderSearchInput()}
           {this.renderCollectionLinks()}
           {this.renderPaginator()}
           {this.renderFormLink()}
@@ -72,6 +74,48 @@ export class CollectionListPage extends React.Component<*, void> {
         Create New Collection
       </a>
     ) : null
+  }
+
+  renderSearchInput() {
+    // Get initial search value from URL if present
+    const params = new URLSearchParams(window.location.search)
+    const searchQuery = params.get('search') || ''
+
+    return (
+      <div className="collection-search">
+        <div className="mdc-text-field mdc-text-field--fullwidth">
+          <input
+            type="text"
+            className="mdc-text-field__input"
+            placeholder="Search collections..."
+            defaultValue={searchQuery}
+            onChange={e => this.handleSearch(e.target.value)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  handleSearch(searchText) {
+    // Reset to page 1 when searching
+    if (this.props.collectionsPagination.currentPage !== 1) {
+      this.props.collectionsPagination.setCurrentPage(1)
+    }
+
+    // Update URL with search params
+    const params = new URLSearchParams(window.location.search)
+    if (searchText) {
+      params.set('search', searchText)
+    } else {
+      params.delete('search')
+    }
+
+    // Push new URL without reloading the page
+    const newUrl = `${window.location.pathname}?${params.toString()}`
+    window.history.pushState({ path: newUrl }, '', newUrl)
+
+    // Trigger a re-fetch of collections with the search parameter
+    this.props.dispatch(actions.collectionsPagination.getPage({ page: 1 }))
   }
 
   openNewCollectionDialog() {

--- a/static/scss/collection.scss
+++ b/static/scss/collection.scss
@@ -62,6 +62,8 @@ $video-card-width: 15.6%;
   }
 
   .mdc-list {
+    margin-bottom: 20px;
+
     @include breakpoint(phone) {
       padding: 8px 10px 0;
     }
@@ -91,6 +93,18 @@ $video-card-width: 15.6%;
 
       .material-icons {
         color: #fff;
+      }
+    }
+  }
+
+  .collection-search {
+    margin-top: 10px;
+    margin-bottom: 20px;
+
+    .mdc-text-field {
+      input {
+        padding: 12px;
+        box-sizing: border-box;
       }
     }
   }

--- a/ui/filters.py
+++ b/ui/filters.py
@@ -1,0 +1,42 @@
+"""
+Filters for ui app
+"""
+
+import django_filters
+from django.db.models import Q
+
+from ui.models import Collection, EdxEndpoint
+
+
+class CollectionFilter(django_filters.FilterSet):
+    """
+    Filter for Collection model
+    """
+
+    title = django_filters.CharFilter(lookup_expr="icontains")
+    slug = django_filters.CharFilter(lookup_expr="icontains")
+    description = django_filters.CharFilter(lookup_expr="icontains")
+    edx_course_id = django_filters.CharFilter(lookup_expr="icontains")
+    edx_endpoint = django_filters.ModelChoiceFilter(
+        queryset=EdxEndpoint.objects.all(),
+        field_name="edx_endpoints",
+    )
+    search = django_filters.CharFilter(method="search_filter")
+
+    def search_filter(self, queryset, name, value):  # pylint: disable=unused-argument
+        """
+        Search filter that looks across collection fields (title, description, edx_course_id, slug)
+        and video fields (title, description)
+        """
+        return queryset.filter(
+            Q(title__icontains=value)
+            | Q(description__icontains=value)
+            | Q(edx_course_id__icontains=value)
+            | Q(slug__icontains=value)
+            | Q(videos__title__icontains=value)
+            | Q(videos__description__icontains=value)
+        ).distinct()
+
+    class Meta:
+        model = Collection
+        fields = ["title", "slug", "description", "edx_course_id", "edx_endpoint"]

--- a/ui/views.py
+++ b/ui/views.py
@@ -14,6 +14,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import TemplateView
+import django_filters.rest_framework
 from rest_framework import authentication, mixins, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -27,6 +28,7 @@ from techtv2ovs.models import TechTVVideo
 from ui import api
 from ui import permissions as ui_permissions
 from ui import serializers
+from ui.filters import CollectionFilter
 from ui.constants import EDX_ADMIN_GROUP
 from ui.models import (
     Collection,
@@ -366,7 +368,11 @@ class CollectionViewSet(viewsets.ModelViewSet):
     permission_classes = (ui_permissions.HasCollectionPermissions,)
 
     pagination_class = CollectionSetPagination
-    filter_backends = (OrderingFilter,)
+    filter_backends = (
+        OrderingFilter,
+        django_filters.rest_framework.DjangoFilterBackend,
+    )
+    filterset_class = CollectionFilter
     ordering_fields = ("created_at", "title")
 
     def get_queryset(self):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7434

### Description (What does it do?)
This PR:
1. Adds filters in Collection API in the backend
2. Adds search input in the frontend to allow users to search collections.

### Screenshot
![image](https://github.com/user-attachments/assets/65f6a9cd-2af5-4af2-b632-2b451fe62868)

### How can this be tested?
1. Checkout to this branch
2. Run docker build just to be sure everything is up to date `docker-compose up --build -d`
3. Go to ovs in your browser
4. You must see a search input, enter any text to search the collections. It supports search by:
    - Collection: title, slug, description, edx_course_id
    - Video: title and description
5. Verify that the search is working and returning results as expected 
