### PR TITLE
fix: bypass bad urls

### DIFF
--- a/ui/management/commands/sync_video_key_with_edx.py
+++ b/ui/management/commands/sync_video_key_with_edx.py
@@ -80,11 +80,16 @@ class Command(BaseCommand):
 
             latest_videos_by_created_at = {}
             for video in course_videos:
-                key = (
-                    (video.get("encoded_videos") or [{}])[0]
-                    .get("url", "/")
-                    .split("/")[-2]
-                )
+                url = (video.get("encoded_videos") or [{}])[0].get("url", "/")
+                try:
+                    key = url.split("/")[-2]
+                except IndexError:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"BAD URL: Could not extract video key from URL {url} for video {video.get('client_video_id')}"
+                        )
+                    )
+                    continue
 
                 # verify if key is a valid UUID
                 try:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5334

### Description (What does it do?)
This PR fixes issue with bad video url

### How can this be tested?
1. Checkout to this branch
2. Make sure your edX integration works fine
3. Update the video url manually in edX side and replace it with bad url e.g; `any_url_without_slash`
4. Run the management command `python manage.py sync_video_key_with_edx [--collection-id={id}]`
5. Make sure the command is successful and logs error starting with `BAD URL: ...`