### PR TITLE
fix: Intermediate job message status fixed

### DIFF
--- a/cloudsync/api.py
+++ b/cloudsync/api.py
@@ -297,7 +297,7 @@ def transcode_video(
         prefix = TRANSCODE_PREFIX
 
     job_id = str(uuid4())
-    err_msg = {"Job": {"Status": "Error", "Id": job_id}}
+    default_msg = {"Status": "Submitted"}
     try:
         # Start the MediaConvert job
         job = media_convert_job(
@@ -316,8 +316,7 @@ def transcode_video(
         else:
             video.update_status(VideoStatus.TRANSCODE_FAILED_INTERNAL)
         if hasattr(exc, "response"):
-            err_msg = exc.response
-            job_id = err_msg["Job"].get("Id", job_id) if "Job" in err_msg else job_id
+            default_msg = exc.response
         raise
     finally:
         # Get the content type for the Video model
@@ -328,7 +327,7 @@ def transcode_video(
             defaults={
                 "content_type": content_type,
                 "object_id": video.pk,
-                "message": err_msg,
+                "message": default_msg,
             },
         )
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7398

### Description (What does it do?)
This PR:
1. Fixes the status of Encode job while its submitted

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/253ef3ca-6e0c-4efc-a1e9-8b353ae9d685)


### How can this be tested?
1. Checkout to this branch
2. Restart Celery container `docker-compose restart celery`
3. Upload video in any collection
4. Navigation to admin > videos `admin/ui/video/` and open the video you just uploaded
5. Verify its Encode Job status under `Encode Jobs` section.
6. Before the job is completed it should be as shown in the above Screen Shot