### PR TITLE
Revert "chore(deps): update node.js to v22.17.1 (#1290)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22.17.1
+          node-version: 22.17.0
 
       - name: Setup environment
         run: sudo apt-get install libelf1

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "webpack-hot-middleware": "^2.26.1"
   },
   "engines": {
-    "node": "22.17.1",
+    "node": "22.17.0",
     "yarn": "1.22.22"
   },
   "resolutions": {


### PR DESCRIPTION
This reverts commit 4fbac1cd9ba3ec4f5e120d1207e1d145f7213589.

### What are the relevant tickets?
https://github.com/mitodl/odl-video-service/pull/1290

### Description (What does it do?)
This PR: 
1. Reverts the nodejs upgrade to 22.17.1 as this release is not available on dockerhub yet