### PR TITLE
fix: sync collection videos with edx

### DIFF
--- a/ui/tasks.py
+++ b/ui/tasks.py
@@ -90,13 +90,13 @@ def post_collection_videos_to_edx(video_ids):
         ),
         key=lambda vf: vf.id,
     )
-    responses = ovs_api.post_video_to_edx(video_files)
-
-    log.info(
-        "Posted collection videos to edX",
-        video_ids=video_ids,
-        responses={
-            endpoint.full_api_url: resp.status_code
-            for endpoint, resp in responses.items()
-        },
-    )
+    for video_file in video_files:
+        responses = ovs_api.post_video_to_edx([video_file])
+        log.info(
+            "Posted collection video to edX",
+            video_title=video_file.video.title,
+            responses={
+                endpoint.full_api_url: resp.status_code
+                for endpoint, resp in responses.items()
+            },
+        )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8083

### Description (What does it do?)
This PR:
1. fixes the feature that sync all collection videos with edX

### How can this be tested?
1. Remain in the master branch `git checkout master`
2. Create collection or use any existing
3. Make sure the edX endpoints are configured correctly
4. Upload video and confirms it gets to edX
5. Upload another video
6. Sync the videos from http://ovs.odl.local:8089/collections/{your-collection} page.
7. Check the logs and you can see some errors while pushing the video to edX
8. Now checkout to this branch `git checkout marslan/8083-sync-collection-videos`
9. Sync the Video again -- There shouldn't be any error now and videos should be sync'd with edX
10. If there are new videos that should be created with 201 status and `file_complete` status in edX and if they are updated then the status in edX should be `updated`
