### PR TITLE
Configure bumpver for Concourse release pipeline

### DIFF
--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -15,7 +15,7 @@ from redbeat import RedBeatScheduler
 from odl_video.envs import get_any, get_bool, get_int, get_key, get_string, parse_env
 from odl_video.sentry import init_sentry
 
-VERSION = "0.85.0"
+VERSION = "2026.04.16.1"
 
 ENVIRONMENT = get_string("ODL_VIDEO_ENVIRONMENT", "dev")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,13 @@ module-root = ""
 [build-system]
 requires = ["uv_build>=0.10.0,<0.11.0"]
 build-backend = "uv_build"
+
+[tool.bumpver]
+current_version = "2026.04.16.1"
+version_pattern = "YYYY.0M.0D.INC1"
+commit = false
+tag = false
+push = false
+
+[tool.bumpver.file_patterns]
+"odl_video/settings.py" = ['VERSION = "{version}"']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "odl-video-service"
-version = "0.70.0"
+version = "0.92.0"
 description = "building blocks for a basic video service for ODL"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.12,<4"
@@ -83,3 +83,36 @@ module-root = ""
 [build-system]
 requires = ["uv_build>=0.10.0,<0.11.0"]
 build-backend = "uv_build"
+
+[tool.bumpversion]
+commit = false
+tag = false
+parse = "(?P<release>(?:[1-9][0-9]{3})\\.(?:1[0-2]|[1-9])\\.(?:3[0-1]|[12][0-9]|[1-9]))\\.(?P<build>\\d+)"
+serialize = ["{release}.{build}"]
+
+[tool.bumpversion.parts.release]
+calver_format = "{YYYY}.{MM}.{DD}"
+
+[tool.bumpversion.parts.build]
+first_value = "1"
+
+[[tool.bumpversion.files]]
+filename = "odl_video/settings.py"
+search = 'VERSION = "{current_version}"'
+replace = 'VERSION = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "uv.lock"
+search = """
+name = "odl-video-service"
+version = "{current_version}"
+source = {{ virtual = "." }}"""
+replace = """
+name = "odl-video-service"
+version = "{new_version}"
+source = {{ virtual = "." }}"""

--- a/uv.lock
+++ b/uv.lock
@@ -1324,7 +1324,7 @@ wheels = [
 
 [[package]]
 name = "odl-video-service"
-version = "0.70.0"
+version = "0.92.0"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds `[tool.bumpver]` configuration to `pyproject.toml` so the Concourse
release pipeline can update the application version automatically on each
release.

The new version format is `YYYY.MM.DD.N` (e.g., `2026.04.16.1`), which
replaces the previous semver-style version strings. This is required by the
Concourse `release` resource workflow being rolled out in
mitodl/ol-infrastructure#4506.

The `VERSION` constant in Django settings is updated to the initial release
format version as part of this change.

### How can this be tested?
1. With `bumpver` installed (`pip install bumpver`), run `bumpver update --dry` from the repo root and confirm it shows the expected diff with no errors.
2. Check that `VERSION` in Django settings matches `current_version` in `pyproject.toml`.

### Additional Context
Part of the Concourse release pipeline modernization — migrating from the Doof
Slack bot to a Concourse-native release workflow using GitHub Issues as
production gates.