### PR TITLE
Compatibility with ol-mit keycloak realm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,14 +46,22 @@ YT_REFRESH_TOKEN=
 
 # Keycloak configuration
 USE_KEYCLOAK=True
+
+# Runtime OIDC login — consumed by social-auth-app-django.
+SOCIAL_AUTH_KEYCLOAK_KEY=odl-video-app
+SOCIAL_AUTH_KEYCLOAK_SECRET=odl-video-secret-2025
+SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY=
+SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL=http://kc.odl.local:7080/realms/ovs-local/protocol/openid-connect/auth
+SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL=http://kc.odl.local:7080/realms/ovs-local/protocol/openid-connect/token
+
+# Admin-API access — consumed by the moira-to-keycloak migration commands.
 KEYCLOAK_SERVER_URL=http://kc.odl.local:7080
 KEYCLOAK_REALM=ovs-local
-KEYCLOAK_CLIENT_ID=odl-video-app
-KEYCLOAK_CLIENT_SECRET=odl-video-secret-2025
-KEYCLOAK_PUBLIC_KEY=
-KEYCLOAK_SVC_KEYSTORE_PASSWORD=supersecret123456
-KEYCLOAK_SVC_HOSTNAME=kc.odl.local
 KEYCLOAK_SVC_ADMIN=admin
 KEYCLOAK_SVC_ADMIN_PASSWORD=admin
+
+# Local Keycloak container bootstrap.
+KEYCLOAK_SVC_KEYSTORE_PASSWORD=supersecret123456
+KEYCLOAK_SVC_HOSTNAME=kc.odl.local
 KEYCLOAK_PORT=7080
 KEYCLOAK_SSL_PORT=7443

--- a/README-keycloak.md
+++ b/README-keycloak.md
@@ -108,15 +108,13 @@ KEYCLOAK_SSL_PORT=7443
 6. Django exchanges code for access token
 7. Django creates/updates user account with Keycloak data
 
-### 2. Group/Role Mapping
+### 2. Django Permissions
 
-The application automatically maps Keycloak groups to Django permissions:
-
-- **Admin group** → `is_superuser=True, is_staff=True`
-- **Staff group** → `is_staff=True`
-- **Other groups** → Regular user permissions
-
-This mapping is handled by the custom pipeline in `odl_video/pipeline.py`.
+Keycloak authenticates users but does **not** manage Django's `is_staff` /
+`is_superuser` flags. Those are set manually via the Django admin or shell and
+are preserved across logins. The raw `user_groups` claim from Keycloak is still
+stored on the social user's `extra_data` (see `SOCIAL_AUTH_KEYCLOAK_EXTRA_DATA`
+in `odl_video/settings.py`) but nothing acts on it.
 
 ## Testing Authentication
 
@@ -161,13 +159,11 @@ In Keycloak Admin Console:
 - Verify Keycloak URL is accessible: `curl http://kc.odl.local:7080`
 
 #### 5. Users Can Login But Have No Permissions
-- Check that groups are properly configured
-- Verify the pipeline function `assign_user_groups` is working
-- Check Django logs for pipeline errors
+- `is_staff` / `is_superuser` are set manually in Django admin or shell; log in
+  as an existing superuser and promote the new user from there.
 
 ## File Locations
 
 - **Realm Configuration**: `config/keycloak/realms/ovs-local-realm.json`
 - **Django Settings**: `odl_video/settings.py`
-- **Authentication Pipeline**: `odl_video/pipeline.py`
 - **Docker Compose**: `docker-compose.yml` (Keycloak service definition)

--- a/README-keycloak.md
+++ b/README-keycloak.md
@@ -69,7 +69,7 @@ You need to get the public key from your Keycloak instance:
 5. Update your `.env` file with the key on a single line:
 
 ```env
-KEYCLOAK_PUBLIC_KEY=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
+SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
 ```
 
 ## Environment Configuration
@@ -77,17 +77,21 @@ KEYCLOAK_PUBLIC_KEY=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
 Create/update your `.env` file with these Keycloak settings:
 
 ```env
-# Keycloak Configuration
+# Runtime OIDC login — consumed by social-auth-app-django.
+SOCIAL_AUTH_KEYCLOAK_KEY=odl-video-app
+SOCIAL_AUTH_KEYCLOAK_SECRET=odl-video-secret-2025
+SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
+SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL=http://kc.odl.local:7080/realms/ovs-local/protocol/openid-connect/auth
+SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL=http://kc.odl.local:7080/realms/ovs-local/protocol/openid-connect/token
+
+# Admin-API access — consumed by the moira-to-keycloak migration commands.
 KEYCLOAK_SERVER_URL=http://kc.odl.local:7080
 KEYCLOAK_REALM=ovs-local
-KEYCLOAK_CLIENT_ID=odl-video-app
-KEYCLOAK_CLIENT_SECRET=odl-video-secret-2025
-KEYCLOAK_PUBLIC_KEY=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
-
-# Keycloak Service Configuration (for docker-compose)
-KEYCLOAK_SVC_HOSTNAME=kc.odl.local
 KEYCLOAK_SVC_ADMIN=admin
 KEYCLOAK_SVC_ADMIN_PASSWORD=admin
+
+# Local Keycloak container bootstrap.
+KEYCLOAK_SVC_HOSTNAME=kc.odl.local
 KEYCLOAK_PORT=7080
 KEYCLOAK_SSL_PORT=7443
 ```
@@ -144,8 +148,8 @@ In Keycloak Admin Console:
 - Ensure Web Origins are set correctly
 
 #### 2. "Invalid client" Error
-- Verify `KEYCLOAK_CLIENT_ID` matches the client ID in Keycloak
-- Check that `KEYCLOAK_CLIENT_SECRET` is correct
+- Verify `SOCIAL_AUTH_KEYCLOAK_KEY` matches the client ID in Keycloak
+- Check that `SOCIAL_AUTH_KEYCLOAK_SECRET` is correct
 
 #### 3. "Invalid public key" Error
 - Get a fresh public key from Keycloak Admin Console

--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,18 @@ Touchstone hasn't been configured yet, but here are some instructions for
 `Touchstone integration`_.
 
 
+Keycloak (local authentication)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Local development uses Keycloak as the OIDC provider instead of Touchstone.
+A ``keycloak`` service runs in ``docker-compose`` with a pre-configured
+``ovs-local`` realm, seeded users, and an ``odl-video-app`` client. See
+`README-keycloak.md`_ for the full setup walkthrough — adding the
+``kc.odl.local`` entry to ``/etc/hosts``, pulling the realm public key, and
+populating the ``SOCIAL_AUTH_KEYCLOAK_*`` and ``KEYCLOAK_*`` values in your
+``.env``.
+
+
 YouTube Integration
 ~~~~~~~~~~~~~~~~~~~
 
@@ -186,6 +198,7 @@ like this:
 .. _Touchstone integration: https://github.com/singingwolfboy/touchstone-notes
 .. _Moira: http://kb.mit.edu/confluence/display/istcontrib/Moira+Overview
 .. _Docker Compose: https://docs.docker.com/compose/
+.. _README-keycloak.md: ./README-keycloak.md
 
 .. |build-status| image:: https://travis-ci.org/mitodl/odl-video-service.svg?branch=master&style=flat
    :target: https://travis-ci.org/mitodl/odl-video-service

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -119,32 +119,26 @@ if USE_KEYCLOAK:
     LOGIN_URL = "/auth/login/keycloak/"
 
 
-# Keycloak OIDC Configuration
-KEYCLOAK_CLIENT_ID = get_string("KEYCLOAK_CLIENT_ID", "")
-KEYCLOAK_CLIENT_SECRET = get_string("KEYCLOAK_CLIENT_SECRET", "")
-KEYCLOAK_PUBLIC_KEY = get_string("KEYCLOAK_PUBLIC_KEY", "")
+# Keycloak OIDC settings — consumed by social-auth-app-django at runtime.
+SOCIAL_AUTH_KEYCLOAK_KEY = get_string("SOCIAL_AUTH_KEYCLOAK_KEY", "")
+SOCIAL_AUTH_KEYCLOAK_SECRET = get_string("SOCIAL_AUTH_KEYCLOAK_SECRET", "")
+SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY = get_string("SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY", "")
+SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = get_string(
+    "SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL", ""
+)
+SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL = get_string(
+    "SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL", ""
+)
+SOCIAL_AUTH_KEYCLOAK_LOGOUT_URL = SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL.replace(
+    "/protocol/openid-connect/auth", "/protocol/openid-connect/logout"
+)
+
+# Keycloak admin-API settings — consumed by the moira-to-keycloak migration
+# management commands, not by the runtime login flow.
 KEYCLOAK_SERVER_URL = get_string("KEYCLOAK_SERVER_URL", "http://kc.odl.local:7080")
 KEYCLOAK_REALM = get_string("KEYCLOAK_REALM", "ovs-local")
 KEYCLOAK_SVC_ADMIN = get_string("KEYCLOAK_SVC_ADMIN", "admin")
 KEYCLOAK_SVC_ADMIN_PASSWORD = get_string("KEYCLOAK_SVC_ADMIN_PASSWORD", "admin")
-
-# Social Auth Keycloak settings
-SOCIAL_AUTH_KEYCLOAK_KEY = KEYCLOAK_CLIENT_ID
-SOCIAL_AUTH_KEYCLOAK_SECRET = KEYCLOAK_CLIENT_SECRET
-SOCIAL_AUTH_PUBLIC_KEY = KEYCLOAK_PUBLIC_KEY
-
-# Keycloak URLs
-if KEYCLOAK_SERVER_URL and KEYCLOAK_REALM:
-    KEYCLOAK_BASE_URL = f"{KEYCLOAK_SERVER_URL}/realms/{KEYCLOAK_REALM}"
-    SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = (
-        f"{KEYCLOAK_BASE_URL}/protocol/openid-connect/auth"
-    )
-    SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL = (
-        f"{KEYCLOAK_BASE_URL}/protocol/openid-connect/token"
-    )
-    SOCIAL_AUTH_KEYCLOAK_LOGOUT_URL = (
-        f"{KEYCLOAK_BASE_URL}/protocol/openid-connect/logout"
-    )
 
 # Social Auth Pipeline - Custom pipeline for user creation and role mapping
 SOCIAL_AUTH_PIPELINE = [
@@ -164,7 +158,6 @@ SOCIAL_AUTH_PIPELINE = [
     # Associate the current social details with the user in the database.
     "social_core.pipeline.social_auth.associate_user",
     "social_core.pipeline.social_auth.load_extra_data",
-    "odl_video.pipeline.assign_user_groups",
     "social_core.pipeline.user.user_details",
 ]
 

--- a/ui/views.py
+++ b/ui/views.py
@@ -671,7 +671,7 @@ class LogoutView(View):
 
                 params = {"post_logout_redirect_uri": redirect_uri}
 
-                client_id = getattr(settings, "KEYCLOAK_CLIENT_ID", "")
+                client_id = getattr(settings, "SOCIAL_AUTH_KEYCLOAK_KEY", "")
                 if client_id:
                     params["client_id"] = client_id
 


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/6821 and https://github.com/mitodl/ol-infrastructure/pull/4522

### Description (What does it do?)
Makes the keycloak integration in OVS compatible with ol-infrastructure ol-mit keycloak setup


### How can this be tested?
- Follow instructions in the keycloak README, you should be able to log in as `admin@ovs.local` with password `admin`
