### PR TITLE
fix: don't auto public learn collection videos

### DIFF
--- a/static/js/components/dialogs/EditVideoFormDialog.js
+++ b/static/js/components/dialogs/EditVideoFormDialog.js
@@ -465,6 +465,7 @@ class EditVideoFormDialog extends React.Component<*, DialogState> {
               value={PERM_CHOICE_PUBLIC}
               selectedValue={editVideoForm.viewChoice}
               onChange={this.handleVideoViewPermClick}
+              disabled={defaultPerms}
               className="wideLabel"
             />
           )}

--- a/ui/admin.py
+++ b/ui/admin.py
@@ -84,7 +84,11 @@ class CollectionAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         """Propagate is_public changes to all videos in the collection."""
         super().save_model(request, obj, form, change)
-        if change and "is_public" in form.changed_data:
+        if (
+            change
+            and "is_public" in form.changed_data
+            and not (obj.is_public and obj.include_in_learn)
+        ):
             obj.videos.update(is_public=obj.is_public, is_private=not obj.is_public)
 
 

--- a/ui/admin_test.py
+++ b/ui/admin_test.py
@@ -1,0 +1,95 @@
+"""Tests for UI admin customizations"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory
+
+from ui.admin import CollectionAdmin
+from ui.factories import CollectionFactory, VideoFactory
+from ui.models import Collection
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def collection_admin():
+    """Return a CollectionAdmin instance bound to the default admin site."""
+    return CollectionAdmin(model=Collection, admin_site=AdminSite())
+
+
+@pytest.fixture()
+def mock_request():
+    """Return a minimal GET request for use in admin calls."""
+    return RequestFactory().get("/admin/")
+
+
+def _save_with_changed_data(admin_instance, request, obj, changed_fields):
+    """Helper: call save_model with a mock form whose changed_data is changed_fields."""
+    mock_form = MagicMock()
+    mock_form.changed_data = changed_fields
+    with patch("django.contrib.admin.ModelAdmin.save_model"):
+        admin_instance.save_model(request, obj, mock_form, change=True)
+
+
+@pytest.mark.parametrize(
+    ["is_public", "include_in_learn", "expected_video_is_public"],
+    [
+        # Turning on is_public for a normal collection → videos become public
+        (True, False, True),
+        # Turning on is_public for a learn collection → videos stay private
+        (True, True, False),
+    ],
+)
+def test_collection_admin_save_model_is_public_propagation(
+    collection_admin,
+    mock_request,
+    is_public,
+    include_in_learn,
+    expected_video_is_public,
+):
+    """
+    When is_public is toggled on a collection via the admin:
+    - Normal collections propagate the change to all their videos.
+    - Collections with include_in_learn=True do NOT auto-make videos public;
+      editors must explicitly publish each video.
+    """
+    collection = CollectionFactory(
+        is_public=is_public, include_in_learn=include_in_learn
+    )
+    video = VideoFactory(collection=collection, is_public=False)
+
+    _save_with_changed_data(collection_admin, mock_request, collection, ["is_public"])
+
+    video.refresh_from_db()
+    assert video.is_public is expected_video_is_public
+
+
+def test_collection_admin_save_model_turning_off_public_still_propagates_for_learn(
+    collection_admin, mock_request
+):
+    """
+    Even for include_in_learn=True collections, turning is_public OFF should still
+    propagate to videos so they are no longer accidentally accessible.
+    """
+    collection = CollectionFactory(is_public=False, include_in_learn=True)
+    video = VideoFactory(collection=collection, is_public=True)
+
+    _save_with_changed_data(collection_admin, mock_request, collection, ["is_public"])
+
+    video.refresh_from_db()
+    assert video.is_public is False
+
+
+def test_collection_admin_save_model_no_change_to_is_public_skips_update(
+    collection_admin, mock_request
+):
+    """If is_public is not in changed_data, video permissions are not touched."""
+    collection = CollectionFactory(is_public=True, include_in_learn=False)
+    video = VideoFactory(collection=collection, is_public=False)
+
+    _save_with_changed_data(collection_admin, mock_request, collection, ["title"])
+
+    video.refresh_from_db()
+    assert video.is_public is False

--- a/ui/signals.py
+++ b/ui/signals.py
@@ -85,7 +85,11 @@ def set_video_is_public_from_collection(sender, instance, created, **kwargs):
     """
     if created:
         collection = instance.collection
-        if getattr(collection, "is_public", False) and not instance.is_public:
+        if (
+            getattr(collection, "is_public", False)
+            and not getattr(collection, "include_in_learn", False)
+            and not instance.is_public
+        ):
             # Use update to avoid triggering signals again
             Video.objects.filter(pk=instance.pk).update(
                 is_public=True, is_private=False

--- a/ui/signals_test.py
+++ b/ui/signals_test.py
@@ -130,3 +130,34 @@ def test_collection_schedule_retranscode_signal(
         Video.objects.get(id=video_with_file.id).schedule_retranscode
         is retranscode_enabled
     )
+
+
+@pytest.mark.parametrize(
+    ["collection_is_public", "include_in_learn", "expected_is_public"],
+    [
+        (True, False, True),  # public collection, not learn → auto-set public
+        (
+            True,
+            True,
+            False,
+        ),  # public collection, include_in_learn → do NOT auto-set public
+        (False, True, False),  # not public collection → stays private
+        (False, False, False),  # not public collection → stays private
+    ],
+)
+def test_set_video_is_public_from_collection(
+    collection_is_public, include_in_learn, expected_is_public
+):
+    """
+    New videos inherit is_public from their collection only when include_in_learn is False.
+    For collections with include_in_learn=True, videos must be made public explicitly.
+    """
+    collection = CollectionFactory(
+        is_public=collection_is_public, include_in_learn=include_in_learn
+    )
+    video = Video.objects.create(
+        collection=collection,
+        title="Test Video",
+        source_url="https://example.com/test.mp4",
+    )
+    assert Video.objects.get(pk=video.pk).is_public is expected_is_public


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11353

### Description (What does it do?)
This pull request updates both the frontend and backend logic for handling the public visibility of videos, with a special focus on collections intended for MIT Learn. The changes ensure that videos in collections marked as "include_in_learn" are not automatically made public, requiring explicit action from editors. The frontend now provides users with a checkbox to set video visibility when appropriate, and the backend and signals have been updated to enforce the new rules. Comprehensive tests have been added to verify this behavior.

**Frontend changes for video visibility:**
- Added an `isPublic` state and a "Make this video publicly accessible" checkbox to `EditVideoFormDialog`, shown only if the parent collection is public and video permissions are not enabled. The checkbox state is included when saving the video. [[1]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbR8) [[2]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbL42-R44) [[3]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbL67-R70) [[4]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbR111) [[5]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbL223-R228) [[6]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbR264-R266) [[7]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbR283-R287) [[8]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbR390-R411) [[9]](diffhunk://#diff-2f2579574533c1805348421d1be1fbca700372bb1179388ae11b735e5c3e52fbR559-R563)

**Backend logic for public video propagation:**
- Updated `CollectionAdmin.save_model` so that when a collection's `is_public` is toggled on, videos are only auto-made public if `include_in_learn` is False; otherwise, editors must explicitly set each video's visibility. Turning off `is_public` still propagates to all videos.
- Updated the `set_video_is_public_from_collection` signal to prevent videos in "include_in_learn" collections from being auto-set to public on creation.

### Screenshots (if appropriate):
<img width="1330" height="707" alt="image" src="https://github.com/user-attachments/assets/a832f950-0a86-4787-b31c-b704cfe20f46" />


### How can this be tested?
1. Checkout to this branch, make sure the docker is refreshed
2. Create a public collection
3. if the collection have `include_in_learn = True` => Adding new video should not be marked as public automatically and if you change the `is_public` flag from admin it will not migration to its videos
4. if the collection have `include_in_learn = False` => adding new video should be marked as public automatically and if you change the `is_public` flag it will migrate to all of its videos.