### PR TITLE
Use portrait aspect ratio when transcoding video shorts

### DIFF
--- a/cloudsync/api.py
+++ b/cloudsync/api.py
@@ -328,6 +328,16 @@ def prepare_results(video: Video, job: EncodeJob, results: str) -> dict:
     return results
 
 
+def _get_template_path(video: Video) -> str | None:
+    """
+    Return the portrait MediaConvert template path for a shorts video,
+    otherwise return None (default landscape template).
+    """
+    if video.collection.for_shorts:
+        return settings.TRANSCODE_JOB_TEMPLATE_PORTRAIT
+    return None
+
+
 def transcode_video(
     video: Video, video_file: VideoFile, generate_mp4_videofile: bool = False
 ) -> None:
@@ -365,6 +375,7 @@ def transcode_video(
                 "exclude_mp4": not generate_mp4_videofile,
                 "exclude_thumbnail": exclude_thumbnail,
             },
+            template_path=_get_template_path(video),
         )
         job_id = job.get("Job", {}).get("Id", job_id)
     except ClientError as exc:

--- a/cloudsync/api_test.py
+++ b/cloudsync/api_test.py
@@ -34,6 +34,7 @@ from cloudsync.api import (
 from cloudsync.conftest import MockBoto, MockClientMC
 from ui.constants import VideoStatus
 from ui.factories import (
+    CollectionFactory,
     EncodeJobFactory,
     UserFactory,
     VideoFactory,
@@ -284,6 +285,7 @@ def test_process_watch(mocker):
             "exclude_mp4": True,
             "exclude_thumbnail": False,
         },
+        template_path=None,
     )
 
 
@@ -361,6 +363,7 @@ def test_transcode_job(mocker, status, expected_status, exclude_thumbnail):
             "exclude_mp4": True,
             "exclude_thumbnail": exclude_thumbnail,
         },
+        template_path=None,
     )
     assert len(video.encode_jobs.all()) == 1
     assert mock_delete_objects.call_count == (
@@ -404,9 +407,69 @@ def test_transcode_job_failure(mocker, status, error_status, exclude_thumbnail):
         videofile.s3_object_key,
         destination_prefix=prefix,
         group_settings={"exclude_mp4": True, "exclude_thumbnail": exclude_thumbnail},
+        template_path=None,
     )
     assert len(video.encode_jobs.all()) == 1
     assert Video.objects.get(id=video.id).status == error_status
+
+
+@pytest.mark.parametrize(
+    "for_shorts,expected_template",
+    [
+        (True, "TRANSCODE_JOB_TEMPLATE_PORTRAIT"),
+        (False, None),
+    ],
+)
+def test_transcode_video_routes_shorts_to_portrait_template(
+    mocker, for_shorts, expected_template
+):
+    """
+    Videos in a for_shorts collection should be sent through the portrait
+    MediaConvert template; every other video uses the default landscape one
+    (signalled by template_path=None, which the transcoding library resolves
+    via settings.TRANSCODE_JOB_TEMPLATE).
+    """
+    collection = CollectionFactory.create(for_shorts=for_shorts)
+    video = VideoFactory.create(collection=collection, status=VideoStatus.UPLOADING)
+    videofile = VideoFileFactory.create(video=video)
+
+    mock_job = {"Job": {"Id": str(uuid.uuid4())}}
+    mock_encoder = mocker.patch(
+        "cloudsync.api.media_convert_job", return_value=mock_job
+    )
+    mocker.patch("ui.models.tasks")
+
+    api.transcode_video(video, videofile)
+
+    expected = getattr(settings, expected_template) if expected_template else None
+    assert mock_encoder.call_args.kwargs["template_path"] == expected
+
+
+def test_portrait_mediaconvert_outputs_are_taller_than_wide():
+    """
+    Guard against accidental landscape regression in the portrait template:
+    every output that declares Width and Height must have Height > Width.
+    """
+    import json
+    from pathlib import Path
+
+    template_path = Path(settings.BASE_DIR) / "config" / "mediaconvert_portrait.json"
+    template = json.loads(template_path.read_text())
+
+    sized_outputs = [
+        output
+        for group in template["Settings"]["OutputGroups"]
+        for output in group["Outputs"]
+        if "Width" in output.get("VideoDescription", {})
+        and "Height" in output["VideoDescription"]
+    ]
+    assert sized_outputs, "portrait template should declare sized outputs"
+    for output in sized_outputs:
+        vd = output["VideoDescription"]
+        assert vd["Height"] > vd["Width"], (
+            f"output {output.get('NameModifier')!r} is not portrait: "
+            f"{vd['Width']}x{vd['Height']}"
+        )
 
 
 @pytest.mark.parametrize("replace", [True, False])

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -384,6 +384,7 @@ def test_monitor_watch(mocker, user):
             "exclude_mp4": True,
             "exclude_thumbnail": False,
         },
+        template_path=None,
     )
     assert new_videofile.bucket_name == settings.VIDEO_S3_BUCKET
     with pytest.raises(ClientError):

--- a/config/mediaconvert_portrait.json
+++ b/config/mediaconvert_portrait.json
@@ -29,12 +29,12 @@
               "Container": "M3U8"
             },
             "VideoDescription": {
-              "Width": 576,
-              "Height": 1024,
+              "Width": 1080,
+              "Height": 1920,
               "CodecSettings": {
                 "Codec": "H_264",
                 "H264Settings": {
-                  "Bitrate": 1872000,
+                  "Bitrate": 4000000,
                   "RateControlMode": "CBR",
                   "GopSize": 90,
                   "GopSizeUnits": "FRAMES",
@@ -61,12 +61,12 @@
               "Container": "M3U8"
             },
             "VideoDescription": {
-              "Width": 540,
-              "Height": 960,
+              "Width": 720,
+              "Height": 1280,
               "CodecSettings": {
                 "Codec": "H_264",
                 "H264Settings": {
-                  "Bitrate": 1500000,
+                  "Bitrate": 2000000,
                   "RateControlMode": "CBR",
                   "GopSize": 90,
                   "GopSizeUnits": "FRAMES",
@@ -93,12 +93,12 @@
               "Container": "M3U8"
             },
             "VideoDescription": {
-              "Width": 224,
-              "Height": 400,
+              "Width": 540,
+              "Height": 960,
               "CodecSettings": {
                 "Codec": "H_264",
                 "H264Settings": {
-                  "Bitrate": 400000,
+                  "Bitrate": 1000000,
                   "RateControlMode": "CBR",
                   "GopSize": 90,
                   "GopSizeUnits": "FRAMES",

--- a/config/mediaconvert_portrait.json
+++ b/config/mediaconvert_portrait.json
@@ -1,0 +1,216 @@
+{
+  "UserMetadata": {},
+  "Settings": {
+    "OutputGroups": [
+      {
+        "Name": "Apple HLS",
+        "OutputGroupSettings": {
+          "Type": "HLS_GROUP_SETTINGS",
+          "HlsGroupSettings": {
+            "MinSegmentLength": 0,
+            "ManifestDurationFormat": "INTEGER",
+            "CodecSpecification": "RFC_4281",
+            "DirectoryStructure": "SINGLE_DIRECTORY",
+            "ManifestCompression": "NONE",
+            "CaptionLanguageSetting": "OMIT",
+            "ImageBasedTrickPlay": "NONE",
+            "OutputSelection": "MANIFESTS_AND_SEGMENTS",
+            "AdditionalManifests": [
+              {
+                "SelectedOutputs": ["_HLS2M", "_HLS1.5M", "_HLS400k"]
+              }
+           ]
+          }
+        },
+        "Outputs": [
+          {
+            "NameModifier": "_HLS2M",
+            "ContainerSettings": {
+              "Container": "M3U8"
+            },
+            "VideoDescription": {
+              "Width": 576,
+              "Height": 1024,
+              "CodecSettings": {
+                "Codec": "H_264",
+                "H264Settings": {
+                  "Bitrate": 1872000,
+                  "RateControlMode": "CBR",
+                  "GopSize": 90,
+                  "GopSizeUnits": "FRAMES",
+                  "InterlaceMode": "PROGRESSIVE"
+                }
+              }
+            },
+            "AudioDescriptions": [
+              {
+                "CodecSettings": {
+                  "Codec": "AAC",
+                  "AacSettings": {
+                    "Bitrate": 128000,
+                    "CodingMode": "CODING_MODE_2_0",
+                    "SampleRate": 44100
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "NameModifier": "_HLS1.5M",
+            "ContainerSettings": {
+              "Container": "M3U8"
+            },
+            "VideoDescription": {
+              "Width": 540,
+              "Height": 960,
+              "CodecSettings": {
+                "Codec": "H_264",
+                "H264Settings": {
+                  "Bitrate": 1500000,
+                  "RateControlMode": "CBR",
+                  "GopSize": 90,
+                  "GopSizeUnits": "FRAMES",
+                  "InterlaceMode": "PROGRESSIVE"
+                }
+              }
+            },
+            "AudioDescriptions": [
+              {
+                "CodecSettings": {
+                  "Codec": "AAC",
+                  "AacSettings": {
+                    "Bitrate": 128000,
+                    "CodingMode": "CODING_MODE_2_0",
+                    "SampleRate": 44100
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "NameModifier": "_HLS400k",
+            "ContainerSettings": {
+              "Container": "M3U8"
+            },
+            "VideoDescription": {
+              "Width": 224,
+              "Height": 400,
+              "CodecSettings": {
+                "Codec": "H_264",
+                "H264Settings": {
+                  "Bitrate": 400000,
+                  "RateControlMode": "CBR",
+                  "GopSize": 90,
+                  "GopSizeUnits": "FRAMES",
+                  "InterlaceMode": "PROGRESSIVE"
+                }
+              }
+            },
+            "AudioDescriptions": [
+              {
+                "CodecSettings": {
+                  "Codec": "AAC",
+                  "AacSettings": {
+                    "Bitrate": 96000,
+                    "CodingMode": "CODING_MODE_2_0",
+                    "SampleRate": 44100
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "Name": "File Group",
+        "Outputs": [
+          {
+            "ContainerSettings": {
+              "Container": "MP4",
+              "Mp4Settings": {}
+            },
+            "VideoDescription": {
+              "Width": 720,
+              "Height": 1280,
+              "ScalingBehavior": "DEFAULT",
+              "CodecSettings": {
+                "Codec": "H_264",
+                "H264Settings": {
+                  "FramerateDenominator": 1,
+                  "FramerateNumerator": 30,
+                  "Bitrate": 1800000,
+                  "InterlaceMode": "PROGRESSIVE",
+                  "RateControlMode": "CBR"
+                }
+              }
+            },
+            "AudioDescriptions": [
+              {
+                "CodecSettings": {
+                  "Codec": "AAC",
+                  "AacSettings": {
+                    "Bitrate": 96000,
+                    "CodingMode": "CODING_MODE_1_0",
+                    "SampleRate": 44100
+                  }
+                }
+              }
+            ],
+            "NameModifier": "_custom"
+          }
+        ],
+        "OutputGroupSettings": {
+          "Type": "FILE_GROUP_SETTINGS",
+          "FileGroupSettings": {
+            "Destination": null
+          }
+        }
+      },
+      {
+        "Name": "Thumbnail Group",
+        "Outputs": [
+          {
+            "NameModifier": "_thumbnail",
+            "ContainerSettings": {
+              "Container": "RAW"
+            },
+            "VideoDescription": {
+              "CodecSettings": {
+                "Codec": "FRAME_CAPTURE",
+                "FrameCaptureSettings": {
+                  "FramerateNumerator": 1,
+                  "FramerateDenominator": 1,
+                  "MaxCaptures": 1,
+                  "Quality": 80
+                }
+              }
+            }
+          }
+        ],
+        "OutputGroupSettings": {
+          "Type": "FILE_GROUP_SETTINGS",
+          "FileGroupSettings": {
+            "Destination": null
+          }
+        }
+      }
+    ],
+    "Inputs": [
+      {
+        "AudioSelectors": {
+          "Audio Selector 1": {
+            "DefaultSelection": "DEFAULT"
+          }
+        },
+        "VideoSelector": {},
+        "TimecodeSource": "ZEROBASED",
+        "FileInput": null
+      }
+    ]
+  },
+  "AccelerationSettings": {
+    "Mode": "DISABLED"
+  },
+  "StatusUpdateInterval": "SECONDS_60",
+  "Priority": 0
+}

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -395,6 +395,9 @@ AWS_ACCOUNT_ID = get_string("AWS_ACCOUNT_ID", "")
 AWS_TRANSCODE_BUCKET_NAME = get_string("AWS_TRANSCODE_BUCKET_NAME", "")
 AWS_ROLE_NAME = get_string("AWS_ROLE_NAME", "")
 VIDEO_S3_TRANSCODE_PREFIX = get_string("VIDEO_S3_TRANSCODE_PREFIX", "transcoded")
+TRANSCODE_JOB_TEMPLATE_PORTRAIT = get_string(
+    "TRANSCODE_JOB_TEMPLATE_PORTRAIT", "config/mediaconvert_portrait.json"
+)
 # List of mandatory settings. If any of these is not set, the app will not start
 # and will raise an ImproperlyConfigured exception
 MANDATORY_SETTINGS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "django==4.2.30",
     "django-encrypted-model-fields>=0.6.5,<0.7",
     "django-hijack>=3.7.1,<4",
-    "django-redis>=5.4.0,<5.5.0",
+    "django-redis>=6.0.0,<7",
     "django-webpack-loader>=3.0.0,<4",
     "djangorestframework>=3.11.2,<4",
     "google-api-python-client>=2.58.0,<3",
@@ -46,7 +46,7 @@ dependencies = [
     "mitol-django-observability>=2026.1.0",
     "urllib3>=2.0.0,<3",
     "uwsgi==2.0.31",
-    "mitol-django-transcoding>=2025.5.21,<2026",
+    "mitol-django-transcoding>=2025.5.21",
     "django-filter>=25.1,<26",
     "setuptools>=80.0.0,<81",
 ]
@@ -76,6 +76,9 @@ dev = [
 [tool.uv]
 package = false
 default-groups = "all"
+
+[tool.uv.sources]
+mitol-django-transcoding = { git = "https://github.com/mitodl/ol-django.git", rev = "ed8ad1ebcca0fecab63a108c8a58c3297b5041ff", subdirectory = "src/transcoding" }  # pragma: allowlist secret
 
 [tool.uv.build-backend]
 module-root = ""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -645,15 +645,15 @@ wheels = [
 
 [[package]]
 name = "django-redis"
-version = "5.4.0"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/9d/2272742fdd9d0a9f0b28cd995b0539430c9467a2192e4de2cea9ea6ad38c/django-redis-5.4.0.tar.gz", hash = "sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42", size = 52567, upload-time = "2023-10-01T20:22:01.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/53/dbcfa1e528e0d6c39947092625b2c89274b5d88f14d357cee53c4d6dbbd4/django_redis-6.0.0.tar.gz", hash = "sha256:2d9cb12a20424a4c4dde082c6122f486628bae2d9c2bee4c0126a4de7fda00dd", size = 56904, upload-time = "2025-06-17T18:15:46.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/f1/63caad7c9222c26a62082f4f777de26389233b7574629996098bf6d25a4d/django_redis-5.4.0-py3-none-any.whl", hash = "sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b", size = 31119, upload-time = "2023-10-01T20:21:33.009Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/79/055dfcc508cfe9f439d9f453741188d633efa9eab90fc78a67b0ab50b137/django_redis-6.0.0-py3-none-any.whl", hash = "sha256:20bf0063a8abee567eb5f77f375143c32810c8700c0674ced34737f8de4e36c0", size = 33687, upload-time = "2025-06-17T18:15:34.165Z" },
 ]
 
 [[package]]
@@ -1218,22 +1218,16 @@ wheels = [
 
 [[package]]
 name = "mitol-django-common"
-version = "2025.6.20"
-source = { registry = "https://pypi.org/simple" }
+version = "2026.4.29"
+source = { git = "https://github.com/mitodl/ol-django.git?subdirectory=src%2Fcommon&rev=ed8ad1ebcca0fecab63a108c8a58c3297b5041ff#ed8ad1ebcca0fecab63a108c8a58c3297b5041ff" }
 dependencies = [
     { name = "django" },
     { name = "django-redis" },
     { name = "django-stubs" },
     { name = "django-webpack-loader" },
-    { name = "factory-boy" },
-    { name = "pytest" },
     { name = "pytz" },
     { name = "requests" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/0e/b4dda829f5119338da3f8c7bd63a2350131bd4f84bd2f0e373c34921f520/mitol_django_common-2025.6.20.tar.gz", hash = "sha256:5060a99537a571ec8e5b94a3972161a318ae60dc7df4154ebcc8cb5f29cfbdbb", size = 21695, upload-time = "2025-06-20T08:08:05.727Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/c2/d562e5e8721a1e4319f0ca78c7dc2fbe2fe796a58fda9aae44b4462a7a14/mitol_django_common-2025.6.20-py3-none-any.whl", hash = "sha256:a3a1d2ed1570cf905132651ab1338cf30924904c6f4d98af62e80cf9a25d4f54", size = 31511, upload-time = "2025-06-20T08:08:04.965Z" },
 ]
 
 [[package]]
@@ -1257,17 +1251,13 @@ wheels = [
 
 [[package]]
 name = "mitol-django-transcoding"
-version = "2025.5.21"
-source = { registry = "https://pypi.org/simple" }
+version = "2026.4.2"
+source = { git = "https://github.com/mitodl/ol-django.git?subdirectory=src%2Ftranscoding&rev=ed8ad1ebcca0fecab63a108c8a58c3297b5041ff#ed8ad1ebcca0fecab63a108c8a58c3297b5041ff" }
 dependencies = [
     { name = "boto3" },
     { name = "django" },
     { name = "django-stubs" },
     { name = "mitol-django-common" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/70/add89c781d35a0f0f1893c3dc93d34b61e7c7a2d5c89afd4b382a3a982e1/mitol_django_transcoding-2025.5.21.tar.gz", hash = "sha256:456b444f606d7bad032a1249fd4c8789a3c5c08f15e72353bb00b8878cbe487f", size = 6018, upload-time = "2025-05-21T07:55:51.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/de/e8dfd26f07c3c43f57d073aaae465087f1bf897f18dc4f6288e42354728d/mitol_django_transcoding-2025.5.21-py3-none-any.whl", hash = "sha256:0bf29ca82adf059c66def1841b55bd117d9ce5e35b0db6a7bd30647880c24baa", size = 9513, upload-time = "2025-05-21T07:55:50.776Z" },
 ]
 
 [[package]]
@@ -1402,7 +1392,7 @@ requires-dist = [
     { name = "django-encrypted-model-fields", specifier = ">=0.6.5,<0.7" },
     { name = "django-filter", specifier = ">=25.1,<26" },
     { name = "django-hijack", specifier = ">=3.7.1,<4" },
-    { name = "django-redis", specifier = ">=5.4.0,<5.5.0" },
+    { name = "django-redis", specifier = ">=6.0.0,<7" },
     { name = "django-webpack-loader", specifier = ">=3.0.0,<4" },
     { name = "djangorestframework", specifier = ">=3.11.2,<4" },
     { name = "google-api-python-client", specifier = ">=2.58.0,<3" },
@@ -1412,7 +1402,7 @@ requires-dist = [
     { name = "httplib2", specifier = ">=0.31.0,<0.32" },
     { name = "ipython", specifier = ">=9.0.0,<10" },
     { name = "mitol-django-observability", specifier = ">=2026.1.0" },
-    { name = "mitol-django-transcoding", specifier = ">=2025.5.21,<2026" },
+    { name = "mitol-django-transcoding", git = "https://github.com/mitodl/ol-django.git?subdirectory=src%2Ftranscoding&rev=ed8ad1ebcca0fecab63a108c8a58c3297b5041ff" },
     { name = "pillow", specifier = ">=10.0.0,<13" },
     { name = "psycopg2", specifier = ">=2.9.10,<3" },
     { name = "pycountry", specifier = ">=24.0.0,<25" },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11396
Depends on https://github.com/mitodl/ol-django/pull/469

### Description (What does it do?)
Uses an alternate MediaConvert job template for any videos in a `for_shorts` Collection so that the transcoded videos are in portrait mode.


### How can this be tested?
- Set `for_shorts=True` for a `Collection` via django admin
- Find a video in portrait mode, upload to your dropbox account, then upload it via your local OVS
- Wait for transcoding to complete
- Verify that the transcoded video has a portrait aspect ratio
- Upload a typical landscape video to a non-shorts collection
- Wait for transcoding to complete
- Verify that the transcoded video is in landscape aspect ration

### Additional Context
After https://github.com/mitodl/ol-django/pull/469 is merged and release to pypi, this PR will be updated to point to the  correct ol-django version.

It might be worth checking each video's native aspect ratio before selecting a template, instead of basing it only on the parent collection `for_shorts` attribute (maybe via PIL or ffmpeg), but I think that can be a future enhancement.

