### PR TITLE
Retain existing django permissions for users not in keycloak groups

### DIFF
--- a/odl_video/pipeline.py
+++ b/odl_video/pipeline.py
@@ -36,7 +36,7 @@ def assign_user_groups(strategy, details, backend, user=None, *args, **kwargs):
             extra_groups = extra_data["user_groups"]
             groups.extend(extra_groups)
 
-    logger.info(f"Groups found for user {user.username}: {groups}")
+    logger.debug(f"Groups found for user {user.username}: {groups}")
 
     # Store current state to check if changes are needed
     old_is_superuser = user.is_superuser
@@ -48,26 +48,26 @@ def assign_user_groups(strategy, details, backend, user=None, *args, **kwargs):
         # A user in the keycloak "Admin" group should be a Django superuser and staff
         user.is_superuser = True
         user.is_staff = True
-        logger.info(f"Assigned superuser and staff privileges to user {user.username}")
+        logger.debug(f"Assigned superuser and staff privileges to user {user.username}")
     elif "/staff" in groups_lower:
         # A user in the keycloak "Staff" group should be a Django staff but not superuser
         user.is_superuser = False
         user.is_staff = True
-        logger.info(f"Assigned staff privileges to user {user.username}")
+        logger.debug(f"Assigned staff privileges to user {user.username}")
     else:
         # Keep existing Django superuser/staff status, whatever it may be
-        logger.info(f"Maintaining current Django privileges for user {user.username}")
+        logger.debug(f"Maintaining current Django privileges for user {user.username}")
 
     # Only save if permissions changed
     if old_is_superuser != user.is_superuser or old_is_staff != user.is_staff:
         try:
             user.save()
-            logger.info(
+            logger.debug(
                 f"Successfully updated permissions for user {user.username} - superuser: {user.is_superuser}, staff: {user.is_staff}"
             )
         except Exception as e:
             logger.error(f"Failed to save user {user.username}: {str(e)}")
     else:
-        logger.info(f"No permission changes needed for user {user.username}")
+        logger.debug(f"No permission changes needed for user {user.username}")
 
     return {"user": user}

--- a/odl_video/pipeline.py
+++ b/odl_video/pipeline.py
@@ -12,13 +12,15 @@ User = get_user_model()
 
 def assign_user_groups(strategy, details, backend, user=None, *args, **kwargs):
     """
-    Custom pipeline function to assign Django permissions based on Keycloak groups.
-    This runs after user creation/lookup to ensure permissions are properly assigned.
+    Custom pipeline function to override Django permissions for users in admin/staff Keycloak groups.
+    This runs after user creation/lookup to ensure permissions are properly assigned for those users.
+    Any Django user that is not in either Keycloak group will have their existing permissions
+    maintained, whether they are a superuser, staff, or regular user.
 
     Keycloak group mapping:
     - "Admin" group → Django superuser (is_superuser=True, is_staff=True)
     - "Staff" group → Django staff (is_staff=True)
-    - Any other group or no group → regular user (no special flags)
+    - Any other group or no group → no change to existing Django permissions
     """
     if not user:
         logger.debug("assign_user_groups called but no user provided")
@@ -43,17 +45,18 @@ def assign_user_groups(strategy, details, backend, user=None, *args, **kwargs):
     groups_lower = [group.lower() for group in groups]
 
     if "/admin" in groups_lower:
+        # A user in the keycloak "Admin" group should be a Django superuser and staff
         user.is_superuser = True
         user.is_staff = True
         logger.info(f"Assigned superuser and staff privileges to user {user.username}")
     elif "/staff" in groups_lower:
+        # A user in the keycloak "Staff" group should be a Django staff but not superuser
         user.is_superuser = False
         user.is_staff = True
         logger.info(f"Assigned staff privileges to user {user.username}")
     else:
-        user.is_superuser = False
-        user.is_staff = False
-        logger.info(f"Set regular user privileges for user {user.username}")
+        # Keep existing Django superuser/staff status, whatever it may be
+        logger.info(f"Maintaining current Django privileges for user {user.username}")
 
     # Only save if permissions changed
     if old_is_superuser != user.is_superuser or old_is_staff != user.is_staff:

--- a/odl_video/pipeline_test.py
+++ b/odl_video/pipeline_test.py
@@ -1,0 +1,112 @@
+"""Tests for odl_video.pipeline"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from odl_video.pipeline import assign_user_groups
+
+
+@pytest.fixture
+def mock_user():
+    """A user-like mock with default non-privileged flags."""
+    user = MagicMock()
+    user.username = "testuser"
+    user.is_superuser = False
+    user.is_staff = False
+    return user
+
+
+@pytest.fixture
+def make_kwargs():
+    """Build the kwargs that assign_user_groups expects from social-auth."""
+
+    def _make(groups=None, with_social=True):
+        if not with_social:
+            return {}
+        social_user = MagicMock()
+        social_user.extra_data = {} if groups is None else {"user_groups": list(groups)}
+        return {"social": social_user}
+
+    return _make
+
+
+@pytest.mark.parametrize(
+    ("groups", "expected_superuser", "expected_staff"),
+    [
+        (["/Admin"], True, True),
+        (["/admin"], True, True),
+        (["/admin", "/staff"], True, True),
+        (["/Staff"], False, True),
+        (["/staff"], False, True),
+    ],
+)
+def test_admin_and_staff_groups_assign_privileges(
+    mock_user, make_kwargs, groups, expected_superuser, expected_staff
+):
+    """Admin/Staff keycloak groups map to the expected Django flags."""
+    result = assign_user_groups(None, None, None, user=mock_user, **make_kwargs(groups))
+    assert mock_user.is_superuser is expected_superuser
+    assert mock_user.is_staff is expected_staff
+    mock_user.save.assert_called_once()
+    assert result == {"user": mock_user}
+
+
+@pytest.mark.parametrize("starting_superuser", [True, False])
+@pytest.mark.parametrize("starting_staff", [True, False])
+@pytest.mark.parametrize(
+    ("groups", "with_social"),
+    [
+        pytest.param(["/other"], True, id="other-group"),
+        pytest.param([], True, id="empty-groups"),
+        pytest.param(None, True, id="no-user_groups-key"),
+        pytest.param(None, False, id="no-social-user"),
+    ],
+)
+def test_non_admin_staff_group_preserves_existing_privileges(
+    mock_user, make_kwargs, starting_superuser, starting_staff, groups, with_social
+):
+    """When the user is not in the Admin/Staff groups, existing flags are preserved."""
+    mock_user.is_superuser = starting_superuser
+    mock_user.is_staff = starting_staff
+
+    assign_user_groups(
+        None,
+        None,
+        None,
+        user=mock_user,
+        **make_kwargs(groups=groups, with_social=with_social),
+    )
+
+    assert mock_user.is_superuser is starting_superuser
+    assert mock_user.is_staff is starting_staff
+    mock_user.save.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("starting_superuser", "starting_staff", "groups"),
+    [
+        (True, True, ["/admin"]),
+        (False, True, ["/staff"]),
+    ],
+)
+def test_no_save_when_privileges_unchanged(
+    mock_user, make_kwargs, starting_superuser, starting_staff, groups
+):
+    """If the assigned flags already match the user, save() is skipped."""
+    mock_user.is_superuser = starting_superuser
+    mock_user.is_staff = starting_staff
+
+    assign_user_groups(None, None, None, user=mock_user, **make_kwargs(groups))
+
+    mock_user.save.assert_not_called()
+
+
+def test_save_exception_is_caught_and_logged(mock_user, make_kwargs, mocker):
+    """Errors raised by user.save() are logged, not propagated."""
+    mock_user.save.side_effect = Exception("db error")
+    mock_logger = mocker.patch("odl_video.pipeline.logger")
+
+    assign_user_groups(None, None, None, user=mock_user, **make_kwargs(["/admin"]))
+
+    mock_logger.error.assert_called_once()


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11474

### Description (What does it do?)
Updates the `assign_user_groups` social-auth pipeline step so that users who are not in the Keycloak `Admin` or `Staff` groups keep their existing Django `is_superuser` / `is_staff` flags instead of having them reset to `False` on each login.

### How can this be tested?
**On `master`:**
- Log in as `admin@ovs.local` — you will be staff/superuser.
- In an incognito tab, log in as `user@ovs.local` — you will be a regular user.
- In your admin tab, go to Django admin and set `user@ovs.local` as staff & superuser.
- In your incognito tab, go to Django admin — you should be able to access it.
- Close the incognito tab, open a new one, log in as `user@ovs.local` again. Try going to Django admin — your staff/superuser permissions will be gone.

**On this branch:**
- Repeat the above. On the last step, `user@ovs.local` should still have staff/superuser permissions.