### PR TITLE
Always render pytest output colorized

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov . --cov-report term --cov-report html --cov-report xml --ds=odl_video.settings --reuse-db
+addopts = --cov . --cov-report term --cov-report html --cov-report xml --ds=odl_video.settings --reuse-db --color=yes
 norecursedirs = node_modules .git static templates .* CVS _darcs {arch} *.egg
 env =
   USE_WEBPACK_DEV_SERVER=False


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This forces pytest to render color output so that we can see failures in diffs easier.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
See the github action test output, the pytest run should include color text now.