### PR TITLE
Handle null user_groups

### DIFF
--- a/odl_video/pipeline.py
+++ b/odl_video/pipeline.py
@@ -33,8 +33,9 @@ def assign_user_groups(strategy, details, backend, user=None, *args, **kwargs):
         extra_data = social_user.extra_data
 
         if "user_groups" in extra_data:
-            extra_groups = extra_data["user_groups"]
-            groups.extend(extra_groups)
+            extra_groups = extra_data.get("user_groups") or []
+            if extra_groups:
+                groups.extend(extra_groups)
 
     logger.debug(f"Groups found for user {user.username}: {groups}")
 

--- a/odl_video/pipeline.py
+++ b/odl_video/pipeline.py
@@ -32,10 +32,9 @@ def assign_user_groups(strategy, details, backend, user=None, *args, **kwargs):
     if social_user and hasattr(social_user, "extra_data"):
         extra_data = social_user.extra_data
 
-        if "user_groups" in extra_data:
-            extra_groups = extra_data.get("user_groups") or []
-            if extra_groups:
-                groups.extend(extra_groups)
+        extra_groups = extra_data.get("user_groups")
+        if extra_groups:
+            groups.extend(extra_groups)
 
     logger.debug(f"Groups found for user {user.username}: {groups}")
 

--- a/odl_video/pipeline_test.py
+++ b/odl_video/pipeline_test.py
@@ -21,11 +21,11 @@ def mock_user():
 def make_kwargs():
     """Build the kwargs that assign_user_groups expects from social-auth."""
 
-    def _make(groups=None, with_social=True):
+    def _make(extra_data=None, with_social=True):
         if not with_social:
             return {}
         social_user = MagicMock()
-        social_user.extra_data = {} if groups is None else {"user_groups": list(groups)}
+        social_user.extra_data = extra_data or {}
         return {"social": social_user}
 
     return _make
@@ -45,7 +45,9 @@ def test_admin_and_staff_groups_assign_privileges(
     mock_user, make_kwargs, groups, expected_superuser, expected_staff
 ):
     """Admin/Staff keycloak groups map to the expected Django flags."""
-    result = assign_user_groups(None, None, None, user=mock_user, **make_kwargs(groups))
+    result = assign_user_groups(
+        None, None, None, user=mock_user, **make_kwargs({"user_groups": groups})
+    )
     assert mock_user.is_superuser is expected_superuser
     assert mock_user.is_staff is expected_staff
     mock_user.save.assert_called_once()
@@ -55,16 +57,17 @@ def test_admin_and_staff_groups_assign_privileges(
 @pytest.mark.parametrize("starting_superuser", [True, False])
 @pytest.mark.parametrize("starting_staff", [True, False])
 @pytest.mark.parametrize(
-    ("groups", "with_social"),
+    ("extra_data", "with_social"),
     [
-        pytest.param(["/other"], True, id="other-group"),
-        pytest.param([], True, id="empty-groups"),
-        pytest.param(None, True, id="no-user_groups-key"),
+        pytest.param({"user_groups": ["/other"]}, True, id="other-group"),
+        pytest.param({"user_groups": []}, True, id="empty-groups"),
+        pytest.param({"user_groups": None}, True, id="user_groups-none"),
+        pytest.param({}, True, id="no-user_groups-key"),
         pytest.param(None, False, id="no-social-user"),
     ],
 )
 def test_non_admin_staff_group_preserves_existing_privileges(
-    mock_user, make_kwargs, starting_superuser, starting_staff, groups, with_social
+    mock_user, make_kwargs, starting_superuser, starting_staff, extra_data, with_social
 ):
     """When the user is not in the Admin/Staff groups, existing flags are preserved."""
     mock_user.is_superuser = starting_superuser
@@ -75,7 +78,7 @@ def test_non_admin_staff_group_preserves_existing_privileges(
         None,
         None,
         user=mock_user,
-        **make_kwargs(groups=groups, with_social=with_social),
+        **make_kwargs(extra_data, with_social=with_social),
     )
 
     assert mock_user.is_superuser is starting_superuser
@@ -97,7 +100,9 @@ def test_no_save_when_privileges_unchanged(
     mock_user.is_superuser = starting_superuser
     mock_user.is_staff = starting_staff
 
-    assign_user_groups(None, None, None, user=mock_user, **make_kwargs(groups))
+    assign_user_groups(
+        None, None, None, user=mock_user, **make_kwargs({"user_groups": groups})
+    )
 
     mock_user.save.assert_not_called()
 
@@ -107,6 +112,8 @@ def test_save_exception_is_caught_and_logged(mock_user, make_kwargs, mocker):
     mock_user.save.side_effect = Exception("db error")
     mock_logger = mocker.patch("odl_video.pipeline.logger")
 
-    assign_user_groups(None, None, None, user=mock_user, **make_kwargs(["/admin"]))
+    assign_user_groups(
+        None, None, None, user=mock_user, **make_kwargs({"user_groups": ["/admin"]})
+    )
 
     mock_logger.error.assert_called_once()


### PR DESCRIPTION
### What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/7439403681/events/?project=194353&query=is%3Aunresolved&referrer=issue-stream

### Description (What does it do?)
Fixes a bug I noticed on prod where keycloak is returning `"user_groups": null` for my user, causing a 500 error

### How can this be tested?
Tests should pass

