### PR TITLE
fix: add new action to retry upload failed videos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -107,7 +107,7 @@ def stream_to_s3(self, video_id):
 
     task_id = self.get_task_id()
     try:
-        response = requests.get(video.source_url, stream=True, timeout=60)
+        response = requests.get(video.source_url, stream=True, timeout=120)
         response.raise_for_status()
     except requests.HTTPError:
         video.update_status(VideoStatus.UPLOAD_FAILED)

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -4,6 +4,7 @@ Tasks for cloudsync app
 
 import os
 import re
+from datetime import timedelta
 from urllib.parse import unquote
 
 import boto3
@@ -21,7 +22,7 @@ import structlog
 from ui.constants import StreamSource, VideoStatus, YouTubeStatus
 from ui.encodings import EncodingNames
 from ui.models import Collection, EncodeJob, Video, VideoSubtitle, YouTubeVideo
-from ui.utils import get_bucket
+from ui.utils import get_bucket, now_in_utc
 
 log = structlog.get_logger(__name__)
 
@@ -88,6 +89,29 @@ def update_video_statuses(self):
                 response=exc.response,
             )
             video.update_status(error)
+
+
+@shared_task
+def fail_stuck_uploading_videos():
+    """
+    Fail videos stuck in UPLOADING past the threshold so they can be retried.
+    """
+    now = now_in_utc()
+    threshold = now - timedelta(hours=settings.STUCK_UPLOADING_THRESHOLD_HOURS)
+    stuck_videos = Video.objects.filter(
+        status=VideoStatus.UPLOADING, updated_at__lt=threshold
+    )
+    for video in stuck_videos.iterator():
+        log.info(
+            "Failing video stuck in UPLOADING",
+            video_id=video.id,
+            uploading_since=video.updated_at.isoformat(),
+        )
+        try:
+            video.update_status(VideoStatus.UPLOAD_FAILED)
+        except Exception:
+            # Don't let one bad video abort the sweep of the rest.
+            log.exception("Failed to update stuck video status", video_id=video.id)
 
 
 @shared_task(bind=True, base=VideoTask)

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -6,6 +6,7 @@ import io
 import os
 import random
 import string
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import PropertyMock, call
 
@@ -23,6 +24,7 @@ from cloudsync.conftest import MockBoto, MockHttpErrorResponse
 from cloudsync.exceptions import TranscodeTargetDoesNotExist
 from cloudsync.tasks import (
     VideoTask,
+    fail_stuck_uploading_videos,
     monitor_watch_bucket,
     remove_youtube_caption,
     remove_youtube_video,
@@ -46,8 +48,76 @@ from ui.factories import (
     YouTubeVideoFactory,
 )
 from ui.models import TRANSCODE_PREFIX, Collection, Video, YouTubeVideo
+from ui.utils import now_in_utc
 
 pytestmark = pytest.mark.django_db
+
+
+def _make_uploading_video(updated_hours_ago, created_hours_ago=None):
+    """Create an UPLOADING video with backdated timestamps via .update()."""
+    if created_hours_ago is None:
+        created_hours_ago = updated_hours_ago
+    video = VideoFactory(status=VideoStatus.UPLOADING)
+    Video.objects.filter(pk=video.pk).update(
+        updated_at=now_in_utc() - timedelta(hours=updated_hours_ago),
+        created_at=now_in_utc() - timedelta(hours=created_hours_ago),
+    )
+    video.refresh_from_db()
+    return video
+
+
+def test_fail_stuck_uploading_recent_video_notifies(mocker):
+    """Stuck + recently created → UPLOAD_FAILED with an email."""
+    mocked_email = mocker.patch(
+        "mail.tasks.async_send_notification_email", autospec=True
+    )
+    video = _make_uploading_video(updated_hours_ago=3.5, created_hours_ago=3.5)
+
+    fail_stuck_uploading_videos.delay()
+
+    video.refresh_from_db()
+    assert video.status == VideoStatus.UPLOAD_FAILED
+    mocked_email.delay.assert_called_once_with(video.id)
+
+
+def test_fail_stuck_uploading_within_threshold_untouched(mocker):
+    """Recently-updated UPLOADING video (under threshold) is left alone."""
+    mocker.patch("mail.tasks.async_send_notification_email", autospec=True)
+    video = _make_uploading_video(updated_hours_ago=0.1)
+
+    fail_stuck_uploading_videos.delay()
+
+    video.refresh_from_db()
+    assert video.status == VideoStatus.UPLOADING
+
+
+def test_fail_stuck_uploading_ignores_other_statuses(mocker):
+    """Non-UPLOADING videos are never touched, however old."""
+    mocker.patch("mail.tasks.async_send_notification_email", autospec=True)
+    video = VideoFactory(status=VideoStatus.TRANSCODING)
+    Video.objects.filter(pk=video.pk).update(
+        updated_at=now_in_utc() - timedelta(hours=5)
+    )
+
+    fail_stuck_uploading_videos.delay()
+
+    video.refresh_from_db()
+    assert video.status == VideoStatus.TRANSCODING
+
+
+def test_fail_stuck_uploading_continues_after_error(mocker):
+    """A failure on one video must not abort the sweep of the rest."""
+    mocker.patch("mail.tasks.async_send_notification_email", autospec=True)
+    _make_uploading_video(updated_hours_ago=3.5)
+    _make_uploading_video(updated_hours_ago=3.5)
+    mocked_update = mocker.patch(
+        "ui.models.Video.update_status", side_effect=[Exception("boom"), None]
+    )
+
+    fail_stuck_uploading_videos.delay()
+
+    # Both stuck videos were processed even though the first raised.
+    assert mocked_update.call_count == 2
 
 
 @pytest.fixture()

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -355,6 +355,9 @@ AWS_S3_UPLOAD_TRANSFER_CONFIG = dict(
     use_threads=AWS_S3_UPLOAD_USE_THREADS,
 )
 
+# Janitor: fail videos stuck in UPLOADING past the threshold so they can be retried.
+STUCK_UPLOADING_THRESHOLD_HOURS = get_int("STUCK_UPLOADING_THRESHOLD_HOURS", 2)
+
 VIDEO_CLOUDFRONT_DIST = get_string("VIDEO_CLOUDFRONT_DIST", "")
 VIDEO_CDN_DISTRIBUTION_ID = get_string("VIDEO_CDN_DISTRIBUTION_ID", "")
 VIDEO_S3_BUCKET = AWS_STORAGE_BUCKET_NAME = get_string("VIDEO_S3_BUCKET", "")
@@ -497,6 +500,10 @@ CELERY_BEAT_SCHEDULE = {
     "upload_youtube_videos": {
         "task": "cloudsync.tasks.upload_youtube_videos",
         "schedule": get_int("YT_UPLOAD_FREQUENCY", 3600),
+    },
+    "fail-stuck-uploading-videos": {
+        "task": "cloudsync.tasks.fail_stuck_uploading_videos",
+        "schedule": get_int("STUCK_UPLOADING_CHECK_FREQUENCY", 3600),
     },
 }
 

--- a/ui/admin.py
+++ b/ui/admin.py
@@ -2,18 +2,16 @@
 Admin for UI app
 """
 
+from collections import Counter
 from urllib.parse import urljoin
 
-from celery import chain
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.urls import reverse
 from django.utils.html import format_html
 
-from cloudsync import tasks
-from ui import models
-from ui.constants import VideoStatus
+from ui import api, models
 from ui.models import EncodeJob
 
 
@@ -201,57 +199,40 @@ class VideoAdmin(admin.ModelAdmin):
     )
     actions = ["retry_upload"]
 
-    RETRY_ELIGIBLE_STATUSES = (VideoStatus.UPLOAD_FAILED, VideoStatus.UPLOADING)
-
-    @admin.action(
-        description="Retry upload for selected 'Upload failed' or 'Uploading' videos"
-    )
+    @admin.action(description="Retry upload for selected 'Upload failed' videos")
     def retry_upload(self, request, queryset):
-        """
-        Re-runs the stream_to_s3 + transcode_from_s3 chain for selected videos
-        whose status is 'Upload failed' or 'Uploading' and which have a
-        non-empty source_url. Videos that don't meet both conditions are skipped.
+        """Retry each selected 'Upload failed' video via api.retry_failed_upload and report outcomes."""
+        tally = Counter(api.retry_failed_upload(video) for video in queryset)
 
-        Note: re-running for 'Uploading' is intended for videos stuck due to a
-        crashed worker. If a stream_to_s3 task is still actually in flight, this
-        will kick off a duplicate task on the same S3 key.
-        """
-        retried = 0
-        skipped_status = 0
-        skipped_no_source = 0
-        for video in queryset:
-            if video.status not in self.RETRY_ELIGIBLE_STATUSES:
-                skipped_status += 1
-                continue
-            if not video.source_url:
-                skipped_no_source += 1
-                continue
-            video.update_status(VideoStatus.CREATED)
-            chain(
-                tasks.stream_to_s3.s(video.id),
-                tasks.transcode_from_s3.si(video.id),
-            ).delay()
-            retried += 1
+        def report(count, message, level):
+            if count:
+                self.message_user(request, message.format(n=count), level=level)
 
-        if retried:
-            self.message_user(
-                request,
-                f"Re-queued upload for {retried} video(s).",
-                level=messages.SUCCESS,
-            )
-        if skipped_status:
-            self.message_user(
-                request,
-                f"Skipped {skipped_status} video(s) not in "
-                "'Upload failed' or 'Uploading' status.",
-                level=messages.WARNING,
-            )
-        if skipped_no_source:
-            self.message_user(
-                request,
-                f"Skipped {skipped_no_source} video(s) without a source_url.",
-                level=messages.WARNING,
-            )
+        report(
+            tally["retried"],
+            "Re-queued upload for {n} video(s).",
+            messages.SUCCESS,
+        )
+        report(
+            tally["dispatch_failed"],
+            "Failed to re-queue {n} video(s); status left as 'Upload failed'.",
+            messages.ERROR,
+        )
+        report(
+            tally["skipped_status"] + tally["skipped_conflict"],
+            "Skipped {n} video(s) not in 'Upload failed' status.",
+            messages.WARNING,
+        )
+        report(
+            tally["skipped_no_source"],
+            "Skipped {n} video(s) without a source_url.",
+            messages.WARNING,
+        )
+        report(
+            tally["skipped_no_original"],
+            "Skipped {n} video(s) missing an original video file.",
+            messages.WARNING,
+        )
 
 
 class VideoFileAdmin(admin.ModelAdmin):

--- a/ui/admin.py
+++ b/ui/admin.py
@@ -4,13 +4,16 @@ Admin for UI app
 
 from urllib.parse import urljoin
 
+from celery import chain
 from django.conf import settings
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.urls import reverse
 from django.utils.html import format_html
 
+from cloudsync import tasks
 from ui import models
+from ui.constants import VideoStatus
 from ui.models import EncodeJob
 
 
@@ -196,6 +199,50 @@ class VideoAdmin(admin.ModelAdmin):
         "collection__title",
         "view_lists__name",
     )
+    actions = ["retry_upload"]
+
+    @admin.action(description="Retry upload for selected 'Upload failed' videos")
+    def retry_upload(self, request, queryset):
+        """
+        Re-runs the stream_to_s3 + transcode_from_s3 chain for selected videos
+        whose status is 'Upload failed' and which have a non-empty source_url.
+        Videos that don't meet both conditions are skipped.
+        """
+        retried = 0
+        skipped_status = 0
+        skipped_no_source = 0
+        for video in queryset:
+            if video.status != VideoStatus.UPLOAD_FAILED:
+                skipped_status += 1
+                continue
+            if not video.source_url:
+                skipped_no_source += 1
+                continue
+            video.update_status(VideoStatus.CREATED)
+            chain(
+                tasks.stream_to_s3.s(video.id),
+                tasks.transcode_from_s3.si(video.id),
+            ).delay()
+            retried += 1
+
+        if retried:
+            self.message_user(
+                request,
+                f"Re-queued upload for {retried} video(s).",
+                level=messages.SUCCESS,
+            )
+        if skipped_status:
+            self.message_user(
+                request,
+                f"Skipped {skipped_status} video(s) not in 'Upload failed' status.",
+                level=messages.WARNING,
+            )
+        if skipped_no_source:
+            self.message_user(
+                request,
+                f"Skipped {skipped_no_source} video(s) without a source_url.",
+                level=messages.WARNING,
+            )
 
 
 class VideoFileAdmin(admin.ModelAdmin):

--- a/ui/admin.py
+++ b/ui/admin.py
@@ -201,18 +201,26 @@ class VideoAdmin(admin.ModelAdmin):
     )
     actions = ["retry_upload"]
 
-    @admin.action(description="Retry upload for selected 'Upload failed' videos")
+    RETRY_ELIGIBLE_STATUSES = (VideoStatus.UPLOAD_FAILED, VideoStatus.UPLOADING)
+
+    @admin.action(
+        description="Retry upload for selected 'Upload failed' or 'Uploading' videos"
+    )
     def retry_upload(self, request, queryset):
         """
         Re-runs the stream_to_s3 + transcode_from_s3 chain for selected videos
-        whose status is 'Upload failed' and which have a non-empty source_url.
-        Videos that don't meet both conditions are skipped.
+        whose status is 'Upload failed' or 'Uploading' and which have a
+        non-empty source_url. Videos that don't meet both conditions are skipped.
+
+        Note: re-running for 'Uploading' is intended for videos stuck due to a
+        crashed worker. If a stream_to_s3 task is still actually in flight, this
+        will kick off a duplicate task on the same S3 key.
         """
         retried = 0
         skipped_status = 0
         skipped_no_source = 0
         for video in queryset:
-            if video.status != VideoStatus.UPLOAD_FAILED:
+            if video.status not in self.RETRY_ELIGIBLE_STATUSES:
                 skipped_status += 1
                 continue
             if not video.source_url:
@@ -234,7 +242,8 @@ class VideoAdmin(admin.ModelAdmin):
         if skipped_status:
             self.message_user(
                 request,
-                f"Skipped {skipped_status} video(s) not in 'Upload failed' status.",
+                f"Skipped {skipped_status} video(s) not in "
+                "'Upload failed' or 'Uploading' status.",
                 level=messages.WARNING,
             )
         if skipped_no_source:

--- a/ui/admin_test.py
+++ b/ui/admin_test.py
@@ -115,14 +115,16 @@ def admin_request():
     return request
 
 
-def test_retry_upload_eligible_video(video_admin, admin_request):
+@pytest.mark.parametrize(
+    "initial_status", [VideoStatus.UPLOAD_FAILED, VideoStatus.UPLOADING]
+)
+def test_retry_upload_eligible_video(video_admin, admin_request, initial_status):
     """
-    retry_upload should reset an UPLOAD_FAILED video with a non-empty source_url
-    back to CREATED and kick off the stream_to_s3 + transcode_from_s3 chain.
+    retry_upload should reset videos in either UPLOAD_FAILED or UPLOADING status
+    (when they have a non-empty source_url) back to CREATED and kick off the
+    stream_to_s3 + transcode_from_s3 chain.
     """
-    video = VideoFactory(
-        status=VideoStatus.UPLOAD_FAILED, source_url="http://example.com/foo.mp4"
-    )
+    video = VideoFactory(status=initial_status, source_url="http://example.com/foo.mp4")
 
     with (
         patch("ui.admin.chain") as mocked_chain,
@@ -141,10 +143,10 @@ def test_retry_upload_eligible_video(video_admin, admin_request):
     mocked_chain.return_value.delay.assert_called_once()
 
 
-def test_retry_upload_skips_non_failed_status(video_admin, admin_request):
+def test_retry_upload_skips_ineligible_status(video_admin, admin_request):
     """
-    Videos not in UPLOAD_FAILED status must be skipped: no chain dispatched
-    and status left untouched.
+    Videos whose status is not in (UPLOAD_FAILED, UPLOADING) must be skipped:
+    no chain dispatched and status left untouched.
     """
     video = VideoFactory(
         status=VideoStatus.COMPLETE, source_url="http://example.com/foo.mp4"

--- a/ui/admin_test.py
+++ b/ui/admin_test.py
@@ -3,13 +3,15 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.contrib import messages
 from django.contrib.admin.sites import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
 
 from ui.admin import CollectionAdmin, VideoAdmin
 from ui.constants import VideoStatus
-from ui.factories import CollectionFactory, VideoFactory
+from ui.encodings import EncodingNames
+from ui.factories import CollectionFactory, VideoFactory, VideoFileFactory
 from ui.models import Collection, Video
 
 pytestmark = pytest.mark.django_db
@@ -115,94 +117,110 @@ def admin_request():
     return request
 
 
-@pytest.mark.parametrize(
-    "initial_status", [VideoStatus.UPLOAD_FAILED, VideoStatus.UPLOADING]
-)
-def test_retry_upload_eligible_video(video_admin, admin_request, initial_status):
+def test_retry_upload_eligible_video(video_admin, admin_request, mocker):
     """
-    retry_upload should reset videos in either UPLOAD_FAILED or UPLOADING status
-    (when they have a non-empty source_url) back to CREATED and kick off the
-    stream_to_s3 + transcode_from_s3 chain.
+    retry_upload should reset an eligible UPLOAD_FAILED video back to CREATED and
+    dispatch the stream_to_s3 + transcode_from_s3 chain via the helper.
     """
-    video = VideoFactory(status=initial_status, source_url="http://example.com/foo.mp4")
+    mocked_chain = mocker.patch("ui.api.chain")
+    video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    VideoFileFactory(video=video, encoding=EncodingNames.ORIGINAL)
 
-    with (
-        patch("ui.admin.chain") as mocked_chain,
-        patch("cloudsync.tasks.stream_to_s3") as mocked_stream,
-        patch("cloudsync.tasks.transcode_from_s3") as mocked_transcode,
-    ):
-        video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
+    video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
 
     video.refresh_from_db()
     assert video.status == VideoStatus.CREATED
-    mocked_stream.s.assert_called_once_with(video.id)
-    mocked_transcode.si.assert_called_once_with(video.id)
-    mocked_chain.assert_called_once_with(
-        mocked_stream.s(video.id), mocked_transcode.si(video.id)
-    )
     mocked_chain.return_value.delay.assert_called_once()
 
 
-def test_retry_upload_skips_ineligible_status(video_admin, admin_request):
-    """
-    Videos whose status is not in (UPLOAD_FAILED, UPLOADING) must be skipped:
-    no chain dispatched and status left untouched.
-    """
-    video = VideoFactory(
-        status=VideoStatus.COMPLETE, source_url="http://example.com/foo.mp4"
-    )
+def test_retry_upload_skips_non_failed_status(video_admin, admin_request, mocker):
+    """Videos not in UPLOAD_FAILED status are skipped, status left untouched."""
+    mocked_chain = mocker.patch("ui.api.chain")
+    video = VideoFactory(status=VideoStatus.COMPLETE)
 
-    with patch("ui.admin.chain") as mocked_chain:
-        video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
+    video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
 
     video.refresh_from_db()
     assert video.status == VideoStatus.COMPLETE
     mocked_chain.assert_not_called()
 
 
-def test_retry_upload_skips_video_without_source_url(video_admin, admin_request):
+def test_retry_upload_skips_video_without_source_url(
+    video_admin, admin_request, mocker
+):
     """
-    Even an UPLOAD_FAILED video without a source_url cannot be retried and
-    must be skipped. The factory enforces a non-empty source_url via
-    ValidateOnSaveMixin.full_clean(), so we clear it via .update() which
-    bypasses save() validation.
+    An UPLOAD_FAILED video without a source_url cannot be retried. The factory
+    enforces a non-empty source_url via full_clean(), so we clear it via .update()
+    which bypasses save() validation.
     """
+    mocked_chain = mocker.patch("ui.api.chain")
     video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    VideoFileFactory(video=video, encoding=EncodingNames.ORIGINAL)
     Video.objects.filter(pk=video.pk).update(source_url="")
 
-    with patch("ui.admin.chain") as mocked_chain:
-        video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
+    video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
 
     video.refresh_from_db()
     assert video.status == VideoStatus.UPLOAD_FAILED
     mocked_chain.assert_not_called()
 
 
-def test_retry_upload_mixed_queryset_reports_each_category(video_admin, admin_request):
+def test_retry_upload_skips_missing_original_videofile(
+    video_admin, admin_request, mocker
+):
     """
-    With a mixed queryset, only eligible videos should be re-queued. The
-    skipped categories should each trigger a message_user call so the admin
-    sees what was skipped and why.
+    An UPLOAD_FAILED video without an original VideoFile would fail in transcode,
+    so it is skipped (status untouched) and reported with a warning.
     """
-    eligible = VideoFactory(
-        status=VideoStatus.UPLOAD_FAILED, source_url="http://example.com/a.mp4"
-    )
-    wrong_status = VideoFactory(
-        status=VideoStatus.COMPLETE, source_url="http://example.com/b.mp4"
-    )
+    mocked_chain = mocker.patch("ui.api.chain")
+    video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    video_admin.message_user = MagicMock()
+
+    video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
+
+    video.refresh_from_db()
+    assert video.status == VideoStatus.UPLOAD_FAILED
+    mocked_chain.assert_not_called()
+    video_admin.message_user.assert_called_once()
+    assert video_admin.message_user.call_args.kwargs["level"] == messages.WARNING
+
+
+def test_retry_upload_reports_dispatch_failure(video_admin, admin_request, mocker):
+    """If dispatch raises, status is reverted to UPLOAD_FAILED and reported as error."""
+    mocked_chain = mocker.patch("ui.api.chain")
+    mocked_chain.return_value.delay.side_effect = Exception("broker down")
+    video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    VideoFileFactory(video=video, encoding=EncodingNames.ORIGINAL)
+    video_admin.message_user = MagicMock()
+
+    video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
+
+    video.refresh_from_db()
+    assert video.status == VideoStatus.UPLOAD_FAILED
+    video_admin.message_user.assert_called_once()
+    assert video_admin.message_user.call_args.kwargs["level"] == messages.ERROR
+
+
+def test_retry_upload_mixed_queryset_reports_each_category(
+    video_admin, admin_request, mocker
+):
+    """
+    With a mixed queryset, only the eligible video is re-queued, and each skipped
+    category triggers its own message_user call.
+    """
+    mocked_chain = mocker.patch("ui.api.chain")
+    eligible = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    VideoFileFactory(video=eligible, encoding=EncodingNames.ORIGINAL)
+    wrong_status = VideoFactory(status=VideoStatus.COMPLETE)
     no_source = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    VideoFileFactory(video=no_source, encoding=EncodingNames.ORIGINAL)
     Video.objects.filter(pk=no_source.pk).update(source_url="")
     video_admin.message_user = MagicMock()
 
-    with (
-        patch("ui.admin.chain") as mocked_chain,
-        patch("cloudsync.tasks.stream_to_s3"),
-        patch("cloudsync.tasks.transcode_from_s3"),
-    ):
-        video_admin.retry_upload(
-            admin_request,
-            Video.objects.filter(pk__in=[eligible.pk, wrong_status.pk, no_source.pk]),
-        )
+    video_admin.retry_upload(
+        admin_request,
+        Video.objects.filter(pk__in=[eligible.pk, wrong_status.pk, no_source.pk]),
+    )
 
     eligible.refresh_from_db()
     wrong_status.refresh_from_db()
@@ -212,6 +230,6 @@ def test_retry_upload_mixed_queryset_reports_each_category(video_admin, admin_re
     assert wrong_status.status == VideoStatus.COMPLETE
     assert no_source.status == VideoStatus.UPLOAD_FAILED
 
-    assert mocked_chain.call_count == 1
-    # one message for retried + one for skipped_status + one for skipped_no_source
+    assert mocked_chain.return_value.delay.call_count == 1
+    # one message each for retried + skipped_status + skipped_no_source
     assert video_admin.message_user.call_count == 3

--- a/ui/admin_test.py
+++ b/ui/admin_test.py
@@ -4,11 +4,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
 
-from ui.admin import CollectionAdmin
+from ui.admin import CollectionAdmin, VideoAdmin
+from ui.constants import VideoStatus
 from ui.factories import CollectionFactory, VideoFactory
-from ui.models import Collection
+from ui.models import Collection, Video
 
 pytestmark = pytest.mark.django_db
 
@@ -93,3 +95,121 @@ def test_collection_admin_save_model_no_change_to_is_public_skips_update(
 
     video.refresh_from_db()
     assert video.is_public is False
+
+
+@pytest.fixture()
+def video_admin():
+    """Return a VideoAdmin instance bound to the default admin site."""
+    return VideoAdmin(model=Video, admin_site=AdminSite())
+
+
+@pytest.fixture()
+def admin_request():
+    """
+    A request with messages storage attached, since `message_user` writes to
+    `request._messages` (normally populated by MessageMiddleware).
+    """
+    request = RequestFactory().get("/admin/")
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+def test_retry_upload_eligible_video(video_admin, admin_request):
+    """
+    retry_upload should reset an UPLOAD_FAILED video with a non-empty source_url
+    back to CREATED and kick off the stream_to_s3 + transcode_from_s3 chain.
+    """
+    video = VideoFactory(
+        status=VideoStatus.UPLOAD_FAILED, source_url="http://example.com/foo.mp4"
+    )
+
+    with (
+        patch("ui.admin.chain") as mocked_chain,
+        patch("cloudsync.tasks.stream_to_s3") as mocked_stream,
+        patch("cloudsync.tasks.transcode_from_s3") as mocked_transcode,
+    ):
+        video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
+
+    video.refresh_from_db()
+    assert video.status == VideoStatus.CREATED
+    mocked_stream.s.assert_called_once_with(video.id)
+    mocked_transcode.si.assert_called_once_with(video.id)
+    mocked_chain.assert_called_once_with(
+        mocked_stream.s(video.id), mocked_transcode.si(video.id)
+    )
+    mocked_chain.return_value.delay.assert_called_once()
+
+
+def test_retry_upload_skips_non_failed_status(video_admin, admin_request):
+    """
+    Videos not in UPLOAD_FAILED status must be skipped: no chain dispatched
+    and status left untouched.
+    """
+    video = VideoFactory(
+        status=VideoStatus.COMPLETE, source_url="http://example.com/foo.mp4"
+    )
+
+    with patch("ui.admin.chain") as mocked_chain:
+        video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
+
+    video.refresh_from_db()
+    assert video.status == VideoStatus.COMPLETE
+    mocked_chain.assert_not_called()
+
+
+def test_retry_upload_skips_video_without_source_url(video_admin, admin_request):
+    """
+    Even an UPLOAD_FAILED video without a source_url cannot be retried and
+    must be skipped. The factory enforces a non-empty source_url via
+    ValidateOnSaveMixin.full_clean(), so we clear it via .update() which
+    bypasses save() validation.
+    """
+    video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    Video.objects.filter(pk=video.pk).update(source_url="")
+
+    with patch("ui.admin.chain") as mocked_chain:
+        video_admin.retry_upload(admin_request, Video.objects.filter(pk=video.pk))
+
+    video.refresh_from_db()
+    assert video.status == VideoStatus.UPLOAD_FAILED
+    mocked_chain.assert_not_called()
+
+
+def test_retry_upload_mixed_queryset_reports_each_category(video_admin, admin_request):
+    """
+    With a mixed queryset, only eligible videos should be re-queued. The
+    skipped categories should each trigger a message_user call so the admin
+    sees what was skipped and why.
+    """
+    eligible = VideoFactory(
+        status=VideoStatus.UPLOAD_FAILED, source_url="http://example.com/a.mp4"
+    )
+    wrong_status = VideoFactory(
+        status=VideoStatus.COMPLETE, source_url="http://example.com/b.mp4"
+    )
+    no_source = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    Video.objects.filter(pk=no_source.pk).update(source_url="")
+    video_admin.message_user = MagicMock()
+
+    with (
+        patch("ui.admin.chain") as mocked_chain,
+        patch("cloudsync.tasks.stream_to_s3"),
+        patch("cloudsync.tasks.transcode_from_s3"),
+    ):
+        video_admin.retry_upload(
+            admin_request,
+            Video.objects.filter(pk__in=[eligible.pk, wrong_status.pk, no_source.pk]),
+        )
+
+    eligible.refresh_from_db()
+    wrong_status.refresh_from_db()
+    no_source.refresh_from_db()
+
+    assert eligible.status == VideoStatus.CREATED
+    assert wrong_status.status == VideoStatus.COMPLETE
+    assert no_source.status == VideoStatus.UPLOAD_FAILED
+
+    assert mocked_chain.call_count == 1
+    # one message for retried + one for skipped_status + one for skipped_no_source
+    assert video_admin.message_user.call_count == 3

--- a/ui/api.py
+++ b/ui/api.py
@@ -13,9 +13,17 @@ from cloudsync import tasks
 import structlog
 from ui import models
 from ui.constants import VideoStatus
+from ui.encodings import EncodingNames
 from ui.utils import get_error_response_summary_dict
 
 log = structlog.get_logger(__name__)
+
+
+def dispatch_upload_chain(video_id):
+    """Kick off the chained stream_to_s3 → transcode_from_s3 tasks for a video."""
+    return chain(
+        tasks.stream_to_s3.s(video_id), tasks.transcode_from_s3.si(video_id)
+    ).delay()
 
 
 def process_dropbox_data(dropbox_upload_data):
@@ -47,15 +55,46 @@ def process_dropbox_data(dropbox_upload_data):
                 bucket_name=settings.VIDEO_S3_BUCKET,
             )
         # Kick off chained async celery tasks to transfer file to S3, then start a transcode job
-        chain(
-            tasks.stream_to_s3.s(video.id), tasks.transcode_from_s3.si(video.id)
-        ).delay()
+        dispatch_upload_chain(video.id)
 
         response_data[video.hexkey] = {
             "s3key": video.get_s3_key(),
             "title": video.title,
         }
     return response_data
+
+
+def retry_failed_upload(video):
+    """
+    Re-dispatch the upload chain for one UPLOAD_FAILED video; returns an outcome string.
+
+    Guards run before the status flip and dispatch failures revert it, so the video
+    is never left marooned.
+    """
+    if video.status != VideoStatus.UPLOAD_FAILED:
+        return "skipped_status"
+    if not video.source_url:
+        return "skipped_no_source"
+    if not video.videofile_set.filter(encoding=EncodingNames.ORIGINAL).exists():
+        return "skipped_no_original"
+
+    # Atomic compare-and-swap so two concurrent retries can't both dispatch a chain
+    # for the same video; only the caller that flips the row proceeds.
+    changed = models.Video.objects.filter(
+        pk=video.pk, status=VideoStatus.UPLOAD_FAILED
+    ).update(status=VideoStatus.CREATED)
+    if changed != 1:
+        return "skipped_conflict"
+
+    try:
+        dispatch_upload_chain(video.id)
+    except Exception:
+        models.Video.objects.filter(pk=video.pk).update(
+            status=VideoStatus.UPLOAD_FAILED
+        )
+        log.exception("Failed to dispatch retry upload chain", video_id=video.id)
+        return "dispatch_failed"
+    return "retried"
 
 
 def replace_video_from_dropbox(video_key, dropbox_file):

--- a/ui/api_test.py
+++ b/ui/api_test.py
@@ -14,6 +14,7 @@ from django.http import Http404
 
 from odl_video.test_utils import any_instance_of
 from ui import api, models
+from ui.constants import VideoStatus
 from ui.encodings import EncodingNames
 from ui.factories import (
     CollectionEdxEndpointFactory,
@@ -516,3 +517,87 @@ def test_get_duration_from_encode_job():
     encode_job = {}
     duration = api.get_duration_from_encode_job(encode_job)
     assert duration == 0.0
+
+
+def test_retry_failed_upload_dispatches(mocker):
+    """An eligible UPLOAD_FAILED video is reset to CREATED and re-queued."""
+    mocked_chain = mocker.patch("ui.api.chain")
+    video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    VideoFileFactory(video=video, encoding=EncodingNames.ORIGINAL)
+
+    outcome = api.retry_failed_upload(video)
+
+    assert outcome == "retried"
+    video.refresh_from_db()
+    assert video.status == VideoStatus.CREATED
+    mocked_chain.return_value.delay.assert_called_once()
+
+
+def test_retry_failed_upload_skips_missing_original(mocker):
+    """Without an original VideoFile the chain would fail in transcode; skip it."""
+    mocked_chain = mocker.patch("ui.api.chain")
+    video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+
+    outcome = api.retry_failed_upload(video)
+
+    assert outcome == "skipped_no_original"
+    video.refresh_from_db()
+    assert video.status == VideoStatus.UPLOAD_FAILED
+    mocked_chain.assert_not_called()
+
+
+def test_retry_failed_upload_reverts_on_dispatch_failure(mocker):
+    """If dispatch raises, the video is restored to UPLOAD_FAILED, not marooned."""
+    mocked_chain = mocker.patch("ui.api.chain")
+    mocked_chain.return_value.delay.side_effect = Exception("broker down")
+    video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    VideoFileFactory(video=video, encoding=EncodingNames.ORIGINAL)
+
+    outcome = api.retry_failed_upload(video)
+
+    assert outcome == "dispatch_failed"
+    video.refresh_from_db()
+    assert video.status == VideoStatus.UPLOAD_FAILED
+
+
+def test_retry_failed_upload_skips_conflict(mocker):
+    """
+    If the persisted row is no longer UPLOAD_FAILED when the atomic transition
+    runs (a concurrent retry grabbed it first), skip without dispatching.
+    """
+    mocked_chain = mocker.patch("ui.api.chain")
+    video = VideoFactory(status=VideoStatus.CREATED)
+    VideoFileFactory(video=video, encoding=EncodingNames.ORIGINAL)
+    # In-memory object looks eligible, but the persisted row is not UPLOAD_FAILED.
+    video.status = VideoStatus.UPLOAD_FAILED
+
+    outcome = api.retry_failed_upload(video)
+
+    assert outcome == "skipped_conflict"
+    mocked_chain.assert_not_called()
+    video.refresh_from_db()
+    assert video.status == VideoStatus.CREATED
+
+
+def test_retry_failed_upload_skips_non_failed(mocker):
+    """A video not in UPLOAD_FAILED status is skipped."""
+    mocked_chain = mocker.patch("ui.api.chain")
+    video = VideoFactory(status=VideoStatus.COMPLETE)
+
+    outcome = api.retry_failed_upload(video)
+
+    assert outcome == "skipped_status"
+    mocked_chain.assert_not_called()
+
+
+def test_retry_failed_upload_skips_no_source(mocker):
+    """A video without a source_url cannot be retried."""
+    mocked_chain = mocker.patch("ui.api.chain")
+    video = VideoFactory(status=VideoStatus.UPLOAD_FAILED)
+    models.Video.objects.filter(pk=video.pk).update(source_url="")
+    video.refresh_from_db()
+
+    outcome = api.retry_failed_upload(video)
+
+    assert outcome == "skipped_no_source"
+    mocked_chain.assert_not_called()

--- a/ui/migrations/0043_fail_stuck_uploading_videos.py
+++ b/ui/migrations/0043_fail_stuck_uploading_videos.py
@@ -1,0 +1,30 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.db import migrations
+from django.utils import timezone
+
+from ui.constants import VideoStatus
+
+
+def fail_stuck_uploading_videos(apps, schema_editor):
+    """Fail videos stuck in UPLOADING past the configured threshold."""
+    Video = apps.get_model("ui", "Video")
+    threshold = timezone.now() - timedelta(
+        hours=settings.STUCK_UPLOADING_THRESHOLD_HOURS
+    )
+    Video.objects.filter(
+        status=VideoStatus.UPLOADING, updated_at__lt=threshold
+    ).update(status=VideoStatus.UPLOAD_FAILED)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ui", "0042_alter_videothumbnail_options"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            fail_stuck_uploading_videos, migrations.RunPython.noop
+        ),
+    ]

--- a/ui/models.py
+++ b/ui/models.py
@@ -530,7 +530,6 @@ class Video(TimestampedModel):
 
         Args:
             status(str): The status to assign the video
-            notify(bool): Send a notification if true
         """
         self.status = status
         if status == VideoStatus.RETRANSCODE_SCHEDULED:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11644
https://github.com/mitodl/hq/issues/11643

**NOTE:** Its a shortcut to allow admins to retry transcoding videos without deleting and uploading them again.
We are working on figuring out the actual issue ...

### Description (What does it do?)
This pull request introduces a new bulk admin action to the Django admin interface for videos, allowing admins to retry uploads for videos that previously failed to upload. It also adds comprehensive tests for this feature to ensure correct behavior in different scenarios.

**Admin interface enhancements:**

* Added a `retry_upload` action to `VideoAdmin` that lets admins re-queue videos with status `UPLOAD_FAILED` and a valid `source_url` for upload and transcoding. The action updates the video status and dispatches the appropriate Celery task chain; videos that don't meet the criteria are skipped, and informative messages are shown for each category. [[1]](diffhunk://#diff-c6f04cfde76e4bb0e5e12b73b1e0aa0fc4a95570d160c39c4304d19771ad2b10R202-R245) [[2]](diffhunk://#diff-c6f04cfde76e4bb0e5e12b73b1e0aa0fc4a95570d160c39c4304d19771ad2b10R7-R16)

**Testing improvements:**

* Added tests for the `retry_upload` admin action, covering eligible videos, videos with non-failed status, videos missing a source URL, and mixed querysets. These tests use fixtures and mocks to verify correct behavior and messaging. [[1]](diffhunk://#diff-b0beb303b17cc6bdf82c2e199756476a61abcdaad3e3917d9dca7dd63b915603R98-R215) [[2]](diffhunk://#diff-b0beb303b17cc6bdf82c2e199756476a61abcdaad3e3917d9dca7dd63b915603R7-R13)

**Documentation:**

* Added a new `CLAUDE.md` file referencing `AGENTS.md`.

### Screenshots (if appropriate):
<img width="668" height="413" alt="image" src="https://github.com/user-attachments/assets/4464589e-9291-411e-af63-9d12ec75946d" />


### How can this be tested?
1. Add bad AWS credentials
2. Upload a video to transcode -- It will fail
3. Update the video status to "Upload Failed"
4. Select that video from admin (checkbox)
5. You should see a new menu in the dropdown to retry upload failed videos
6. That should re-trigger the process of stream to s3 and transcode video
