### PR TITLE
Fix Dockerfile node version to match package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0@sha256:f22d6a1f082c02f292e86929b5b0442ac2e5eaf438a5dea9b1566601c3e05940 AS node
+FROM node:24.16.0@sha256:9c1d881a5b3354362cd134d15b6eee789313833caa720c3cb6ea8862925d6eb8 AS node
 ENV NODE_ENV=production
 RUN apt-get update && apt-get install libelf1 -y
 COPY . /src

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,4 +1,4 @@
-FROM node:24.15.0@sha256:f22d6a1f082c02f292e86929b5b0442ac2e5eaf438a5dea9b1566601c3e05940
+FROM node:24.16.0@sha256:9c1d881a5b3354362cd134d15b6eee789313833caa720c3cb6ea8862925d6eb8
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 RUN apt-get update && apt-get install libelf1 -y


### PR DESCRIPTION
## Summary

- Renovate PR #1511 bumped `package.json` engines to `24.16.0` and CI to `24.16.0`, but only bumped the Dockerfiles to `24.15.0`, leaving them inconsistent
- This causes `yarn install` to fail with "The engine "node" is incompatible with this module. Expected version "24.16.0". Got "24.15.0"" in the `watch` container
- Align `Dockerfile` and `Dockerfile-node` to `node:24.16.0`

## Test plan

`docker-compose up watch` no longer fails with engine incompatibility error