### PR TITLE
Add retries to stream_to_s3 upload task

### DIFF
--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -23,6 +23,7 @@ from celery.utils.time import get_exponential_backoff_interval
 from django.conf import settings
 from django.db import connection
 from googleapiclient.errors import HttpError
+from redis.exceptions import LockError
 from urllib3.exceptions import ProtocolError as Urllib3ProtocolError
 from urllib3.exceptions import TimeoutError as Urllib3TimeoutError
 
@@ -181,6 +182,20 @@ def fail_stuck_uploading_videos():
             log.exception("Failed to update stuck video status", video_id=video.id)
 
 
+def _video_upload_lock(app, video_id):
+    """
+    Non-blocking redis lock serializing concurrent uploads of one video.
+
+    thread_local=False: acquired on the task thread but reacquired/released from
+    s3transfer callback threads.
+    """
+    return app.backend.client.lock(
+        f"stream_to_s3:lock:{video_id}",
+        timeout=settings.CLOUDSYNC_STREAM_S3_LOCK_TTL,
+        thread_local=False,
+    )
+
+
 @shared_task(
     bind=True,
     base=VideoTask,
@@ -200,6 +215,15 @@ def stream_to_s3(self, video_id):
     except (Video.DoesNotExist, Video.MultipleObjectsReturned):
         log.error("Exception retrieving video", video_id=video_id)
         raise
+
+    lock = _video_upload_lock(self.app, video_id)
+    if not lock.acquire(blocking=False):
+        log.debug(
+            "stream_to_s3 skipped; another worker holds the upload lock",
+            video_id=video_id,
+        )
+        return False
+
     video.update_status(VideoStatus.UPLOADING)
 
     task_id = self.get_task_id()
@@ -245,6 +269,15 @@ def stream_to_s3(self, video_id):
                 meta={"uploaded": uploaded, "total": content_length},
             )
             if should_refresh:
+                # Heartbeat the lease so a short TTL survives a long upload.
+                # Best-effort: if already lost, another worker owns it now.
+                try:
+                    lock.reacquire()
+                except LockError:
+                    log.warning(
+                        "stream_to_s3 lost upload lock during heartbeat",
+                        video_id=video.id,
+                    )
                 # Keep updated_at fresh so the fail_stuck_uploading_videos janitor
                 # treats an actively streaming upload as alive rather than stuck.
                 # Throttled (above) to avoid a DB write on every chunk callback.
@@ -292,6 +325,14 @@ def stream_to_s3(self, video_id):
         # successful-upload path where nothing else closes it.
         if response is not None:
             response.close()
+        # Release the upload lock.
+        try:
+            lock.release()
+        except LockError:
+            log.warning(
+                "stream_to_s3 upload lock already released or expired",
+                video_id=video_id,
+            )
 
 
 @shared_task(bind=True, base=VideoTask)

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -8,9 +8,11 @@ import re
 from datetime import timedelta
 
 import boto3
+import requests
 from boto3.s3.transfer import TransferConfig
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 from celery import Task, group, shared_task, states
+from celery.utils.time import get_exponential_backoff_interval
 from django.conf import settings
 from googleapiclient.errors import HttpError
 
@@ -25,6 +27,24 @@ from ui.models import Collection, EncodeJob, Video, VideoSubtitle, YouTubeVideo
 from ui.utils import get_bucket, now_in_utc
 
 log = structlog.get_logger(__name__)
+
+
+def _should_retry_upload(exc):
+    """
+    True for transient upload errors worth retrying. Excludes permanent failures
+    like malformed Dropbox metadata (KeyError/ValueError), auth errors, and HTTP
+    4xx responses (e.g. a revoked or missing shared link), which won't fix
+    themselves on retry.
+    """
+    if isinstance(exc, (BotoCoreError, ClientError)):
+        return True
+    if isinstance(exc, requests.HTTPError):
+        # Only server-side (5xx) and throttling/timeout statuses are transient.
+        status = getattr(exc.response, "status_code", None)
+        return status is not None and (status >= 500 or status in (408, 429))
+    # Connection/timeout/chunked-encoding level errors are transient. Checked
+    # after HTTPError since HTTPError is also a RequestException.
+    return isinstance(exc, requests.exceptions.RequestException)
 
 
 class VideoTask(Task):
@@ -111,7 +131,13 @@ def fail_stuck_uploading_videos():
             log.exception("Failed to update stuck video status", video_id=video.id)
 
 
-@shared_task(bind=True, base=VideoTask)
+@shared_task(
+    bind=True,
+    base=VideoTask,
+    acks_late=True,
+    reject_on_worker_lost=True,
+    max_retries=settings.CLOUDSYNC_STREAM_S3_MAX_RETRIES,
+)
 def stream_to_s3(self, video_id):
     """
     Stream the contents of the given URL to Amazon S3
@@ -128,6 +154,11 @@ def stream_to_s3(self, video_id):
 
     task_id = self.get_task_id()
     response = None
+
+    def mark_failed():
+        video.update_status(VideoStatus.UPLOAD_FAILED)
+        self.update_state(task_id=task_id, state=states.FAILURE)
+
     try:
         response = dropbox_api.stream_shared_link(video.source_url)
         # KeyError/ValueError here mean the Dropbox metadata header is
@@ -137,18 +168,30 @@ def stream_to_s3(self, video_id):
         s3 = boto3.resource("s3")
         bucket = s3.Bucket(settings.VIDEO_S3_BUCKET)
         total_bytes_uploaded = 0
+        last_progress_refresh = None
 
         def callback(bytes_uploaded):
             """
             Callback function after upload
             """
-            nonlocal total_bytes_uploaded
+            nonlocal total_bytes_uploaded, last_progress_refresh
             total_bytes_uploaded += bytes_uploaded
             data = {
                 "uploaded": total_bytes_uploaded,
                 "total": content_length,
             }
             self.update_state(task_id=task_id, state="PROGRESS", meta=data)
+            # Keep updated_at fresh so the fail_stuck_uploading_videos janitor
+            # treats an actively streaming upload as alive rather than stuck.
+            # Throttled to avoid a DB write on every chunk callback.
+            now = now_in_utc()
+            if (
+                last_progress_refresh is None
+                or (now - last_progress_refresh).total_seconds()
+                >= settings.CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS
+            ):
+                last_progress_refresh = now
+                Video.objects.filter(id=video.id).update(updated_at=now)
 
         config = TransferConfig(**settings.AWS_S3_UPLOAD_TRANSFER_CONFIG)
         bucket.upload_fileobj(
@@ -158,9 +201,26 @@ def stream_to_s3(self, video_id):
             Callback=callback,
             Config=config,
         )
-    except Exception:
-        video.update_status(VideoStatus.UPLOAD_FAILED)
-        self.update_state(task_id=task_id, state=states.FAILURE)
+    except Exception as exc:
+        retryable = _should_retry_upload(exc)
+        if retryable and self.request.retries < self.max_retries:
+            countdown = get_exponential_backoff_interval(
+                factor=settings.CLOUDSYNC_STREAM_S3_RETRY_BACKOFF,
+                retries=self.request.retries,
+                maximum=settings.CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF,
+                full_jitter=True,
+            )
+            log.warning(
+                "Retrying stream_to_s3 after transient error",
+                video_id=video_id,
+                attempt=self.request.retries + 1,
+                countdown=countdown,
+                error=str(exc),
+            )
+            raise self.retry(exc=exc, countdown=countdown)
+        if retryable:
+            log.error("stream_to_s3 retries exhausted", video_id=video_id)
+        mark_failed()
         raise
     finally:
         # Always release the streamed Dropbox connection, including on the

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -222,6 +222,10 @@ def stream_to_s3(self, video_id):
             "stream_to_s3 skipped; another worker holds the upload lock",
             video_id=video_id,
         )
+        # Don't advance the chain: the worker that owns the upload transcodes via
+        # its own chain. Returning normally would otherwise run transcode_from_s3
+        # on an incomplete object and poison the video out of UPLOADING.
+        self.request.chain = self.request.callbacks = None
         return False
 
     video.update_status(VideoStatus.UPLOADING)

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -102,6 +102,29 @@ def _should_retry_upload(exc):
     return isinstance(exc, TRANSIENT_STREAM_ERRORS)
 
 
+def _retry_after_seconds(exc, retries: int) -> int:
+    """Return the Retry-After wait (seconds) from a 429 throttle response, else use exponential backoff."""
+    seconds = None
+    response = getattr(exc, "response", None)
+    if response and getattr(response, "status_code", None) == 429:
+        headers = getattr(response, "headers", None) or {}
+        value = headers.get("Retry-After", None)
+        if value:
+            try:
+                seconds = int(value)
+            except (TypeError, ValueError):
+                log.warning("Invalid Retry-After header value; ignoring")
+    if seconds is None:
+        # No valid Retry-After header; use exponential backoff with jitter.
+        seconds = get_exponential_backoff_interval(
+            factor=settings.CLOUDSYNC_STREAM_S3_RETRY_BACKOFF,
+            retries=retries,
+            maximum=settings.CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF,
+            full_jitter=True,
+        )
+    return seconds
+
+
 class VideoTask(Task):
     """
     Custom Celery Task class for video uploads and transcodes
@@ -315,12 +338,7 @@ def stream_to_s3(self, video_id):
     except Exception as exc:
         retryable = _should_retry_upload(exc)
         if retryable and self.request.retries < self.max_retries:
-            countdown = get_exponential_backoff_interval(
-                factor=settings.CLOUDSYNC_STREAM_S3_RETRY_BACKOFF,
-                retries=self.request.retries,
-                maximum=settings.CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF,
-                full_jitter=True,
-            )
+            countdown = _retry_after_seconds(exc, self.request.retries)
             log.warning(
                 "Retrying stream_to_s3 after transient error",
                 video_id=video_id,

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -42,32 +42,33 @@ log = structlog.get_logger(__name__)
 
 # botocore transport errors worth retrying — connection drops and read/connect
 # timeouts — as opposed to permanent ones like NoCredentialsError.
-_TRANSIENT_BOTOCORE_ERRORS = (
+TRANSIENT_BOTOCORE_ERRORS = (
     BotoConnectionError,
     ConnectionClosedError,
     HTTPClientError,
 )
 # S3 error codes that are transient even when their HTTP status is not 5xx
 # (e.g. RequestTimeout is a 400).
-_TRANSIENT_S3_ERROR_CODES = frozenset(
+TRANSIENT_S3_ERROR_CODES = frozenset(
     {
         "RequestTimeout",
         "RequestTimeTooSkewed",
-        "SlowDown",
-        "InternalError",
-        "ServiceUnavailable",
         "ThrottlingException",
         "Throttling",
     }
 )
 # Socket/transport errors raised while boto3 streams from response.raw (the
 # urllib3 socket); these are NOT requests.RequestException subclasses.
-_TRANSIENT_STREAM_ERRORS = (
+TRANSIENT_STREAM_ERRORS = (
     ConnectionError,  # builtin: ConnectionReset/BrokenPipe/etc.
     TimeoutError,  # builtin
     Urllib3ProtocolError,
     Urllib3TimeoutError,
 )
+
+UPLOAD_PROGRESS_REFRESH_SECONDS = 60
+# TTL must exceed the refresh interval; doubled for headroom
+UPLOAD_LOCK_TTL = max(120, UPLOAD_PROGRESS_REFRESH_SECONDS * 2)
 
 
 def _is_transient_http_status(status):
@@ -86,16 +87,16 @@ def _should_retry_upload(exc):
         meta = exc.response.get("ResponseMetadata", {})
         if _is_transient_http_status(meta.get("HTTPStatusCode")):
             return True
-        return exc.response.get("Error", {}).get("Code") in _TRANSIENT_S3_ERROR_CODES
+        return exc.response.get("Error", {}).get("Code") in TRANSIENT_S3_ERROR_CODES
     if isinstance(exc, BotoCoreError):
-        return isinstance(exc, _TRANSIENT_BOTOCORE_ERRORS)
+        return isinstance(exc, TRANSIENT_BOTOCORE_ERRORS)
     if isinstance(exc, requests.HTTPError):
         return _is_transient_http_status(getattr(exc.response, "status_code", None))
     if isinstance(exc, requests.exceptions.RequestException):
         # requests-level connection/timeout/chunked-encoding errors are transient.
         # Checked after HTTPError, since HTTPError is also a RequestException.
         return True
-    return isinstance(exc, _TRANSIENT_STREAM_ERRORS)
+    return isinstance(exc, TRANSIENT_STREAM_ERRORS)
 
 
 class VideoTask(Task):
@@ -191,7 +192,7 @@ def _video_upload_lock(app, video_id):
     """
     return app.backend.client.lock(
         f"stream_to_s3:lock:{video_id}",
-        timeout=settings.CLOUDSYNC_STREAM_S3_LOCK_TTL,
+        timeout=UPLOAD_LOCK_TTL,
         thread_local=False,
     )
 
@@ -233,10 +234,6 @@ def stream_to_s3(self, video_id):
     task_id = self.get_task_id()
     response = None
 
-    def mark_failed():
-        video.update_status(VideoStatus.UPLOAD_FAILED)
-        self.update_state(task_id=task_id, state=states.FAILURE)
-
     try:
         response = dropbox_api.stream_shared_link(video.source_url)
         # KeyError/ValueError here mean the Dropbox metadata header is
@@ -263,7 +260,7 @@ def stream_to_s3(self, video_id):
                 should_refresh = (
                     last_progress_refresh is None
                     or (now - last_progress_refresh).total_seconds()
-                    >= settings.CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS
+                    >= UPLOAD_PROGRESS_REFRESH_SECONDS
                 )
                 if should_refresh:
                     last_progress_refresh = now
@@ -322,7 +319,8 @@ def stream_to_s3(self, video_id):
             raise self.retry(exc=exc, countdown=countdown)
         if retryable:
             log.error("stream_to_s3 retries exhausted", video_id=video_id)
-        mark_failed()
+        video.update_status(VideoStatus.UPLOAD_FAILED)
+        self.update_state(task_id=task_id, state=states.FAILURE)
         raise
     finally:
         # Always release the streamed Dropbox connection, including on the

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -42,6 +42,11 @@ from ui.utils import get_bucket, now_in_utc
 log = structlog.get_logger(__name__)
 
 
+class _UploadLockLost(Exception):
+    """Raised from the progress callback when stream_to_s3 loses its upload lock
+    mid-stream, so the upload aborts before two workers can write the same key."""
+
+
 # botocore transport errors worth retrying — connection drops and read/connect
 # timeouts — as opposed to permanent ones like NoCredentialsError.
 TRANSIENT_BOTOCORE_ERRORS = (
@@ -67,10 +72,6 @@ TRANSIENT_STREAM_ERRORS = (
     Urllib3ProtocolError,
     Urllib3TimeoutError,
 )
-
-UPLOAD_PROGRESS_REFRESH_SECONDS = 60
-# TTL must exceed the refresh interval; doubled for headroom
-UPLOAD_LOCK_TTL = max(120, UPLOAD_PROGRESS_REFRESH_SECONDS * 2)
 
 
 def _is_transient_http_status(status):
@@ -194,7 +195,7 @@ def _video_upload_lock(app, video_id):
     """
     return app.backend.client.lock(
         f"stream_to_s3:lock:{video_id}",
-        timeout=UPLOAD_LOCK_TTL,
+        timeout=settings.CLOUDSYNC_STREAM_S3_LOCK_TTL,
         thread_local=False,
     )
 
@@ -258,29 +259,28 @@ def stream_to_s3(self, video_id):
             now = now_in_utc()
             with progress_lock:
                 total_bytes_uploaded += bytes_uploaded
-                uploaded = total_bytes_uploaded
                 should_refresh = (
                     last_progress_refresh is None
                     or (now - last_progress_refresh).total_seconds()
-                    >= UPLOAD_PROGRESS_REFRESH_SECONDS
+                    >= settings.CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS
                 )
                 if should_refresh:
                     last_progress_refresh = now
             self.update_state(
                 task_id=task_id,
                 state="PROGRESS",
-                meta={"uploaded": uploaded, "total": content_length},
+                meta={"uploaded": total_bytes_uploaded, "total": content_length},
             )
             if should_refresh:
-                # Heartbeat the lease so a short TTL survives a long upload.
-                # Best-effort: if already lost, another worker owns it now.
+                # Heartbeat the lease so a short TTL survives a long upload. If we
+                # can't reacquire, another worker now owns the lock and may be
+                # streaming the same key — abort this upload rather than letting two
+                # workers write concurrently. Redelivery/retry re-enters normal lock
+                # acquisition so exactly one worker proceeds.
                 try:
                     lock.reacquire()
-                except LockError:
-                    log.warning(
-                        "stream_to_s3 lost upload lock during heartbeat",
-                        video_id=video.id,
-                    )
+                except LockError as exc:
+                    raise _UploadLockLost from exc
                 # Keep updated_at fresh so the fail_stuck_uploading_videos janitor
                 # treats an actively streaming upload as alive rather than stuck.
                 # Throttled (above) to avoid a DB write on every chunk callback.
@@ -302,6 +302,16 @@ def stream_to_s3(self, video_id):
             Callback=callback,
             Config=config,
         )
+    except _UploadLockLost:
+        # Another worker owns the lock now and is driving this upload (and its
+        # transcode chain). Give up quietly: don't fail the video, don't retry,
+        # and don't advance the chain, mirroring the can't-acquire path above.
+        log.warning(
+            "stream_to_s3 lost upload lock mid-stream; another worker owns it",
+            video_id=video_id,
+        )
+        self.request.chain = self.request.callbacks = None
+        return False
     except Exception as exc:
         retryable = _should_retry_upload(exc)
         if retryable and self.request.retries < self.max_retries:

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -5,16 +5,26 @@ Tasks for cloudsync app
 import json
 import mimetypes
 import re
+import threading
 from datetime import timedelta
 
 import boto3
 import requests
 from boto3.s3.transfer import TransferConfig
-from botocore.exceptions import BotoCoreError, ClientError
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    ConnectionClosedError,
+    HTTPClientError,
+)
+from botocore.exceptions import ConnectionError as BotoConnectionError
 from celery import Task, group, shared_task, states
 from celery.utils.time import get_exponential_backoff_interval
 from django.conf import settings
+from django.db import connection
 from googleapiclient.errors import HttpError
+from urllib3.exceptions import ProtocolError as Urllib3ProtocolError
+from urllib3.exceptions import TimeoutError as Urllib3TimeoutError
 
 from cloudsync import dropbox_api
 from cloudsync.api import process_watch_file, refresh_status, transcode_video
@@ -29,22 +39,62 @@ from ui.utils import get_bucket, now_in_utc
 log = structlog.get_logger(__name__)
 
 
+# botocore transport errors worth retrying — connection drops and read/connect
+# timeouts — as opposed to permanent ones like NoCredentialsError.
+_TRANSIENT_BOTOCORE_ERRORS = (
+    BotoConnectionError,
+    ConnectionClosedError,
+    HTTPClientError,
+)
+# S3 error codes that are transient even when their HTTP status is not 5xx
+# (e.g. RequestTimeout is a 400).
+_TRANSIENT_S3_ERROR_CODES = frozenset(
+    {
+        "RequestTimeout",
+        "RequestTimeTooSkewed",
+        "SlowDown",
+        "InternalError",
+        "ServiceUnavailable",
+        "ThrottlingException",
+        "Throttling",
+    }
+)
+# Socket/transport errors raised while boto3 streams from response.raw (the
+# urllib3 socket); these are NOT requests.RequestException subclasses.
+_TRANSIENT_STREAM_ERRORS = (
+    ConnectionError,  # builtin: ConnectionReset/BrokenPipe/etc.
+    TimeoutError,  # builtin
+    Urllib3ProtocolError,
+    Urllib3TimeoutError,
+)
+
+
+def _is_transient_http_status(status):
+    """5xx, plus request-timeout (408) and too-many-requests (429), are transient."""
+    return status is not None and (status >= 500 or status in (408, 429))
+
+
 def _should_retry_upload(exc):
     """
-    True for transient upload errors worth retrying. Excludes permanent failures
-    like malformed Dropbox metadata (KeyError/ValueError), auth errors, and HTTP
-    4xx responses (e.g. a revoked or missing shared link), which won't fix
-    themselves on retry.
+    True for transient upload errors worth retrying. Permanent failures fail fast:
+    malformed Dropbox metadata (KeyError/ValueError), auth errors, HTTP 4xx (e.g. a
+    revoked or missing shared link), and permanent S3 errors (AccessDenied,
+    NoSuchBucket, ...).
     """
-    if isinstance(exc, (BotoCoreError, ClientError)):
-        return True
+    if isinstance(exc, ClientError):
+        meta = exc.response.get("ResponseMetadata", {})
+        if _is_transient_http_status(meta.get("HTTPStatusCode")):
+            return True
+        return exc.response.get("Error", {}).get("Code") in _TRANSIENT_S3_ERROR_CODES
+    if isinstance(exc, BotoCoreError):
+        return isinstance(exc, _TRANSIENT_BOTOCORE_ERRORS)
     if isinstance(exc, requests.HTTPError):
-        # Only server-side (5xx) and throttling/timeout statuses are transient.
-        status = getattr(exc.response, "status_code", None)
-        return status is not None and (status >= 500 or status in (408, 429))
-    # Connection/timeout/chunked-encoding level errors are transient. Checked
-    # after HTTPError since HTTPError is also a RequestException.
-    return isinstance(exc, requests.exceptions.RequestException)
+        return _is_transient_http_status(getattr(exc.response, "status_code", None))
+    if isinstance(exc, requests.exceptions.RequestException):
+        # requests-level connection/timeout/chunked-encoding errors are transient.
+        # Checked after HTTPError, since HTTPError is also a RequestException.
+        return True
+    return isinstance(exc, _TRANSIENT_STREAM_ERRORS)
 
 
 class VideoTask(Task):
@@ -169,29 +219,44 @@ def stream_to_s3(self, video_id):
         bucket = s3.Bucket(settings.VIDEO_S3_BUCKET)
         total_bytes_uploaded = 0
         last_progress_refresh = None
+        # boto3's s3transfer invokes this callback concurrently from a thread
+        # pool, so guard the shared progress state.
+        progress_lock = threading.Lock()
 
         def callback(bytes_uploaded):
             """
             Callback function after upload
             """
             nonlocal total_bytes_uploaded, last_progress_refresh
-            total_bytes_uploaded += bytes_uploaded
-            data = {
-                "uploaded": total_bytes_uploaded,
-                "total": content_length,
-            }
-            self.update_state(task_id=task_id, state="PROGRESS", meta=data)
-            # Keep updated_at fresh so the fail_stuck_uploading_videos janitor
-            # treats an actively streaming upload as alive rather than stuck.
-            # Throttled to avoid a DB write on every chunk callback.
             now = now_in_utc()
-            if (
-                last_progress_refresh is None
-                or (now - last_progress_refresh).total_seconds()
-                >= settings.CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS
-            ):
-                last_progress_refresh = now
-                Video.objects.filter(id=video.id).update(updated_at=now)
+            with progress_lock:
+                total_bytes_uploaded += bytes_uploaded
+                uploaded = total_bytes_uploaded
+                should_refresh = (
+                    last_progress_refresh is None
+                    or (now - last_progress_refresh).total_seconds()
+                    >= settings.CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS
+                )
+                if should_refresh:
+                    last_progress_refresh = now
+            self.update_state(
+                task_id=task_id,
+                state="PROGRESS",
+                meta={"uploaded": uploaded, "total": content_length},
+            )
+            if should_refresh:
+                # Keep updated_at fresh so the fail_stuck_uploading_videos janitor
+                # treats an actively streaming upload as alive rather than stuck.
+                # Throttled (above) to avoid a DB write on every chunk callback.
+                try:
+                    Video.objects.filter(id=video.id).update(updated_at=now)
+                finally:
+                    # When invoked from an s3transfer worker thread, Django opens
+                    # a thread-local connection nothing else will close; close it
+                    # here to avoid leaking connections. Leave the main task's
+                    # connection alone.
+                    if threading.current_thread() is not threading.main_thread():
+                        connection.close()
 
         config = TransferConfig(**settings.AWS_S3_UPLOAD_TRANSFER_CONFIG)
         bucket.upload_fileobj(

--- a/cloudsync/tasks.py
+++ b/cloudsync/tasks.py
@@ -14,18 +14,20 @@ from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import (
     BotoCoreError,
     ClientError,
+    ConnectionError as BotoConnectionError,
     ConnectionClosedError,
     HTTPClientError,
 )
-from botocore.exceptions import ConnectionError as BotoConnectionError
 from celery import Task, group, shared_task, states
 from celery.utils.time import get_exponential_backoff_interval
 from django.conf import settings
 from django.db import connection
 from googleapiclient.errors import HttpError
 from redis.exceptions import LockError
-from urllib3.exceptions import ProtocolError as Urllib3ProtocolError
-from urllib3.exceptions import TimeoutError as Urllib3TimeoutError
+from urllib3.exceptions import (
+    ProtocolError as Urllib3ProtocolError,
+    TimeoutError as Urllib3TimeoutError,
+)
 
 from cloudsync import dropbox_api
 from cloudsync.api import process_watch_file, refresh_status, transcode_video

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -358,6 +358,59 @@ def test_upload_transient_error_retries(mocker, video, exc):
     assert Video.objects.get(id=video.id).status == VideoStatus.UPLOADING
 
 
+@pytest.mark.parametrize(
+    "retry_after, expected_countdown",
+    [
+        ("42", 42),  # honored verbatim
+        ("0", 0),  # Dropbox may say retry immediately
+        ("99999", 99999),  # honored verbatim, no upper cap
+    ],
+)
+def test_upload_honors_retry_after_header(
+    mocker, video, retry_after, expected_countdown
+):
+    """A throttle response's Retry-After header (seconds) drives the retry
+    countdown verbatim, instead of exponential backoff."""
+    err = HTTPError("429 throttled")
+    err.response = SimpleNamespace(
+        status_code=429, headers={"Retry-After": retry_after}
+    )
+    mocker.patch("ui.models.tasks.async_send_notification_email")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mocker.patch("cloudsync.tasks.dropbox_api.stream_shared_link", side_effect=err)
+    mocker.patch("cloudsync.tasks.boto3")
+    backoff = mocker.patch("cloudsync.tasks.get_exponential_backoff_interval")
+    retry = mocker.patch.object(
+        stream_to_s3, "retry", side_effect=celery.exceptions.Retry("retry")
+    )
+    with pytest.raises(celery.exceptions.Retry):
+        stream_to_s3.apply((video.id,), retries=0, throw=True).get()
+    assert retry.call_args.kwargs["countdown"] == expected_countdown
+    # The header overrides exponential backoff entirely.
+    backoff.assert_not_called()
+
+
+def test_upload_ignores_retry_after_for_non_429(mocker, video):
+    """Retry-After is honored only for 429 throttles. A transient 503 carrying the
+    header still uses exponential backoff, not the header value."""
+    err = HTTPError("503 unavailable")
+    err.response = SimpleNamespace(status_code=503, headers={"Retry-After": "42"})
+    mocker.patch("ui.models.tasks.async_send_notification_email")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mocker.patch("cloudsync.tasks.dropbox_api.stream_shared_link", side_effect=err)
+    mocker.patch("cloudsync.tasks.boto3")
+    backoff = mocker.patch(
+        "cloudsync.tasks.get_exponential_backoff_interval", return_value=7
+    )
+    retry = mocker.patch.object(
+        stream_to_s3, "retry", side_effect=celery.exceptions.Retry("retry")
+    )
+    with pytest.raises(celery.exceptions.Retry):
+        stream_to_s3.apply((video.id,), retries=0, throw=True).get()
+    assert retry.call_args.kwargs["countdown"] == 7
+    backoff.assert_called_once()
+
+
 @pytest.mark.parametrize("exc", TRANSIENT_UPLOAD_ERRORS)
 def test_upload_retries_exhausted(mocker, video, exc):
     """Once retries are exhausted the original error fails the video."""

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -21,12 +21,14 @@ from django.test import override_settings
 from googleapiclient.errors import HttpError, ResumableUploadError
 from moto import mock_aws
 from requests import HTTPError
+from urllib3.exceptions import ProtocolError as Urllib3ProtocolError
 
 from cloudsync import dropbox_api
 from cloudsync.conftest import MockBoto, MockHttpErrorResponse
 from cloudsync.exceptions import TranscodeTargetDoesNotExist
 from cloudsync.tasks import (
     VideoTask,
+    _should_retry_upload,
     fail_stuck_uploading_videos,
     monitor_watch_bucket,
     parse_content_metadata,
@@ -298,20 +300,34 @@ def _http_error(status):
     return err
 
 
+def _client_error(status, code="SomeError"):
+    """Build a botocore ClientError with the given HTTP status and error code."""
+    return ClientError(
+        {"Error": {"Code": code}, "ResponseMetadata": {"HTTPStatusCode": status}},
+        "PutObject",
+    )
+
+
 TRANSIENT_UPLOAD_ERRORS = [
     requests.Timeout("read timed out"),
     requests.ConnectionError("connection reset"),
-    ClientError({"Error": {}}, "PutObject"),
+    _client_error(503, "ServiceUnavailable"),
+    _client_error(400, "RequestTimeout"),  # transient despite 4xx status
     _http_error(503),
     _http_error(429),
+    ConnectionError("connection reset by peer"),  # builtin socket error
+    Urllib3ProtocolError("connection broken"),  # raw-stream transport error
 ]
 
-# 4xx (except throttling/timeout) and statusless HTTP errors are permanent.
-PERMANENT_HTTP_ERRORS = [
+# 4xx (except throttling/timeout), statusless HTTP errors, and permanent S3
+# errors are not retried.
+PERMANENT_UPLOAD_ERRORS = [
     _http_error(401),
     _http_error(403),
     _http_error(404),
     HTTPError("no response attached"),
+    _client_error(403, "AccessDenied"),
+    _client_error(404, "NoSuchBucket"),
 ]
 
 
@@ -344,17 +360,42 @@ def test_upload_retries_exhausted(mocker, video, exc):
     assert Video.objects.get(id=video.id).status == VideoStatus.UPLOAD_FAILED
 
 
-@pytest.mark.parametrize("exc", PERMANENT_HTTP_ERRORS)
-def test_upload_permanent_http_error_fails_fast(mocker, video, exc):
-    """4xx (and statusless) HTTP errors fail immediately without retrying."""
+@pytest.mark.parametrize("exc", PERMANENT_UPLOAD_ERRORS)
+def test_upload_permanent_error_fails_fast(mocker, video, exc):
+    """Permanent errors (4xx, statusless, AccessDenied) fail without retrying."""
     mocker.patch("ui.models.tasks.async_send_notification_email")
     mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
     mocker.patch("cloudsync.tasks.dropbox_api.stream_shared_link", side_effect=exc)
     mocker.patch("cloudsync.tasks.boto3")
     # retries=0 but the error is permanent, so it raises the error, not Retry.
-    with pytest.raises(HTTPError):
+    with pytest.raises(type(exc)):
         stream_to_s3.apply((video.id,), retries=0, throw=True).get()
     assert Video.objects.get(id=video.id).status == VideoStatus.UPLOAD_FAILED
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (_client_error(503, "ServiceUnavailable"), True),
+        (_client_error(400, "RequestTimeout"), True),  # transient code, 4xx status
+        (_client_error(403, "AccessDenied"), False),
+        (_client_error(404, "NoSuchBucket"), False),
+        (_http_error(503), True),
+        (_http_error(429), True),
+        (_http_error(404), False),
+        (HTTPError("no response attached"), False),
+        (requests.ConnectionError("reset"), True),
+        (ConnectionError("builtin socket reset"), True),
+        (TimeoutError("builtin timeout"), True),
+        (Urllib3ProtocolError("connection broken"), True),
+        (KeyError("Dropbox-API-Result"), False),
+        (ValueError("bad metadata"), False),
+        (dropbox_api.DropboxAuthError("token refresh failed"), False),
+    ],
+)
+def test_should_retry_upload_classification(exc, expected):
+    """Transient transport errors retry; permanent/auth/metadata errors do not."""
+    assert _should_retry_upload(exc) is expected
 
 
 def test_stream_to_s3_task_config():

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -29,6 +29,7 @@ from cloudsync.exceptions import TranscodeTargetDoesNotExist
 from cloudsync.tasks import (
     VideoTask,
     _should_retry_upload,
+    _video_upload_lock,
     fail_stuck_uploading_videos,
     monitor_watch_bucket,
     parse_content_metadata,
@@ -57,6 +58,19 @@ from ui.models import TRANSCODE_PREFIX, Collection, Video, YouTubeVideo
 from ui.utils import now_in_utc
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def upload_lock(mocker):
+    """Replace the redis client backing stream_to_s3's per-video upload lock so
+    tests never touch a real Redis. The lock is acquired by default; lock-specific
+    tests flip ``acquire.return_value`` or assert on release/reacquire."""
+    lock = mocker.MagicMock()
+    lock.acquire.return_value = True
+    client = mocker.MagicMock()
+    client.lock.return_value = lock
+    mocker.patch.object(stream_to_s3.app.backend, "client", client)
+    return lock
 
 
 def _make_uploading_video(updated_hours_ago, created_hours_ago=None):
@@ -403,6 +417,101 @@ def test_stream_to_s3_task_config():
     assert stream_to_s3.acks_late is True
     assert stream_to_s3.reject_on_worker_lost is True
     assert stream_to_s3.max_retries == settings.CLOUDSYNC_STREAM_S3_MAX_RETRIES
+
+
+def _stub_happy_upload(mocker, size=1024):
+    """Wire up dropbox + boto3 mocks for a successful stream_to_s3 run."""
+    fake_response = SimpleNamespace(
+        raw=io.BytesIO(os.urandom(size)),
+        url="https://dropbox.example/file",
+        headers={
+            "Dropbox-API-Result": json.dumps({"name": "video.mp4", "size": size}),
+            "Content-Type": "application/octet-stream",
+        },
+        close=lambda: None,
+    )
+    mocker.patch(
+        "cloudsync.tasks.dropbox_api.stream_shared_link", return_value=fake_response
+    )
+    mock_boto3 = mocker.patch("cloudsync.tasks.boto3")
+    return mock_boto3.resource.return_value.Bucket.return_value
+
+
+def test_video_upload_lock_uses_ttl_and_key(mocker):
+    """The lock is namespaced per video and leased for the configured TTL."""
+    app = mocker.MagicMock()
+    _video_upload_lock(app, 42)
+    # thread_local=False: acquired in the task thread but reacquired/released from
+    # s3transfer worker threads, so the token must be shared across threads.
+    app.backend.client.lock.assert_called_once_with(
+        "stream_to_s3:lock:42",
+        timeout=settings.CLOUDSYNC_STREAM_S3_LOCK_TTL,
+        thread_local=False,
+    )
+
+
+def test_upload_acquires_and_releases_lock(mocker, video, upload_lock):
+    """A successful upload acquires the lock non-blocking and releases it."""
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    _stub_happy_upload(mocker)
+
+    stream_to_s3(video.id)
+
+    upload_lock.acquire.assert_called_once_with(blocking=False)
+    upload_lock.release.assert_called_once()
+
+
+def test_upload_lock_contention_skips(mocker, video, upload_lock):
+    """If the lock is held, give up immediately: another worker owns the upload."""
+    upload_lock.acquire.return_value = False
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mock_bucket = _stub_happy_upload(mocker)
+
+    result = stream_to_s3(video.id)
+
+    assert result is False
+    mock_bucket.upload_fileobj.assert_not_called()
+    upload_lock.release.assert_not_called()
+    assert Video.objects.get(id=video.id).status != VideoStatus.UPLOADING
+
+
+def test_upload_releases_lock_on_error(mocker, video, upload_lock):
+    """The lock is released even when the upload fails."""
+    mocker.patch("ui.models.tasks.async_send_notification_email")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mocker.patch(
+        "cloudsync.tasks.dropbox_api.stream_shared_link", side_effect=_http_error(403)
+    )
+    mocker.patch("cloudsync.tasks.boto3")
+
+    with pytest.raises(HTTPError):
+        stream_to_s3.apply((video.id,), retries=0, throw=True).get()
+
+    upload_lock.release.assert_called_once()
+
+
+def test_lock_release_error_is_swallowed(mocker, video, upload_lock):
+    """A LockError on release (lease lost) must not surface as a task failure."""
+    from redis.exceptions import LockError
+
+    upload_lock.release.side_effect = LockError("not owned")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    _stub_happy_upload(mocker)
+
+    stream_to_s3(video.id)  # does not raise
+
+
+def test_progress_callback_heartbeats_lock(mocker, video, upload_lock):
+    """The throttled progress callback extends the lock lease (heartbeat)."""
+    mocker.patch("ui.models.tasks.async_send_notification_email")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mock_bucket = _stub_happy_upload(mocker)
+
+    stream_to_s3(video.id)
+
+    callback = mock_bucket.upload_fileobj.call_args.kwargs["Callback"]
+    callback(512)
+    upload_lock.reacquire.assert_called()
 
 
 def test_upload_auth_failure(mocker, video):

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -28,7 +28,6 @@ from cloudsync.conftest import MockBoto, MockHttpErrorResponse
 from cloudsync.exceptions import TranscodeTargetDoesNotExist
 from cloudsync.tasks import (
     VideoTask,
-    UPLOAD_LOCK_TTL,
     _should_retry_upload,
     _video_upload_lock,
     fail_stuck_uploading_videos,
@@ -446,7 +445,7 @@ def test_video_upload_lock_uses_ttl_and_key(mocker):
     # s3transfer worker threads, so the token must be shared across threads.
     app.backend.client.lock.assert_called_once_with(
         "stream_to_s3:lock:42",
-        timeout=UPLOAD_LOCK_TTL,
+        timeout=settings.CLOUDSYNC_STREAM_S3_LOCK_TTL,
         thread_local=False,
     )
 
@@ -531,6 +530,35 @@ def test_progress_callback_heartbeats_lock(mocker, video, upload_lock):
     callback = mock_bucket.upload_fileobj.call_args.kwargs["Callback"]
     callback(512)
     upload_lock.reacquire.assert_called()
+
+
+def test_upload_aborts_when_lock_lost_mid_stream(mocker, video, upload_lock):
+    """If the lease is lost mid-upload, abort rather than letting two workers write
+    the same key: no UPLOAD_FAILED, no retry, and the chain is suppressed so the
+    worker that now owns the lock drives transcode."""
+    from redis.exceptions import LockError
+
+    upload_lock.reacquire.side_effect = LockError("lost")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mock_bucket = _stub_happy_upload(mocker)
+    # Real s3transfer fires Callback from ReadFileChunk.read(), so a raising callback
+    # propagates out of upload_fileobj. Mirror that: invoke the callback inline.
+    mock_bucket.upload_fileobj.side_effect = lambda *a, **kw: kw["Callback"](1024)
+    retry = mocker.patch.object(stream_to_s3, "retry")
+
+    chain = [{"options": {"task_id": "transcode-task-id"}}]
+    stream_to_s3.push_request(chain=chain, callbacks=["cb"])
+    try:
+        result = stream_to_s3.run(video.id)
+        assert result is False
+        assert stream_to_s3.request.chain is None
+        assert stream_to_s3.request.callbacks is None
+    finally:
+        stream_to_s3.pop_request()
+
+    retry.assert_not_called()
+    assert Video.objects.get(id=video.id).status == VideoStatus.UPLOADING
+    upload_lock.release.assert_called_once()
 
 
 def test_upload_auth_failure(mocker, video):

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -28,6 +28,7 @@ from cloudsync.conftest import MockBoto, MockHttpErrorResponse
 from cloudsync.exceptions import TranscodeTargetDoesNotExist
 from cloudsync.tasks import (
     VideoTask,
+    UPLOAD_LOCK_TTL,
     _should_retry_upload,
     _video_upload_lock,
     fail_stuck_uploading_videos,
@@ -445,7 +446,7 @@ def test_video_upload_lock_uses_ttl_and_key(mocker):
     # s3transfer worker threads, so the token must be shared across threads.
     app.backend.client.lock.assert_called_once_with(
         "stream_to_s3:lock:42",
-        timeout=settings.CLOUDSYNC_STREAM_S3_LOCK_TTL,
+        timeout=UPLOAD_LOCK_TTL,
         thread_local=False,
     )
 

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -263,20 +263,105 @@ def test_happy_path(mocker, video):
     assert Video.objects.get(id=video.id).status == VideoStatus.UPLOADING
 
 
-def test_upload_failure(mocker, video):
-    """Video is marked failed when the authenticated download errors."""
+def test_upload_progress_refreshes_updated_at(mocker, video):
+    """The progress callback refreshes updated_at so the janitor sees life."""
     mocker.patch("ui.models.tasks.async_send_notification_email")
-    mock_update = mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
-    mocker.patch(
-        "cloudsync.tasks.dropbox_api.stream_shared_link",
-        side_effect=HTTPError("access denied"),
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    fake_response = SimpleNamespace(
+        raw=io.BytesIO(os.urandom(1024)),
+        headers={"Dropbox-API-Result": json.dumps({"name": "video.mp4", "size": 1024})},
+        close=lambda: None,
     )
+    mocker.patch(
+        "cloudsync.tasks.dropbox_api.stream_shared_link", return_value=fake_response
+    )
+    mock_boto3 = mocker.patch("cloudsync.tasks.boto3")
+    mock_bucket = mock_boto3.resource.return_value.Bucket.return_value
+
+    stream_to_s3(video.id)
+
+    # boto3 is mocked, so the callback never fires during the upload; grab it and
+    # invoke it directly with a known "now" to assert it bumps updated_at.
+    callback = mock_bucket.upload_fileobj.call_args.kwargs["Callback"]
+    future = now_in_utc() + timedelta(hours=1)
+    mocker.patch("cloudsync.tasks.now_in_utc", return_value=future)
+    callback(512)
+
+    refreshed = Video.objects.get(id=video.id).updated_at
+    assert abs((refreshed - future).total_seconds()) < 1
+
+
+def _http_error(status):
+    """Build a requests.HTTPError carrying a response with the given status."""
+    err = HTTPError(f"status {status}")
+    err.response = SimpleNamespace(status_code=status)
+    return err
+
+
+TRANSIENT_UPLOAD_ERRORS = [
+    requests.Timeout("read timed out"),
+    requests.ConnectionError("connection reset"),
+    ClientError({"Error": {}}, "PutObject"),
+    _http_error(503),
+    _http_error(429),
+]
+
+# 4xx (except throttling/timeout) and statusless HTTP errors are permanent.
+PERMANENT_HTTP_ERRORS = [
+    _http_error(401),
+    _http_error(403),
+    _http_error(404),
+    HTTPError("no response attached"),
+]
+
+
+@pytest.mark.parametrize("exc", TRANSIENT_UPLOAD_ERRORS)
+def test_upload_transient_error_retries(mocker, video, exc):
+    """Transient errors request a retry and leave the video in UPLOADING."""
+    mocker.patch("ui.models.tasks.async_send_notification_email")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mocker.patch("cloudsync.tasks.dropbox_api.stream_shared_link", side_effect=exc)
     mocker.patch("cloudsync.tasks.boto3")
-    with pytest.raises(HTTPError):
-        stream_to_s3(video.id)
+    # retries=0 < max_retries, so the task raises Retry rather than failing.
+    with pytest.raises(celery.exceptions.Retry):
+        stream_to_s3.apply((video.id,), retries=0, throw=True).get()
+    assert Video.objects.get(id=video.id).status == VideoStatus.UPLOADING
+
+
+@pytest.mark.parametrize("exc", TRANSIENT_UPLOAD_ERRORS)
+def test_upload_retries_exhausted(mocker, video, exc):
+    """Once retries are exhausted the original error fails the video."""
+    mocker.patch("ui.models.tasks.async_send_notification_email")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mocker.patch("cloudsync.tasks.dropbox_api.stream_shared_link", side_effect=exc)
+    mocker.patch("cloudsync.tasks.boto3")
+    with pytest.raises(type(exc)):
+        stream_to_s3.apply(
+            (video.id,),
+            retries=settings.CLOUDSYNC_STREAM_S3_MAX_RETRIES,
+            throw=True,
+        ).get()
     assert Video.objects.get(id=video.id).status == VideoStatus.UPLOAD_FAILED
-    mock_update.assert_called_once()
-    assert mock_update.call_args == call(state="FAILURE", task_id=None)
+
+
+@pytest.mark.parametrize("exc", PERMANENT_HTTP_ERRORS)
+def test_upload_permanent_http_error_fails_fast(mocker, video, exc):
+    """4xx (and statusless) HTTP errors fail immediately without retrying."""
+    mocker.patch("ui.models.tasks.async_send_notification_email")
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+    mocker.patch("cloudsync.tasks.dropbox_api.stream_shared_link", side_effect=exc)
+    mocker.patch("cloudsync.tasks.boto3")
+    # retries=0 but the error is permanent, so it raises the error, not Retry.
+    with pytest.raises(HTTPError):
+        stream_to_s3.apply((video.id,), retries=0, throw=True).get()
+    assert Video.objects.get(id=video.id).status == VideoStatus.UPLOAD_FAILED
+
+
+def test_stream_to_s3_task_config():
+    """The task acks late, rejects on worker loss, and retries up to the max."""
+    assert stream_to_s3.acks_late is True
+    assert stream_to_s3.reject_on_worker_lost is True
+    assert stream_to_s3.max_retries == settings.CLOUDSYNC_STREAM_S3_MAX_RETRIES
 
 
 def test_upload_auth_failure(mocker, video):
@@ -289,29 +374,6 @@ def test_upload_auth_failure(mocker, video):
     )
     mocker.patch("cloudsync.tasks.boto3")
     with pytest.raises(dropbox_api.DropboxAuthError):
-        stream_to_s3(video.id)
-    assert Video.objects.get(id=video.id).status == VideoStatus.UPLOAD_FAILED
-    mock_update.assert_called_once()
-    assert mock_update.call_args == call(state="FAILURE", task_id=None)
-
-
-@pytest.mark.parametrize(
-    "exc",
-    [
-        requests.Timeout("read timed out"),
-        requests.ConnectionError("connection reset"),
-    ],
-)
-def test_upload_network_failure(mocker, video, exc):
-    """Video is marked failed when the download raises a network-level error."""
-    mocker.patch("ui.models.tasks.async_send_notification_email")
-    mock_update = mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
-    mocker.patch(
-        "cloudsync.tasks.dropbox_api.stream_shared_link",
-        side_effect=exc,
-    )
-    mocker.patch("cloudsync.tasks.boto3")
-    with pytest.raises(type(exc)):
         stream_to_s3(video.id)
     assert Video.objects.get(id=video.id).status == VideoStatus.UPLOAD_FAILED
     mock_update.assert_called_once()

--- a/cloudsync/tasks_test.py
+++ b/cloudsync/tasks_test.py
@@ -475,6 +475,24 @@ def test_upload_lock_contention_skips(mocker, video, upload_lock):
     assert Video.objects.get(id=video.id).status != VideoStatus.UPLOADING
 
 
+def test_upload_lock_contention_suppresses_chain(mocker, video, upload_lock):
+    """Giving up must not advance the chain, or transcode_from_s3 would run on an
+    object this task never uploaded (and poison the video out of UPLOADING)."""
+    upload_lock.acquire.return_value = False
+    mocker.patch("cloudsync.tasks.stream_to_s3.update_state")
+
+    # .run() (not __call__) so self.request is the context we push here; __call__
+    # would push its own bare request on top, mirroring nothing about a real worker.
+    stream_to_s3.push_request(chain=["transcode_from_s3"], callbacks=["cb"])
+    try:
+        result = stream_to_s3.run(video.id)
+        assert result is False
+        assert stream_to_s3.request.chain is None
+        assert stream_to_s3.request.callbacks is None
+    finally:
+        stream_to_s3.pop_request()
+
+
 def test_upload_releases_lock_on_error(mocker, video, upload_lock):
     """The lock is released even when the upload fails."""
     mocker.patch("ui.models.tasks.async_send_notification_email")

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -375,6 +375,14 @@ CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS = get_int(
     "CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS", 60
 )
 
+# Per-video lock serializing concurrent stream_to_s3 runs (acks_late can deliver
+# one upload to two workers). A short lease the progress callback heartbeats, so
+# it must exceed the refresh interval and frees itself soon after a worker dies.
+CLOUDSYNC_STREAM_S3_LOCK_TTL = get_int(
+    "CLOUDSYNC_STREAM_S3_LOCK_TTL",
+    max(120, CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS * 2),
+)
+
 VIDEO_CLOUDFRONT_DIST = get_string("VIDEO_CLOUDFRONT_DIST", "")
 VIDEO_CDN_DISTRIBUTION_ID = get_string("VIDEO_CDN_DISTRIBUTION_ID", "")
 VIDEO_S3_BUCKET = AWS_STORAGE_BUCKET_NAME = get_string("VIDEO_S3_BUCKET", "")
@@ -508,14 +516,11 @@ CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TIMEZONE = "UTC"
 CELERY_REDIS_MAX_CONNECTIONS = REDIS_MAX_CONNECTIONS
 
-# acks_late + reject_on_worker_lost on stream_to_s3 rely on broker redelivery if a
-# worker dies mid-upload. visibility_timeout must exceed the longest expected
-# successful upload, or a still-running upload gets redelivered to a second worker.
-# Default 3h. The fail_stuck_uploading_videos janitor is an *idle* timeout
-# (stream_to_s3 refreshes updated_at as it streams), so it only reaps genuinely
-# stalled uploads and does not conflict with this value.
+# Redis-broker redelivery window for unacked messages. The per-video lock (not
+# this value) prevents concurrent double-uploads, so it can be short for faster
+# crash recovery; floor is the longest task ETA/countdown (retry backoffs, ~10m).
 CELERY_BROKER_TRANSPORT_OPTIONS = {
-    "visibility_timeout": get_int("CELERY_BROKER_VISIBILITY_TIMEOUT", 60 * 60 * 3),
+    "visibility_timeout": get_int("CELERY_BROKER_VISIBILITY_TIMEOUT", 60 * 60),
 }
 CELERY_BEAT_SCHEDULE = {
     "update-youtube-statuses": {

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -363,6 +363,18 @@ AWS_S3_UPLOAD_TRANSFER_CONFIG = dict(
 # Janitor: fail videos stuck in UPLOADING past the threshold so they can be retried.
 STUCK_UPLOADING_THRESHOLD_HOURS = get_int("STUCK_UPLOADING_THRESHOLD_HOURS", 2)
 
+# stream_to_s3 retry tuning
+CLOUDSYNC_STREAM_S3_MAX_RETRIES = get_int("CLOUDSYNC_STREAM_S3_MAX_RETRIES", 2)
+CLOUDSYNC_STREAM_S3_RETRY_BACKOFF = get_int("CLOUDSYNC_STREAM_S3_RETRY_BACKOFF", 60)
+CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF = get_int(
+    "CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF", 600
+)
+# Minimum seconds between updated_at refreshes during an in-progress upload, so
+# the stuck-upload janitor sees actively streaming uploads as alive.
+CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS = get_int(
+    "CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS", 60
+)
+
 VIDEO_CLOUDFRONT_DIST = get_string("VIDEO_CLOUDFRONT_DIST", "")
 VIDEO_CDN_DISTRIBUTION_ID = get_string("VIDEO_CDN_DISTRIBUTION_ID", "")
 VIDEO_S3_BUCKET = AWS_STORAGE_BUCKET_NAME = get_string("VIDEO_S3_BUCKET", "")
@@ -495,6 +507,16 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TIMEZONE = "UTC"
 CELERY_REDIS_MAX_CONNECTIONS = REDIS_MAX_CONNECTIONS
+
+# acks_late + reject_on_worker_lost on stream_to_s3 rely on broker redelivery if a
+# worker dies mid-upload. visibility_timeout must exceed the longest expected
+# successful upload, or a still-running upload gets redelivered to a second worker.
+# Default 3h. The fail_stuck_uploading_videos janitor is an *idle* timeout
+# (stream_to_s3 refreshes updated_at as it streams), so it only reaps genuinely
+# stalled uploads and does not conflict with this value.
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    "visibility_timeout": get_int("CELERY_BROKER_VISIBILITY_TIMEOUT", 60 * 60 * 3),
+}
 CELERY_BEAT_SCHEDULE = {
     "update-youtube-statuses": {
         "task": "cloudsync.tasks.update_youtube_statuses",

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -369,20 +369,6 @@ CLOUDSYNC_STREAM_S3_RETRY_BACKOFF = get_int("CLOUDSYNC_STREAM_S3_RETRY_BACKOFF",
 CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF = get_int(
     "CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF", 600
 )
-# Minimum seconds between updated_at refreshes during an in-progress upload, so
-# the stuck-upload janitor sees actively streaming uploads as alive.
-CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS = get_int(
-    "CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS", 60
-)
-
-# Per-video lock serializing concurrent stream_to_s3 runs (acks_late can deliver
-# one upload to two workers). A short lease the progress callback heartbeats, so
-# it must exceed the refresh interval and frees itself soon after a worker dies.
-CLOUDSYNC_STREAM_S3_LOCK_TTL = get_int(
-    "CLOUDSYNC_STREAM_S3_LOCK_TTL",
-    max(120, CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS * 2),
-)
-
 VIDEO_CLOUDFRONT_DIST = get_string("VIDEO_CLOUDFRONT_DIST", "")
 VIDEO_CDN_DISTRIBUTION_ID = get_string("VIDEO_CDN_DISTRIBUTION_ID", "")
 VIDEO_S3_BUCKET = AWS_STORAGE_BUCKET_NAME = get_string("VIDEO_S3_BUCKET", "")

--- a/odl_video/settings.py
+++ b/odl_video/settings.py
@@ -8,6 +8,7 @@ import platform
 from urllib.parse import urljoin
 
 import dj_database_url
+from django.core.exceptions import ImproperlyConfigured
 from mitol.common.envs import import_settings_modules
 from redbeat import RedBeatScheduler
 
@@ -369,6 +370,39 @@ CLOUDSYNC_STREAM_S3_RETRY_BACKOFF = get_int("CLOUDSYNC_STREAM_S3_RETRY_BACKOFF",
 CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF = get_int(
     "CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF", 600
 )
+# How often the stream_to_s3 progress callback refreshes updated_at (janitor
+# heartbeat) and reacquires its lock lease. Must stay below the janitor threshold
+# so a healthy long-running upload isn't reaped as stuck.
+CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS = get_int(
+    "CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS", 60
+)
+# Redis-broker redelivery window for unacked messages (also applied to
+# CELERY_BROKER_TRANSPORT_OPTIONS below). The per-video lock — not this value —
+# prevents concurrent double-uploads, so it can be short for faster crash
+# recovery; floor is the longest task ETA (retry backoffs, ~10m).
+CELERY_BROKER_VISIBILITY_TIMEOUT = get_int("CELERY_BROKER_VISIBILITY_TIMEOUT", 60 * 60)
+# Per-video upload lock lease. Must exceed the refresh interval so the heartbeat
+# can reacquire before expiry, and must stay below CELERY_BROKER_VISIBILITY_TIMEOUT
+# so a dead worker's lock expires before redelivery (letting the retry re-acquire).
+CLOUDSYNC_STREAM_S3_LOCK_TTL = get_int("CLOUDSYNC_STREAM_S3_LOCK_TTL", 120)
+
+if CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS >= STUCK_UPLOADING_THRESHOLD_HOURS * 3600:
+    raise ImproperlyConfigured(
+        "CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS must be below the janitor "
+        "threshold (STUCK_UPLOADING_THRESHOLD_HOURS) or healthy uploads get reaped."
+    )
+if CLOUDSYNC_STREAM_S3_LOCK_TTL <= CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS:
+    raise ImproperlyConfigured(
+        "CLOUDSYNC_STREAM_S3_LOCK_TTL must exceed "
+        "CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS so the lock heartbeat can "
+        "reacquire before the lease expires."
+    )
+if CLOUDSYNC_STREAM_S3_LOCK_TTL >= CELERY_BROKER_VISIBILITY_TIMEOUT:
+    raise ImproperlyConfigured(
+        "CLOUDSYNC_STREAM_S3_LOCK_TTL must stay below "
+        "CELERY_BROKER_VISIBILITY_TIMEOUT so a dead worker's lock expires "
+        "before its task is redelivered."
+    )
 VIDEO_CLOUDFRONT_DIST = get_string("VIDEO_CLOUDFRONT_DIST", "")
 VIDEO_CDN_DISTRIBUTION_ID = get_string("VIDEO_CDN_DISTRIBUTION_ID", "")
 VIDEO_S3_BUCKET = AWS_STORAGE_BUCKET_NAME = get_string("VIDEO_S3_BUCKET", "")
@@ -502,11 +536,8 @@ CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TIMEZONE = "UTC"
 CELERY_REDIS_MAX_CONNECTIONS = REDIS_MAX_CONNECTIONS
 
-# Redis-broker redelivery window for unacked messages. The per-video lock (not
-# this value) prevents concurrent double-uploads, so it can be short for faster
-# crash recovery; floor is the longest task ETA/countdown (retry backoffs, ~10m).
 CELERY_BROKER_TRANSPORT_OPTIONS = {
-    "visibility_timeout": get_int("CELERY_BROKER_VISIBILITY_TIMEOUT", 60 * 60),
+    "visibility_timeout": CELERY_BROKER_VISIBILITY_TIMEOUT,
 }
 CELERY_BEAT_SCHEDULE = {
     "update-youtube-statuses": {


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Makes the Dropbox→S3 upload (`cloudsync.tasks.stream_to_s3`) resilient to transient failures and worker loss:

- **`acks_late=True` + `reject_on_worker_lost=True`** — an in-flight upload now survives a worker crash/redeploy (e.g. OOM-killed child) via broker redelivery, instead of silently dying in `UPLOADING` until the janitor reaps it.
- **Per-video upload lock (Redis)** — because `acks_late` redelivery can hand the same upload to a second worker while the first is still streaming, `stream_to_s3` takes a non-blocking per-`video_id` lock; a worker that can't acquire it gives up, since another worker already owns the upload. The lock is a short lease (`CLOUDSYNC_STREAM_S3_LOCK_TTL`, default 120s) refreshed by the progress callback as a heartbeat, so it frees itself shortly after a worker dies. This is what lets `visibility_timeout` be short without risking concurrent double-uploads to the same S3 key.
- **Retries (2 max, jittered exponential backoff)** on *transient* errors only: connection/timeout/chunked-encoding errors, HTTP **5xx/429/408**, and S3 `ClientError`/`BotoCoreError`. Permanent failures (HTTP 4xx like a revoked/missing link, malformed metadata, auth errors) still fail fast. The video is marked `UPLOAD_FAILED` only after retries are exhausted.
- **Janitor reconciliation** — the upload progress callback now throttle-refreshes `updated_at` (default 60s), so `fail_stuck_uploading_videos` acts as an *idle* timeout and no longer reaps healthy long-running uploads. This decouples it from the broker `visibility_timeout`.

New settings (all env-overridable): `CLOUDSYNC_STREAM_S3_MAX_RETRIES`, `CLOUDSYNC_STREAM_S3_RETRY_BACKOFF`, `CLOUDSYNC_STREAM_S3_RETRY_MAX_BACKOFF`, `CLOUDSYNC_UPLOAD_PROGRESS_REFRESH_SECONDS`, `CLOUDSYNC_STREAM_S3_LOCK_TTL`, `CELERY_BROKER_VISIBILITY_TIMEOUT`.

### How can this be tested?
1. Upload a video via the UI — confirm the video upload completes & transcodes normally.
2. **Retry path:** temporarily make `dropbox_api.stream_shared_link` raise `requests.ConnectionError`. Trigger an upload and confirm the worker logs `"Retrying stream_to_s3 after transient error"` with a jittered countdown, retries twice, then logs `"stream_to_s3 retries exhausted"` and the video flips to `UPLOAD_FAILED`.
3. **Immediate fail path:** temporarily make `dropbox_api.stream_shared_link` raise a `ValueError` → confirm it fails immediately with no retry.
4. **Worker-loss path:** set `CELERY_BROKER_VISIBILITY_TIMEOUT=300`, keeping the default `CLOUDSYNC_STREAM_S3_LOCK_TTL=120` (it must stay below the visibility timeout). Start a large upload, hard-kill the celery worker mid-stream (SIGKILL, so it can't release its lock), then restart it. The dead worker's lock auto-expires after ~120s; the broker re-queues the task at ~5 minutes; confirm the redelivered task re-acquires the lock and restarts the upload (status returns to `UPLOADING`, progress climbs from 0). Recovery requires lock-TTL expiry before redelivery — if the TTL were ≥ the visibility timeout, the redelivered task would find the stale lock still held, skip, and leave recovery to the idle janitor.

### Additional Context
- `visibility_timeout` defaults to 1h and is broker-wide (delays redelivery of *any* genuinely-dead task). It no longer needs to exceed the longest upload — the per-video lock prevents a redelivered copy from racing a still-running one — so it's free to be short for faster crash recovery. The only floor is the longest task ETA/countdown (the `stream_to_s3` retry backoffs, max ~10m); a countdown longer than this would be duplicated. Tune `CELERY_BROKER_VISIBILITY_TIMEOUT` as needed.
- `reject_on_worker_lost` redelivery is not bounded by `max_retries`; a file that reliably OOMs its worker could redeliver repeatedly (rate-capped by `visibility_timeout`, and the idle janitor still fails it).
