### PR TITLE
RTL harness and React upgrade prep 

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,5 +129,10 @@
     "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi --ignore $PWD/'static/js/flow/**/*.js' $PWD/'static/js/**/*.js'",
     "fmt:check": "prettier-eslint --list-different --no-semi --ignore $PWD/'static/js/flow/**/*.js' $PWD/'static/js/**/*.js'",
     "repl": "node --require ./scripts/repl.js"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "8.20.1",
+    "@testing-library/react": "12.1.5",
+    "@testing-library/user-event": "14.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "prop-types": "^15.5.10",
     "ramda": "^0.32.0",
     "react": "^15.6.1",
-    "react-addons-shallow-compare": "^15.6.0",
     "react-document-title": "^2.0.3",
     "react-dom": "^15.6.1",
     "react-dropbox-chooser": "^0.0.5",

--- a/scripts/test/js_test.sh
+++ b/scripts/test/js_test.sh
@@ -3,13 +3,13 @@ TMP_FILE=$(mktemp)
 export TMP_FILE
 
 if [[ -n $COVERAGE ]]; then
-	export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=html mocha"
+	export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=html mocha --exit"
 elif [[ -n $CODECOV ]]; then
-	export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha"
+	export CMD="node ./node_modules/nyc/bin/nyc.js --reporter=lcovonly -R spec mocha --exit"
 elif [[ -n $WATCH ]]; then
 	export CMD="node ./node_modules/mocha/bin/_mocha --watch"
 else
-	export CMD="node ./node_modules/mocha/bin/_mocha"
+	export CMD="node ./node_modules/mocha/bin/_mocha --exit"
 	if [[ -n $BAIL ]]; then
 		export CMD="$CMD --bail"
 	fi

--- a/static/js/actions/collectionsPagination.js
+++ b/static/js/actions/collectionsPagination.js
@@ -25,7 +25,7 @@ actionCreators.getPage = (opts: { page: number }) => {
   const thunk = async (dispatch: Dispatch) => {
     // Get filters from URL parameters
     const params = new URLSearchParams(window.location.search)
-    const searchQuery = params.get('search')
+    const searchQuery = params.get("search")
     // Construct query parameters
     const queryParams = { page }
     if (searchQuery) queryParams.search = searchQuery

--- a/static/js/actions/videoUi.js
+++ b/static/js/actions/videoUi.js
@@ -15,7 +15,9 @@ constants.SET_EDIT_VIDEO_DESC = qualifiedName("SET_EDIT_VIDEO_DESC")
 actionCreators.setEditVideoDesc = createAction(constants.SET_EDIT_VIDEO_DESC)
 
 constants.SET_EDIT_VIDEO_CTA_LINK = qualifiedName("SET_EDIT_VIDEO_CTA_LINK")
-actionCreators.setEditVideoCtaLink = createAction(constants.SET_EDIT_VIDEO_CTA_LINK)
+actionCreators.setEditVideoCtaLink = createAction(
+  constants.SET_EDIT_VIDEO_CTA_LINK
+)
 
 constants.SET_UPLOAD_SUBTITLE = qualifiedName("SET_UPLOAD_SUBTITLE")
 actionCreators.setUploadSubtitle = createAction(constants.SET_UPLOAD_SUBTITLE)

--- a/static/js/babelhook.js
+++ b/static/js/babelhook.js
@@ -1,6 +1,6 @@
 const { babelSharedLoader } = require("../../webpack.config.shared")
 const whatwgURL = require("whatwg-url")
-const { v4: uuidv4 } = require('uuid')
+const { v4: uuidv4 } = require("uuid")
 require("babel-polyfill")
 
 // Update presets to use Babel 7 format for testing
@@ -28,7 +28,7 @@ URL.createObjectURL = function() {
 function copyProps(src, target) {
   Object.defineProperties(target, {
     ...Object.getOwnPropertyDescriptors(src),
-    ...Object.getOwnPropertyDescriptors(target),
+    ...Object.getOwnPropertyDescriptors(target)
   })
 }
 
@@ -41,14 +41,17 @@ window.EventTarget.prototype.dispatchEvent = function(event) {
     return originalDispatchEvent.call(this, event)
   } catch (error) {
     // If it fails due to invalid event type, create a proper event
-    if (error.message.includes('not of type \'Event\'') || error.message.includes('parameter 1 is not of type \'Event\'')) {
-      let eventName = 'custom'
+    if (
+      error.message.includes("not of type 'Event'") ||
+      error.message.includes("parameter 1 is not of type 'Event'")
+    ) {
+      let eventName = "custom"
       let eventData = {}
 
-      if (typeof event === 'string') {
+      if (typeof event === "string") {
         eventName = event
-      } else if (event && typeof event === 'object') {
-        eventName = event.type || event.name || 'custom'
+      } else if (event && typeof event === "object") {
+        eventName = event.type || event.name || "custom"
         eventData = event
       }
 
@@ -79,13 +82,13 @@ const windowProxy = new Proxy(window, {
     }
 
     return Reflect.set(target, prop, value)
-  },
+  }
 })
 
 global.window = windowProxy
 global.document = windowProxy.document
 global.navigator = {
-  userAgent: "node.js",
+  userAgent: "node.js"
 }
 global.requestAnimationFrame = function(callback) {
   return setTimeout(callback, 0)

--- a/static/js/components/Footer.js
+++ b/static/js/components/Footer.js
@@ -52,8 +52,8 @@ export default class Footer extends React.Component<*, void> {
                   </a>
                 </div>
                 <address className="footer-address">
-                  Massachusetts Institute of Technology<br /> Cambridge, MA
-                  02139
+                  Massachusetts Institute of Technology
+                  <br /> Cambridge, MA 02139
                 </address>
               </div>
               <div className="mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet copyright">

--- a/static/js/components/VideoCard.js
+++ b/static/js/components/VideoCard.js
@@ -6,7 +6,12 @@ import _ from "lodash"
 import Menu from "./material/Menu"
 import Card from "./material/Card"
 import { makeVideoThumbnailUrl, makeVideoUrl } from "../lib/urls"
-import { videoIsProcessing, videoHasError, saveToDropbox, videoIsInFlight } from "../lib/video"
+import {
+  videoIsProcessing,
+  videoHasError,
+  saveToDropbox,
+  videoIsInFlight
+} from "../lib/video"
 import DropboxChooser from "react-dropbox-chooser"
 
 import type { Video } from "../flow/videoTypes"
@@ -24,9 +29,17 @@ type VideoCardProps = {
 }
 
 const VideoCard = (props: VideoCardProps) => {
-  const { video, isAdmin, isMenuOpen, showShareVideoDialog,
-    showEditVideoDialog, showDeleteVideoDialog,
-    showVideoMenu, hideVideoMenu, onReplaceVideo } = props
+  const {
+    video,
+    isAdmin,
+    isMenuOpen,
+    showShareVideoDialog,
+    showEditVideoDialog,
+    showDeleteVideoDialog,
+    showVideoMenu,
+    hideVideoMenu,
+    onReplaceVideo
+  } = props
 
   let dropboxTriggerEl: ?HTMLElement = null
   const triggerReplaceDropbox = () => {
@@ -110,9 +123,13 @@ const VideoCard = (props: VideoCardProps) => {
               multiselect={false}
               extensions={["video"]}
             >
-              <button ref={el => {
-                dropboxTriggerEl = el
-              }}>replace</button>
+              <button
+                ref={el => {
+                  dropboxTriggerEl = el
+                }}
+              >
+                replace
+              </button>
             </DropboxChooser>
           </div>
         )}

--- a/static/js/components/VideoCard_test.js
+++ b/static/js/components/VideoCard_test.js
@@ -71,9 +71,7 @@ describe("VideoCard", () => {
     ]
   ].forEach(
     ([adminPermissionSetting, expectedControlLabels, testDescriptor]) => {
-      it(`${testDescriptor} should be shown ${
-        expectedControlLabels.length
-      } option(s) for video controls`, () => {
+      it(`${testDescriptor} should be shown ${expectedControlLabels.length} option(s) for video controls`, () => {
         const isAdmin = adminPermissionSetting
         const wrapper = renderComponent({ isAdmin: isAdmin })
         const menuItems = wrapper.find("Menu").props().menuItems
@@ -86,7 +84,10 @@ describe("VideoCard", () => {
   )
 
   it("executes the right handlers for video actions (edit/share/etc.)", () => {
-    const wrapper = renderComponent({ isAdmin: true, onReplaceVideo: sandbox.stub() })
+    const wrapper = renderComponent({
+      isAdmin:        true,
+      onReplaceVideo: sandbox.stub()
+    })
     const menuItems = wrapper.find("Menu").props().menuItems
     menuItems[0].action()
     sinon.assert.called(showShareVideoDialogStub)
@@ -141,7 +142,10 @@ describe("VideoCard", () => {
 
     it("does not show Replace menu item when onReplaceVideo prop is absent, even if not in-flight", () => {
       videoIsInFlightStub.returns(false)
-      const wrapper = renderComponent({ isAdmin: true, onReplaceVideo: undefined })
+      const wrapper = renderComponent({
+        isAdmin:        true,
+        onReplaceVideo: undefined
+      })
       const menuItems = wrapper.find("Menu").props().menuItems
       assert.isFalse(menuItems.some(item => item.label === "Replace"))
     })

--- a/static/js/components/VideoList.js
+++ b/static/js/components/VideoList.js
@@ -48,7 +48,9 @@ export class VideoList extends React.Component<*, void> {
         isMenuOpen={this.props.isVideoMenuOpen(video.key)}
         onReplaceVideo={
           this.props.onReplaceVideo ?
-            file => this.props.onReplaceVideo && this.props.onReplaceVideo(video.key, file) :
+            file =>
+              this.props.onReplaceVideo &&
+                this.props.onReplaceVideo(video.key, file) :
             undefined
         }
       />

--- a/static/js/components/VideoPlayer.js
+++ b/static/js/components/VideoPlayer.js
@@ -31,9 +31,10 @@ const makeConfigForVideo = (
   startTime: number
 ): Object => ({
   autoplay: false,
-  poster:   !useYouTube && video.videothumbnail_set.length > 0 ?
-    video.videothumbnail_set[0].cloudfront_url :
-    undefined,
+  poster:
+    !useYouTube && video.videothumbnail_set.length > 0 ?
+      video.videothumbnail_set[0].cloudfront_url :
+      undefined,
   controls:    true,
   fluid:       embedded || false,
   playsinline: true,
@@ -297,7 +298,7 @@ class VideoPlayer extends React.Component<*, void> {
     if (action === "timeupdate") {
       // Track amount played in increments of 60 seconds
       const currentTime = this.player.currentTime()
-      const nearestMinute = parseInt((currentTime - currentTime % 60) / 60)
+      const nearestMinute = parseInt((currentTime - (currentTime % 60)) / 60)
       if (this.lastMinuteTracked !== nearestMinute) {
         sendGAEvent(
           "video",

--- a/static/js/components/VideoSubtitleCard.js
+++ b/static/js/components/VideoSubtitleCard.js
@@ -28,42 +28,41 @@ export default class VideoSubtitleCard extends React.Component<*, void> {
           <h4 className="mdc-typography--subheading2">Subtitles / CC</h4>
           <div className="actions">
             <div className="video-subtitle-list">
-              {video.videosubtitle_set.map(
-                (subtitle: VideoSubtitle, key) => {
-                  const filenameParts = subtitle.s3_object_key.split("/")
-                  const fullFilename = filenameParts[filenameParts.length - 1]
-                  const extension = fullFilename.split(".").pop()
-                  return (
-                    <div className="mdc-list-item" key={key}>
-                      <span className="video-subtitle-filename">
-                        {fullFilename.slice(0, 10)}..._{subtitle.language}.{extension}
-                      </span>
-                      <span className="video-subtitle-language">
-                        ({subtitle.language_name})
-                      </span>
+              {video.videosubtitle_set.map((subtitle: VideoSubtitle, key) => {
+                const filenameParts = subtitle.s3_object_key.split("/")
+                const fullFilename = filenameParts[filenameParts.length - 1]
+                const extension = fullFilename.split(".").pop()
+                return (
+                  <div className="mdc-list-item" key={key}>
+                    <span className="video-subtitle-filename">
+                      {fullFilename.slice(0, 10)}..._{subtitle.language}.
+                      {extension}
+                    </span>
+                    <span className="video-subtitle-language">
+                      ({subtitle.language_name})
+                    </span>
+                    <span className="video-subtitle-button">
+                      <a
+                        className="mdc-list-item mdc-link download-link"
+                        href={makeVideoSubtitleUrl(subtitle)}
+                        alt="Download this subtitle"
+                      >
+                        <i className="material-icons">file_download</i>
+                      </a>
+                    </span>
+                    {isAdmin && (
                       <span className="video-subtitle-button">
                         <a
-                          className="mdc-list-item mdc-link download-link"
-                          href={makeVideoSubtitleUrl(subtitle)}
-                          alt="Download this subtitle"
+                          className="mdc-list-item mdc-link delete-btn"
+                          onClick={() => deleteVideoSubtitle(subtitle.id)}
                         >
-                          <i className="material-icons">file_download</i>
+                          <i className="material-icons">delete</i>
                         </a>
                       </span>
-                      {isAdmin && (
-                        <span className="video-subtitle-button">
-                          <a
-                            className="mdc-list-item mdc-link delete-btn"
-                            onClick={() => deleteVideoSubtitle(subtitle.id)}
-                          >
-                            <i className="material-icons">delete</i>
-                          </a>
-                        </span>
-                      )}
-                    </div>
-                  )
-                }
-              )}
+                    )}
+                  </div>
+                )
+              })}
             </div>
             <div className="video-subtitle-upload">
               {isAdmin && (

--- a/static/js/components/analytics/AnalyticsChart.js
+++ b/static/js/components/analytics/AnalyticsChart.js
@@ -110,7 +110,9 @@ export class AnalyticsChart extends React.Component {
     const xMax =
       duration > 0 ?
         duration / 60 :
-        analyticsData.times ? analyticsData.times.slice(-1)[0] : 0
+        analyticsData.times ?
+          analyticsData.times.slice(-1)[0] :
+          0
     return (
       <VictoryChart
         {...dimensions}

--- a/static/js/components/analytics/AnalyticsInfoTable.js
+++ b/static/js/components/analytics/AnalyticsInfoTable.js
@@ -86,7 +86,7 @@ export default class AnalyticsInfoTable extends React.Component<*, void> {
         },
         ...analyticsData.channels.map(channel => {
           const numViews = parseFloat(viewsAtTime[channel] || 0)
-          const percent = totalViews === 0 ? 0 : numViews / totalViews * 100
+          const percent = totalViews === 0 ? 0 : (numViews / totalViews) * 100
           return {
             key:       channel,
             className: `channel ${channel}`,

--- a/static/js/components/dialogs/CollectionFormDialog.js
+++ b/static/js/components/dialogs/CollectionFormDialog.js
@@ -63,7 +63,9 @@ export class CollectionFormDialog extends React.Component<*, void> {
       return
     }
     try {
-      const response = await dispatch(actions.potentialCollectionOwners.get(collectionKey))
+      const response = await dispatch(
+        actions.potentialCollectionOwners.get(collectionKey)
+      )
       this.setState({ users: response.users || [] })
     } catch (error) {
       console.error("Error fetching users:", error)

--- a/static/js/components/dialogs/CollectionFormDialog_test.js
+++ b/static/js/components/dialogs/CollectionFormDialog_test.js
@@ -53,12 +53,14 @@ describe("CollectionFormDialog", () => {
     uiState = INITIAL_UI_STATE
 
     // Mock the users API response
-    sandbox.stub(api, "getPotentialCollectionOwners").returns(Promise.resolve({
-      users: [
-        { id: 1, username: "user1", email: "user1@example.com" },
-        { id: 2, username: "user2", email: "user2@example.com" }
-      ]
-    }))
+    sandbox.stub(api, "getPotentialCollectionOwners").returns(
+      Promise.resolve({
+        users: [
+          { id: 1, username: "user1", email: "user1@example.com" },
+          { id: 2, username: "user2", email: "user2@example.com" }
+        ]
+      })
+    )
   })
 
   afterEach(() => {
@@ -75,7 +77,7 @@ describe("CollectionFormDialog", () => {
             open={true}
             hideDialog={hideDialogStub}
             isEdxCourseAdmin={true}
-            collectionKey={'00000000-0000-0000-0000-000000000000'}
+            collectionKey={"00000000-0000-0000-0000-000000000000"}
             {...props}
           />
         </div>
@@ -138,7 +140,8 @@ describe("CollectionFormDialog", () => {
       it("stores form submission errors in state", async () => {
         const wrapper = await renderComponent()
         let expectedActionTypes
-        const expectedErrorMessage = "Failed to parse URL from /api/v0/collections/"
+        const expectedErrorMessage =
+          "Failed to parse URL from /api/v0/collections/"
         if (isNew) {
           expectedActionTypes = [
             actions.collectionsList.post.requestType,
@@ -434,7 +437,11 @@ describe("CollectionFormDialog", () => {
           apiStub.firstCall.args[0] :
           apiStub.firstCall.args[1]
 
-        assert.equal(payloadArg.owner, 2, "Owner ID should be 2 in the API request")
+        assert.equal(
+          payloadArg.owner,
+          2,
+          "Owner ID should be 2 in the API request"
+        )
       })
 
       it("fetches users on component mount", async () => {
@@ -442,21 +449,25 @@ describe("CollectionFormDialog", () => {
         sandbox.restore()
 
         // Create a new getPotentialCollectionOwnersStub
-        sandbox.stub(api, "getPotentialCollectionOwners").returns(Promise.resolve({
-          users: [
-            { id: 1, username: "user1", email: "user1@example.com" },
-            { id: 2, username: "user2", email: "user2@example.com" }
-          ]
-        }))
+        sandbox.stub(api, "getPotentialCollectionOwners").returns(
+          Promise.resolve({
+            users: [
+              { id: 1, username: "user1", email: "user1@example.com" },
+              { id: 2, username: "user2", email: "user2@example.com" }
+            ]
+          })
+        )
 
         // Create a dispatch stub that returns the expected data
         const dispatchStub = sandbox.stub()
-        dispatchStub.returns(Promise.resolve({
-          users: [
-            { id: 1, username: "user1", email: "user1@example.com" },
-            { id: 2, username: "user2", email: "user2@example.com" }
-          ]
-        }))
+        dispatchStub.returns(
+          Promise.resolve({
+            users: [
+              { id: 1, username: "user1", email: "user1@example.com" },
+              { id: 2, username: "user2", email: "user2@example.com" }
+            ]
+          })
+        )
 
         const wrapper = shallow(
           <UnconnectedCollectionFormDialog
@@ -464,7 +475,7 @@ describe("CollectionFormDialog", () => {
             history={{ push: sandbox.stub() }}
             collectionUi={{ isNew: true }}
             collectionForm={{}}
-            collectionKey={'00000000-0000-0000-0000-000000000000'}
+            collectionKey={"00000000-0000-0000-0000-000000000000"}
           />
         )
 
@@ -477,12 +488,14 @@ describe("CollectionFormDialog", () => {
         // Reinitialize the sandbox with the global stubs for other tests
         sandbox.restore()
         sandbox = sinon.createSandbox()
-        sandbox.stub(api, "getPotentialCollectionOwners").returns(Promise.resolve({
-          users: [
-            { id: 1, username: "user1", email: "user1@example.com" },
-            { id: 2, username: "user2", email: "user2@example.com" }
-          ]
-        }))
+        sandbox.stub(api, "getPotentialCollectionOwners").returns(
+          Promise.resolve({
+            users: [
+              { id: 1, username: "user1", email: "user1@example.com" },
+              { id: 2, username: "user2", email: "user2@example.com" }
+            ]
+          })
+        )
       })
 
       it("handles API errors when fetching users", async () => {
@@ -502,7 +515,7 @@ describe("CollectionFormDialog", () => {
             history={{ push: sandbox.stub() }}
             collectionUi={{ isNew: true }}
             collectionForm={{}}
-            collectionKey={'00000000-0000-0000-0000-000000000000'}
+            collectionKey={"00000000-0000-0000-0000-000000000000"}
           />
         )
 
@@ -539,7 +552,10 @@ describe("CollectionFormDialog", () => {
 
         sinon.assert.notCalled(dispatchStub)
         assert.equal(wrapper.state().users.length, 0)
-        sinon.assert.calledWithMatch(consoleLogStub, "No collection key provided, skipping potential owner fetch.")
+        sinon.assert.calledWithMatch(
+          consoleLogStub,
+          "No collection key provided, skipping potential owner fetch."
+        )
       })
     })
   }

--- a/static/js/components/dialogs/DeleteVideoDialog.js
+++ b/static/js/components/dialogs/DeleteVideoDialog.js
@@ -70,7 +70,9 @@ export class DeleteVideoDialog extends React.Component<*, void> {
 }
 
 export const mapStateToProps = (state: Object, ownProps: Object) => {
-  const { collectionUi: { selectedVideoKey } } = state
+  const {
+    collectionUi: { selectedVideoKey }
+  } = state
   const { collection, video } = ownProps
 
   // The dialog needs a Video object passed in as a prop. Depending on the container that includes this dialog,

--- a/static/js/components/dialogs/DeleteVideoDialog_test.js
+++ b/static/js/components/dialogs/DeleteVideoDialog_test.js
@@ -190,9 +190,7 @@ describe("DeleteVideoDialogTests", () => {
         generateCommonConfirmDeletionTests()
 
         it("assigns window.location", () => {
-          const expectedLocation = `someOrigin/collections/${
-            video.collection_key
-          }/`
+          const expectedLocation = `someOrigin/collections/${video.collection_key}/`
           assert.equal(stubs.window.location, expectedLocation)
         })
       })

--- a/static/js/components/dialogs/EditVideoFormDialog.js
+++ b/static/js/components/dialogs/EditVideoFormDialog.js
@@ -172,7 +172,11 @@ class EditVideoFormDialog extends React.Component<*, DialogState> {
   handleThumbnailChange = (event: Object) => {
     const file = event.target.files[0]
     if (!file) return
-    if (file.type !== "image/jpeg" && file.type !== "image/jpg" && file.type !== "image/png") {
+    if (
+      file.type !== "image/jpeg" &&
+      file.type !== "image/jpg" &&
+      file.type !== "image/png"
+    ) {
       const { thumbnailPreviewUrl } = this.state
       if (thumbnailPreviewUrl) URL.revokeObjectURL(thumbnailPreviewUrl)
       this.setState({
@@ -187,11 +191,12 @@ class EditVideoFormDialog extends React.Component<*, DialogState> {
       const { thumbnailPreviewUrl } = this.state
       if (thumbnailPreviewUrl) URL.revokeObjectURL(thumbnailPreviewUrl)
       const maxBytes = SETTINGS.thumbnail_upload_max_size
-      const maxSizeStr = maxBytes >= 1024 * 1024 ?
-        `${Math.floor(maxBytes / (1024 * 1024))} MB` :
-        maxBytes >= 1024 ?
-          `${Math.floor(maxBytes / 1024)} KB` :
-          `${maxBytes} bytes`
+      const maxSizeStr =
+        maxBytes >= 1024 * 1024 ?
+          `${Math.floor(maxBytes / (1024 * 1024))} MB` :
+          maxBytes >= 1024 ?
+            `${Math.floor(maxBytes / 1024)} KB` :
+            `${maxBytes} bytes`
       this.setState({
         thumbnailError:      `This image is too large (max ${maxSizeStr}). Please reduce the file size and try again.`,
         thumbnailFile:       null,
@@ -366,7 +371,8 @@ class EditVideoFormDialog extends React.Component<*, DialogState> {
             <p
               style={{ color: "#666", margin: "4px 0 0 0", fontSize: "0.8em" }}
             >
-              JPEG or PNG, max {SETTINGS.thumbnail_upload_max_size / (1024 * 1024)} MB
+              JPEG or PNG, max{" "}
+              {SETTINGS.thumbnail_upload_max_size / (1024 * 1024)} MB
             </p>
           )}
         </div>

--- a/static/js/components/dialogs/ShareVideoDialog.js
+++ b/static/js/components/dialogs/ShareVideoDialog.js
@@ -86,7 +86,10 @@ class ShareVideoDialog extends React.Component<*, void> {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { videoUi, collectionUi: { selectedVideoKey } } = state
+  const {
+    videoUi,
+    collectionUi: { selectedVideoKey }
+  } = state
   let { video } = ownProps
 
   // The dialog needs a video key passed in as a prop. Depending on the container that includes this dialog,

--- a/static/js/components/material/Dialog.js
+++ b/static/js/components/material/Dialog.js
@@ -44,10 +44,9 @@ export default class Dialog extends React.Component<*, void> {
     this.destroyMdc()
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps(nextProps: DialogProps) {
-    if (this.props.open !== nextProps.open) {
-      if (nextProps.open) {
+  componentDidUpdate(prevProps: DialogProps) {
+    if (prevProps.open !== this.props.open) {
+      if (this.props.open) {
         this.showMdc()
       } else {
         this.destroyMdc()

--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -58,11 +58,10 @@ class Drawer extends React.Component<*, void> {
     }
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps(nextProps: DrawerProps) {
+  componentDidUpdate(prevProps: DrawerProps) {
     if (this.drawer) {
-      if (this.props.open !== nextProps.open) {
-        this.drawer.open = nextProps.open
+      if (prevProps.open !== this.props.open) {
+        this.drawer.open = this.props.open
       }
     }
   }

--- a/static/js/components/material/Drawer.js
+++ b/static/js/components/material/Drawer.js
@@ -83,7 +83,9 @@ class Drawer extends React.Component<*, void> {
             >
               {SETTINGS.email ?
                 SETTINGS.email :
-                SETTINGS.user ? SETTINGS.user : "Not logged in"}
+                SETTINGS.user ?
+                  SETTINGS.user :
+                  "Not logged in"}
             </a>
           </nav>
           <header className="mdc-drawer__header">

--- a/static/js/components/material/Menu.js
+++ b/static/js/components/material/Menu.js
@@ -25,11 +25,10 @@ export default class Menu extends React.Component<*, void> {
     }
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps(nextProps: MenuProps) {
+  componentDidUpdate(prevProps: MenuProps) {
     if (this.menu) {
-      if (this.props.open !== nextProps.open) {
-        this.menu.open = nextProps.open
+      if (prevProps.open !== this.props.open) {
+        this.menu.open = this.props.open
       }
     }
   }

--- a/static/js/containers/CollectionDetailPage.js
+++ b/static/js/containers/CollectionDetailPage.js
@@ -28,7 +28,10 @@ import type { Video } from "../flow/videoTypes"
 import type { CommonUiState } from "../reducers/commonUi"
 import * as commonUiActions from "../actions/commonUi"
 import VideoSaverScript from "../components/VideoSaverScript"
-import { clearCollectionErrors, clearCollectionData } from "../actions/collectionUi"
+import {
+  clearCollectionErrors,
+  clearCollectionData
+} from "../actions/collectionUi"
 import { replaceVideoFromDropbox } from "../lib/api"
 
 export class CollectionDetailPage extends React.Component<*, void> {
@@ -108,7 +111,9 @@ export class CollectionDetailPage extends React.Component<*, void> {
               {`${collection.title} (${videos.length})`}
             </h1>
             <div className="collection-owner">
-              <span className="mdc-typography--subheading1">Owner: {collection.owner_info.username}</span>
+              <span className="mdc-typography--subheading1">
+                Owner: {collection.owner_info.username}
+              </span>
             </div>
           </div>
           {this.renderTools(isCollectionAdmin)}
@@ -124,7 +129,11 @@ export class CollectionDetailPage extends React.Component<*, void> {
   }
 
   renderAdminTools() {
-    return [this.renderSettingsFrob(), this.renderSyncWithEdXFrob(), this.renderUploadFrob()]
+    return [
+      this.renderSettingsFrob(),
+      this.renderSyncWithEdXFrob(),
+      this.renderUploadFrob()
+    ]
   }
 
   renderSettingsFrob() {
@@ -177,7 +186,9 @@ export class CollectionDetailPage extends React.Component<*, void> {
         className="sync-edx-btn mdc-button--unelevated mdc-ripple-upgraded"
         onClick={this.handleSyncWithEdX.bind(this)}
       >
-        <i className="material-icons" style={{marginRight: "8px"}}>sync</i>
+        <i className="material-icons" style={{ marginRight: "8px" }}>
+          sync
+        </i>
         Sync Videos with edX
       </Button>
     )
@@ -196,24 +207,29 @@ export class CollectionDetailPage extends React.Component<*, void> {
     const { dispatch, collection } = this.props
     try {
       await replaceVideoFromDropbox(videoKey, file)
-      dispatch(actions.toast.addMessage({
-        message: {
-          key:     "replace-video-started",
-          content: "Video replacement has started. You will receive an email when it is ready.",
-          icon:    "check"
-        }
-      }))
+      dispatch(
+        actions.toast.addMessage({
+          message: {
+            key:     "replace-video-started",
+            content:
+              "Video replacement has started. You will receive an email when it is ready.",
+            icon: "check"
+          }
+        })
+      )
       if (collection) {
         dispatch(actions.collections.get(collection.key))
       }
     } catch (error) {
-      dispatch(actions.toast.addMessage({
-        message: {
-          key:     "replace-video-error",
-          content: "Failed to start video replacement. Please try again.",
-          icon:    "error"
-        }
-      }))
+      dispatch(
+        actions.toast.addMessage({
+          message: {
+            key:     "replace-video-error",
+            content: "Failed to start video replacement. Please try again.",
+            icon:    "error"
+          }
+        })
+      )
     }
   }
 
@@ -232,13 +248,16 @@ export class CollectionDetailPage extends React.Component<*, void> {
       await syncCollectionVideosWithEdX(collectionKey)
 
       // Show success message to the user
-      dispatch(actions.toast.addMessage({
-        message: {
-          key:     "scheduled-sync",
-          content: "Videos are being synced with edX. This may take a few minutes.",
-          icon:    "check"
-        }
-      }))
+      dispatch(
+        actions.toast.addMessage({
+          message: {
+            key:     "scheduled-sync",
+            content:
+              "Videos are being synced with edX. This may take a few minutes.",
+            icon: "check"
+          }
+        })
+      )
     } catch (error) {
       // Extract error message if available
       let errorMessage = "Failed to sync videos with edX"
@@ -248,13 +267,15 @@ export class CollectionDetailPage extends React.Component<*, void> {
       }
 
       // Show error message to the user
-      dispatch(actions.toast.addMessage({
-        message: {
-          key:     "sync-error",
-          content: errorMessage,
-          icon:    "error"
-        }
-      }))
+      dispatch(
+        actions.toast.addMessage({
+          message: {
+            key:     "sync-error",
+            content: errorMessage,
+            icon:    "error"
+          }
+        })
+      )
     }
   }
 
@@ -281,7 +302,9 @@ export class CollectionDetailPage extends React.Component<*, void> {
         showVideoMenu={this.showVideoMenu.bind(this)}
         hideVideoMenu={this.hideVideoMenu.bind(this)}
         isVideoMenuOpen={this.isVideoMenuOpen.bind(this)}
-        onReplaceVideo={isAdmin ? this.handleReplaceVideo.bind(this) : undefined}
+        onReplaceVideo={
+          isAdmin ? this.handleReplaceVideo.bind(this) : undefined
+        }
       />
     )
   }
@@ -354,7 +377,8 @@ export const mapStateToProps = (state: any, ownProps: any) => {
   const { collections, commonUi } = state
 
   const collectionKey = match.params.collectionKey
-  const collection = collections.data && collections.data.key ? collections.data : null
+  const collection =
+    collections.data && collections.data.key ? collections.data : null
   const collectionError = collections.error || null
   const collectionChanged = collection && collection.key !== collectionKey
   const isCollectionAdmin = collection && collection.is_admin

--- a/static/js/containers/CollectionDetailPage_test.js
+++ b/static/js/containers/CollectionDetailPage_test.js
@@ -59,7 +59,10 @@ describe("CollectionDetailPage", () => {
     describe("when selecting collection", () => {
       const testDefs = [
         { opts: { loaded: true, data: undefined }, expected: null },
-        { opts: { loaded: true, data: { key: "somedata" } }, expected: { key: "somedata" } },
+        {
+          opts:     { loaded: true, data: { key: "somedata" } },
+          expected: { key: "somedata" }
+        },
         { opts: { loaded: false, data: undefined }, expected: null },
         { opts: { loaded: false, data: {} }, expected: null }
       ]
@@ -340,7 +343,11 @@ describe("CollectionDetailPage", () => {
 
     describe("renderAdminTools", () => {
       beforeEach(() => {
-        stubRenderingMethods(["renderSettingsFrob", "renderSyncWithEdXFrob", "renderUploadFrob"])
+        stubRenderingMethods([
+          "renderSettingsFrob",
+          "renderSyncWithEdXFrob",
+          "renderUploadFrob"
+        ])
       })
 
       const renderAdminTools = ({ extraProps = {} } = {}) => {
@@ -724,7 +731,9 @@ describe("CollectionDetailPage", () => {
         event = {
           preventDefault: sandbox.stub()
         }
-        sandbox.stub(require("../lib/api"), "syncCollectionVideosWithEdX").returns(Promise.resolve())
+        sandbox
+          .stub(require("../lib/api"), "syncCollectionVideosWithEdX")
+          .returns(Promise.resolve())
         page = new CollectionDetailPage(props)
       })
 
@@ -748,8 +757,9 @@ describe("CollectionDetailPage", () => {
           actions.toast.addMessage({
             message: {
               key:     "scheduled-sync",
-              content: "Videos are being synced with edX. This may take a few minutes.",
-              icon:    "check"
+              content:
+                "Videos are being synced with edX. This may take a few minutes.",
+              icon: "check"
             }
           })
         )
@@ -757,7 +767,9 @@ describe("CollectionDetailPage", () => {
 
       it("dispatches error toast message when API call fails", async () => {
         const error = { error: "Custom error message" }
-        require("../lib/api").syncCollectionVideosWithEdX.returns(Promise.reject(error))
+        require("../lib/api").syncCollectionVideosWithEdX.returns(
+          Promise.reject(error)
+        )
 
         await page.handleSyncWithEdX(event)
         sinon.assert.calledWith(
@@ -773,7 +785,9 @@ describe("CollectionDetailPage", () => {
       })
 
       it("dispatches generic error message when API call fails without error details", async () => {
-        require("../lib/api").syncCollectionVideosWithEdX.returns(Promise.reject({}))
+        require("../lib/api").syncCollectionVideosWithEdX.returns(
+          Promise.reject({})
+        )
 
         await page.handleSyncWithEdX(event)
         sinon.assert.calledWith(
@@ -796,7 +810,9 @@ describe("CollectionDetailPage", () => {
 
         const result = await page.handleSyncWithEdX(event)
         assert.isNull(result)
-        sinon.assert.notCalled(require("../lib/api").syncCollectionVideosWithEdX)
+        sinon.assert.notCalled(
+          require("../lib/api").syncCollectionVideosWithEdX
+        )
       })
     })
 
@@ -816,7 +832,10 @@ describe("CollectionDetailPage", () => {
       it("displays the owner username", () => {
         const ownerElement = wrapper.find(".collection-owner")
         assert.isTrue(ownerElement.exists())
-        assert.include(ownerElement.text(), `Owner: ${collection.owner_info.username}`)
+        assert.include(
+          ownerElement.text(),
+          `Owner: ${collection.owner_info.username}`
+        )
       })
     })
   })

--- a/static/js/containers/CollectionListPage.js
+++ b/static/js/containers/CollectionListPage.js
@@ -79,7 +79,7 @@ export class CollectionListPage extends React.Component<*, void> {
   renderSearchInput() {
     // Get initial search value from URL if present
     const params = new URLSearchParams(window.location.search)
-    const searchQuery = params.get('search') || ''
+    const searchQuery = params.get("search") || ""
 
     return (
       <div className="collection-search">
@@ -105,14 +105,14 @@ export class CollectionListPage extends React.Component<*, void> {
     // Update URL with search params
     const params = new URLSearchParams(window.location.search)
     if (searchText) {
-      params.set('search', searchText)
+      params.set("search", searchText)
     } else {
-      params.delete('search')
+      params.delete("search")
     }
 
     // Push new URL without reloading the page
     const newUrl = `${window.location.pathname}?${params.toString()}`
-    window.history.pushState({ path: newUrl }, '', newUrl)
+    window.history.pushState({ path: newUrl }, "", newUrl)
 
     // Trigger a re-fetch of collections with the search parameter
     this.props.dispatch(actions.collectionsPagination.getPage({ page: 1 }))
@@ -148,7 +148,8 @@ export class CollectionListPage extends React.Component<*, void> {
                   {collection.title}
                 </Link>
                 <span className="mdc-list-item__secondary-text">
-                  {collection.video_count} Videos | Owner: {collection.owner_info.username}
+                  {collection.video_count} Videos | Owner:{" "}
+                  {collection.owner_info.username}
                 </span>
               </span>
             </li>

--- a/static/js/containers/CollectionListPage_test.js
+++ b/static/js/containers/CollectionListPage_test.js
@@ -59,7 +59,7 @@ describe("CollectionListPage", () => {
       [
         actions.collectionsList.get.requestType,
         actions.collectionsList.get.successType,
-        collectionsPaginationActions.constants.REQUEST_GET_PAGE,
+        collectionsPaginationActions.constants.REQUEST_GET_PAGE
       ],
       () => {
         wrapper = mount(
@@ -114,7 +114,10 @@ describe("CollectionListPage", () => {
     it("has video counts per collection", async () => {
       const wrapper = await renderPage()
       const counts = wrapper.find(".mdc-list-item__secondary-text")
-      assert.equal(counts.at(0).text(), `${collections[0].video_count} Videos | Owner: ${collections[0].owner_info.username}`)
+      assert.equal(
+        counts.at(0).text(),
+        `${collections[0].video_count} Videos | Owner: ${collections[0].owner_info.username}`
+      )
     })
   })
 

--- a/static/js/containers/ErrorPage.js
+++ b/static/js/containers/ErrorPage.js
@@ -40,7 +40,8 @@ export default class ErrorPage extends React.Component<*, void> {
             continues to happen please{" "}
           <a href={`mailto:${SETTINGS.support_email_address}`}>
               Contact Support
-          </a>.
+          </a>
+            .
         </span>
       )
     }

--- a/static/js/containers/ErrorPage_test.js
+++ b/static/js/containers/ErrorPage_test.js
@@ -2,16 +2,16 @@
 /* global SETTINGS */
 import React from "react"
 import sinon from "sinon"
-import { mount } from "enzyme"
 import { assert } from "chai"
+import { screen } from "@testing-library/react"
 import configureTestStore from "redux-asserts"
-import { Provider } from "react-redux"
 
 import * as api from "../lib/api"
 import ErrorPage from "./ErrorPage"
 import { actions } from "../actions"
 import rootReducer from "../reducers"
 import { makeCollection } from "../factories/collection"
+import renderWithProviders from "../testUtils/renderWithProviders"
 
 describe("ErrorPage", () => {
   let sandbox, store, collections, listenForActions
@@ -32,7 +32,7 @@ describe("ErrorPage", () => {
   })
 
   const renderPage = async (props = {}) => {
-    let wrapper
+    let result
 
     await listenForActions(
       [
@@ -40,15 +40,10 @@ describe("ErrorPage", () => {
         actions.collectionsList.get.successType
       ],
       () => {
-        wrapper = mount(
-          <Provider store={store}>
-            <ErrorPage {...props} />
-          </Provider>
-        )
+        result = renderWithProviders(<ErrorPage {...props} />, { store })
       }
     )
-    if (!wrapper) throw new Error("Never will happen, make flow happy")
-    return wrapper
+    return result
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -72,21 +67,18 @@ describe("ErrorPage", () => {
   ]) {
     it(`renders an error for status=${status}`, async () => {
       SETTINGS.status_code = status
-      const wrapper = await renderPage()
-      assert.equal(
-        wrapper
-          .find(".error-page .title")
-          .text()
-          .trim(),
-        title
-      )
-      assert.equal(
-        wrapper
-          .find(".error-page .message")
-          .text()
-          .trim(),
-        message
-      )
+      const { container } = await renderPage()
+
+      // The title is a single text node, so the accessible query works.
+      assert.isNotNull(screen.getByText(title))
+
+      // The message is deliberately not queried with getByText: for status
+      // 500 the copy is split across a <span>, an <a>, and a trailing text
+      // node, so no single element holds the whole string. textContent on
+      // the container element is the documented RTL fallback for that case.
+      const messageEl = container.querySelector(".error-page .message")
+      assert.isNotNull(messageEl, "expected a .message element to render")
+      assert.equal(messageEl.textContent.trim(), message)
     })
   }
 })

--- a/static/js/containers/TermsPage.js
+++ b/static/js/containers/TermsPage.js
@@ -74,7 +74,8 @@ class TermsPage extends React.Component<*, void> {
                     href="http://web.mit.edu/copyright/"
                   >
                     MIT's copyright guidelines
-                  </a>.
+                  </a>
+                  .
                 </li>
                 <li>
                   <span className="terms-strong">
@@ -85,7 +86,8 @@ class TermsPage extends React.Component<*, void> {
                   us at{" "}
                   <a href="mailto:odl-video-support@mit.edu">
                     odl-video-support@mit.edu
-                  </a>.
+                  </a>
+                  .
                 </li>
                 <li>
                   <span className="terms-strong">
@@ -122,7 +124,8 @@ class TermsPage extends React.Component<*, void> {
                 >
                   {" "}
                   YouTube Terms of Service
-                </a>.
+                </a>
+                .
               </div>
               <div className="terms-div">
                 Visitors to the site merely wishing to view content do not need
@@ -202,14 +205,16 @@ class TermsPage extends React.Component<*, void> {
                   rel="noopener noreferrer"
                 >
                   Touchstone Collaboration account
-                </a>. Users are bound by the{" "}
+                </a>
+                . Users are bound by the{" "}
                 <a
                   href="https://idp.touchstonenetwork.net/cams/terms"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
                   Touchstone Rules of Use
-                </a>.
+                </a>
+                .
               </div>
               <h3 className="terms-subheading">Privacy</h3>
               <div className="terms-div">
@@ -238,7 +243,8 @@ class TermsPage extends React.Component<*, void> {
                   rel="noopener noreferrer"
                 >
                   Google's privacy policy
-                </a>.
+                </a>
+                .
               </div>
               <h3 className="terms-subheading">
                 Hold Harmless And Indemnification
@@ -296,8 +302,9 @@ class TermsPage extends React.Component<*, void> {
                 following address:{" "}
                 <a href="mailto:odl-video-support@mit.edu">
                   odl-video-support@mit.edu
-                </a>. When you do remove your content, the license described
-                above will automatically expire.
+                </a>
+                . When you do remove your content, the license described above
+                will automatically expire.
               </div>
               <h3 className="terms-subheading">
                 Copyright And Other Intellectual Property
@@ -375,8 +382,9 @@ class TermsPage extends React.Component<*, void> {
                   rel="noopener noreferrer"
                 >
                   http://www.creativecommons.org/
-                </a>) or on an all rights reserved basis. You agree to be bound
-                by the terms of each license. As a creator of user-generated
+                </a>
+                ) or on an all rights reserved basis. You agree to be bound by
+                the terms of each license. As a creator of user-generated
                 content or as a passive user of the ODL Video site, you may not
                 modify, publish, transmit, participate in the transfer or sale
                 of, reproduce, create derivative works of, distribute, publicly
@@ -398,7 +406,8 @@ class TermsPage extends React.Component<*, void> {
                 to{" "}
                 <a href="mailto:odl-video-support@mit.edu">
                   odl-video-support@mit.edu
-                </a>:
+                </a>
+                :
                 <ul className="terms-list">
                   <li>
                     The nature of your complaint and an exact description of
@@ -435,7 +444,8 @@ class TermsPage extends React.Component<*, void> {
                   rel="noopener noreferrer"
                 >
                   http://web.mit.edu/stopit/
-                </a>. Any rights not expressly granted herein are reserved.
+                </a>
+                . Any rights not expressly granted herein are reserved.
               </div>
               <h3 className="terms-subheading">Prohibited Content</h3>
               <div className="terms-div">

--- a/static/js/containers/VideoDetailPage.js
+++ b/static/js/containers/VideoDetailPage.js
@@ -27,7 +27,12 @@ import DropboxChooser from "react-dropbox-chooser"
 import { actions } from "../actions"
 import { setDrawerOpen } from "../actions/commonUi"
 import { makeCollectionUrl } from "../lib/urls"
-import { saveToDropbox, videoIsProcessing, videoHasError, videoIsInFlight } from "../lib/video"
+import {
+  saveToDropbox,
+  videoIsProcessing,
+  videoHasError,
+  videoIsInFlight
+} from "../lib/video"
 import { replaceVideoFromDropbox } from "../lib/api"
 import { DIALOGS, MM_DD_YYYY } from "../constants"
 import { initGA, sendGAPageView } from "../util/google_analytics"
@@ -70,7 +75,13 @@ export class VideoDetailPage extends React.Component<*, void> {
   }
 
   updateRequirements = () => {
-    const { dispatch, videoKey, needsUpdate, video, collectionNeedsUpdate } = this.props
+    const {
+      dispatch,
+      videoKey,
+      needsUpdate,
+      video,
+      collectionNeedsUpdate
+    } = this.props
 
     if (needsUpdate) {
       dispatch(actions.videos.get(videoKey))
@@ -147,8 +158,9 @@ export class VideoDetailPage extends React.Component<*, void> {
         actions.toast.addMessage({
           message: {
             key:     "replace-video-started",
-            content: "Video replacement has started. You will receive an email when it is ready.",
-            icon:    "check"
+            content:
+              "Video replacement has started. You will receive an email when it is ready.",
+            icon: "check"
           }
         })
       )
@@ -229,7 +241,10 @@ export class VideoDetailPage extends React.Component<*, void> {
                         {!videoIsInFlight(video) && (
                           <Button
                             className="replace mdc-button--raised"
-                            onClick={() => this.replaceDropboxTriggerRef && this.replaceDropboxTriggerRef.click()}
+                            onClick={() =>
+                              this.replaceDropboxTriggerRef &&
+                              this.replaceDropboxTriggerRef.click()
+                            }
                           >
                             Replace
                           </Button>
@@ -250,14 +265,20 @@ export class VideoDetailPage extends React.Component<*, void> {
                           <div style={{ display: "none" }}>
                             <DropboxChooser
                               appKey={SETTINGS.dropbox_key}
-                              success={files => this.handleReplaceVideo(files[0])}
+                              success={files =>
+                                this.handleReplaceVideo(files[0])
+                              }
                               linkType="preview"
                               multiselect={false}
                               extensions={["video"]}
                             >
-                              <button ref={el => {
-                                this.replaceDropboxTriggerRef = el
-                              }}>replace</button>
+                              <button
+                                ref={el => {
+                                  this.replaceDropboxTriggerRef = el
+                                }}
+                              >
+                                replace
+                              </button>
                             </DropboxChooser>
                           </div>
                         )}
@@ -404,12 +425,15 @@ const mapStateToProps = (state, ownProps) => {
   const needsUpdate = !videos.processing && !videos.loaded
 
   // Get the collection if video exists
-  const collection = video && collections.data && collections.data.key === video.collection_key ?
-    collections.data :
-    null
+  const collection =
+    video && collections.data && collections.data.key === video.collection_key ?
+      collections.data :
+      null
 
   // Only fetch collection if not processing, not loaded, and we don't have it
-  const collectionNeedsUpdate = video && video.collection_key &&
+  const collectionNeedsUpdate =
+    video &&
+    video.collection_key &&
     !collections.processing &&
     !collections.loaded &&
     !collection

--- a/static/js/data/faqs.js
+++ b/static/js/data/faqs.js
@@ -131,7 +131,8 @@ export const sectionFAQs = {
             rel="noopener noreferrer"
           >
             https://ist.mit.edu/email-lists
-          </a>.
+          </a>
+          .
         </div>
       </div>
     ),
@@ -188,7 +189,8 @@ export const sectionFAQs = {
             rel="noopener noreferrer"
           >
             https://w3c.github.io/webvtt/
-          </a>.
+          </a>
+          .
         </div>
         <div>
           Once uploaded, you should see the captions when you play your video
@@ -206,10 +208,12 @@ export const sectionFAQs = {
           rel="noopener noreferrer"
         >
           PlayMedia
-        </a>,{" "}
+        </a>
+        ,{" "}
         <a href="http://www.rev.com" target="_blank" rel="noopener noreferrer">
           Rev
-        </a>, or you can try some free services:{" "}
+        </a>
+        , or you can try some free services:{" "}
         <a
           href="http://www.amara.org"
           target="_blank"
@@ -224,8 +228,9 @@ export const sectionFAQs = {
           rel="noopener noreferrer"
         >
           DotSub.com
-        </a>. Make sure you request a WebVTT file, which you can then upload on
-        your video page.
+        </a>
+        . Make sure you request a WebVTT file, which you can then upload on your
+        video page.
       </div>
     ),
     "I have a question that isn't on the FAQ": (

--- a/static/js/factories/video.js
+++ b/static/js/factories/video.js
@@ -48,7 +48,10 @@ export const makeVideoThumbnail = (
   created_at:     casual.moment.format(),
   s3_object_key:  makeObjectKey(videoKey, encoding),
   bucket_name:    casual.text,
-  cloudfront_url: `https://fake.cloudfront.fake/${makeObjectKey(videoKey, encoding)}`
+  cloudfront_url: `https://fake.cloudfront.fake/${makeObjectKey(
+    videoKey,
+    encoding
+  )}`
 })
 
 export const makeVideoSubtitle = (

--- a/static/js/global_init.js
+++ b/static/js/global_init.js
@@ -1,5 +1,5 @@
 // Define globals we would usually get from Django
-import ReactDOM from "react-dom"
+import { cleanup } from "@testing-library/react"
 import { makeVideo } from "./factories/video"
 
 // For setting up enzyme with react adapter.
@@ -45,10 +45,15 @@ if (!Object.entries) {
 // cleanup after each test run
 // eslint-disable-next-line mocha/no-top-level-hooks
 afterEach(function() {
-  const node = document.querySelector("#integration_test_div")
-  if (node) {
-    ReactDOM.unmountComponentAtNode(node)
-  }
+  // Unmount React trees before detaching the DOM. RTL's auto-cleanup would
+  // still unmount without this -- it holds a direct reference to its own
+  // container, so the innerHTML reset below does not prevent it -- but that
+  // ordering means componentWillUnmount runs against an already-detached
+  // node. Dialog/Drawer/Menu call MDC .destroy() there and VideoPlayer
+  // disposes its video.js player, so they should see an attached DOM.
+  // Calling cleanup() explicitly also removes any dependence on mocha's
+  // hook registration order. It is a no-op when RTL rendered nothing.
+  cleanup()
   document.body.innerHTML = ""
   global.SETTINGS = _createSettings()
   window.location = "http://fake/"

--- a/static/js/lib/api.js
+++ b/static/js/lib/api.js
@@ -51,7 +51,11 @@ export function getVideo(videoKey: string) {
 }
 
 export function getPotentialCollectionOwners(collectionKey: string) {
-  return fetchJSONWithCSRF(`/api/v0/potential_collection_owners/?collection_key=${encodeURI(collectionKey)}`)
+  return fetchJSONWithCSRF(
+    `/api/v0/potential_collection_owners/?collection_key=${encodeURI(
+      collectionKey
+    )}`
+  )
 }
 
 export function updateVideo(videoKey: string, payload: VideoUpdatePayload) {

--- a/static/js/lib/api_test.js
+++ b/static/js/lib/api_test.js
@@ -146,7 +146,11 @@ describe("api", () => {
     const fetchFormStub = sandbox.stub(fetchFuncs, "fetchWithCSRF")
     const video = makeVideo()
     const formData = new FormData()
-    formData.append("thumbnail", new Blob(["fake-image"], { type: "image/jpeg" }), "thumb.jpg")
+    formData.append(
+      "thumbnail",
+      new Blob(["fake-image"], { type: "image/jpeg" }),
+      "thumb.jpg"
+    )
     fetchFormStub.returns(Promise.resolve("{}"))
 
     await uploadThumbnail(video.key, formData)

--- a/static/js/lib/redux_rest.js
+++ b/static/js/lib/redux_rest.js
@@ -10,7 +10,6 @@ import { videoAnalyticsEndpoint } from "../reducers/videoAnalytics"
 import { syncCollectionEdXEndpoint } from "../reducers/syncCollectionEdX"
 import { potentialCollectionOwnersEndpoint } from "../reducers/potentialCollectionOwners"
 
-
 export const endpoints = [
   collectionsListEndpoint,
   collectionsEndpoint,

--- a/static/js/lib/urls.js
+++ b/static/js/lib/urls.js
@@ -12,9 +12,7 @@ export const makeCollectionUrl = (collectionKey: string) =>
   `/collections/${encodeURI(collectionKey)}/`
 export const makeVideoThumbnailUrl = (video: Video): ?string =>
   video.videothumbnail_set && video.videothumbnail_set.length > 0 ?
-    `${SETTINGS.cloudfront_base_url}${
-      video.videothumbnail_set[0].s3_object_key
-    }` :
+    `${SETTINGS.cloudfront_base_url}${video.videothumbnail_set[0].s3_object_key}` :
     null
 
 export const makeVideoFileUrl = (videoFile: VideoFile): ?string =>

--- a/static/js/lib/validation.js
+++ b/static/js/lib/validation.js
@@ -25,7 +25,11 @@ export const validation = R.curry(
 // wrapped in a Just will do.
 export const validate = R.curry((validations, toValidate) =>
   R.converge(
-    R.compose(R.reduce((acc, setter) => setter(acc), {}), S.justs, Array),
+    R.compose(
+      R.reduce((acc, setter) => setter(acc), {}),
+      S.justs,
+      Array
+    ),
     validations
   )(toValidate)
 )

--- a/static/js/reducers/collections.js
+++ b/static/js/reducers/collections.js
@@ -4,7 +4,10 @@ import * as R from "ramda"
 
 import * as api from "../lib/api"
 import type { Collection, CollectionList } from "../flow/collectionTypes"
-import { CLEAR_COLLECTION_ERRORS, CLEAR_COLLECTION_DATA } from "../actions/collectionUi"
+import {
+  CLEAR_COLLECTION_ERRORS,
+  CLEAR_COLLECTION_DATA
+} from "../actions/collectionUi"
 
 export const collectionsListEndpoint = {
   name:               "collectionsList",

--- a/static/js/reducers/potentialCollectionOwners.js
+++ b/static/js/reducers/potentialCollectionOwners.js
@@ -6,8 +6,9 @@ import * as api from "../lib/api"
 import type { User } from "../flow/userTypes"
 
 export const potentialCollectionOwnersEndpoint = {
-  name:              "potentialCollectionOwners",
-  verbs:             [GET],
-  initialState:      { ...INITIAL_STATE, data: [] },
-  getFunc:           (collectionKey: string): Promise<{users: Array<User>}> => api.getPotentialCollectionOwners(collectionKey),
+  name:         "potentialCollectionOwners",
+  verbs:        [GET],
+  initialState: { ...INITIAL_STATE, data: [] },
+  getFunc:      (collectionKey: string): Promise<{ users: Array<User> }> =>
+    api.getPotentialCollectionOwners(collectionKey)
 }

--- a/static/js/reducers/potentialCollectionOwners_test.js
+++ b/static/js/reducers/potentialCollectionOwners_test.js
@@ -34,7 +34,11 @@ describe("Users reducer", () => {
     ]
 
     await listenForActions(expectedActions, () => {
-      return store.dispatch(actions.potentialCollectionOwners.get('b0b7fcb6fd644b5hy6de7b1ce3f2bb7be'))
+      return store.dispatch(
+        actions.potentialCollectionOwners.get(
+          "b0b7fcb6fd644b5hy6de7b1ce3f2bb7be"
+        )
+      )
     })
 
     assert.isTrue(getStub.calledOnce)
@@ -60,9 +64,15 @@ describe("Users reducer", () => {
 
     // The dispatch itself should throw an error, not the listenForActions
     await listenForActions(expectedActions, () => {
-      return store.dispatch(actions.potentialCollectionOwners.get('b0b7fcb6fd644b5hy6de7b1ce3f2bb7be')).catch(() => {
-        return Promise.resolve()
-      })
+      return store
+        .dispatch(
+          actions.potentialCollectionOwners.get(
+            "b0b7fcb6fd644b5hy6de7b1ce3f2bb7be"
+          )
+        )
+        .catch(() => {
+          return Promise.resolve()
+        })
     })
 
     // Verify error state instead of trying to catch the error

--- a/static/js/store/configureStore.js
+++ b/static/js/store/configureStore.js
@@ -1,13 +1,18 @@
 // eslint-disable-next-line no-redeclare
 /* global require:false, module:false */
-import { compose, legacy_createStore as createStore, applyMiddleware } from "redux"
-import { thunk } from "redux-thunk"  // Updated import
+import {
+  compose,
+  legacy_createStore as createStore,
+  applyMiddleware
+} from "redux"
+import { thunk } from "redux-thunk" // Updated import
 import { createLogger } from "redux-logger"
 
 import rootReducer from "../reducers"
 
 const composeEnhancers =
-  (typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) ||
+  (typeof window !== "undefined" &&
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) ||
   compose
 
 let createStoreWithMiddleware
@@ -16,9 +21,7 @@ if (process.env.NODE_ENV !== "production") {
     applyMiddleware(thunk, createLogger())
   )(createStore)
 } else {
-  createStoreWithMiddleware = compose(
-    applyMiddleware(thunk)
-  )(createStore)
+  createStoreWithMiddleware = compose(applyMiddleware(thunk))(createStore)
 }
 
 // @flow

--- a/static/js/testUtils/harness_test.js
+++ b/static/js/testUtils/harness_test.js
@@ -1,0 +1,88 @@
+import React from "react"
+import { assert } from "chai"
+import { render, screen, fireEvent, cleanup } from "@testing-library/react"
+
+class Greeter extends React.Component {
+  render() {
+    return <h1>Hello {this.props.name}</h1>
+  }
+}
+
+class Counter extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { n: 0 }
+  }
+
+  render() {
+    return (
+      <div>
+        <span data-testid="n">{String(this.state.n)}</span>
+        <button onClick={() => this.setState({ n: this.state.n + 1 })}>
+          inc
+        </button>
+      </div>
+    )
+  }
+}
+
+class AsyncLoader extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { value: null }
+  }
+
+  componentDidMount() {
+    Promise.resolve("loaded").then(value => this.setState({ value }))
+  }
+
+  render() {
+    return <div>{this.state.value || "loading"}</div>
+  }
+}
+
+describe("RTL harness", () => {
+  it("renders a React 15 class component and queries it by role", () => {
+    render(<Greeter name="world" />)
+    assert.equal(screen.getByRole("heading").textContent, "Hello world")
+  })
+
+  it("exposes the queries the migration depends on", () => {
+    render(<Greeter name="again" />)
+    assert.isFunction(screen.getByText)
+    assert.isFunction(screen.queryByText)
+    assert.isFunction(screen.findByText)
+    assert.isNotNull(screen.getByText("Hello again"))
+  })
+})
+
+describe("RTL harness on React 15 without act()", () => {
+  it("flushes setState synchronously on fireEvent", () => {
+    render(<Counter />)
+    fireEvent.click(screen.getByRole("button"))
+    assert.equal(screen.getByTestId("n").textContent, "1")
+  })
+
+  it("resolves findBy* after an async setState", async () => {
+    render(<AsyncLoader />)
+    assert.isNotNull(await screen.findByText("loaded"))
+  })
+
+  it("fires componentWillUnmount on cleanup()", () => {
+    let unmounted = 0
+
+    class Recorder extends React.Component {
+      componentWillUnmount() {
+        unmounted += 1
+      }
+
+      render() {
+        return <div>mounted</div>
+      }
+    }
+
+    render(<Recorder />)
+    cleanup()
+    assert.equal(unmounted, 1)
+  })
+})

--- a/static/js/testUtils/renderWithProviders.js
+++ b/static/js/testUtils/renderWithProviders.js
@@ -1,0 +1,26 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import { Provider } from "react-redux"
+
+/**
+ * Render a component tree inside a Redux Provider.
+ *
+ * Replaces the per-file `renderComponent` helpers that the Enzyme tests each
+ * defined locally. Returns RTL's usual result object with `store` added.
+ */
+export default function renderWithProviders(ui, options = {}) {
+  const { store, ...renderOptions } = options
+
+  if (!store) {
+    throw new Error("renderWithProviders requires a `store` option")
+  }
+
+  const Wrapper = ({ children }) => (
+    <Provider store={store}>{children}</Provider>
+  )
+
+  return {
+    store,
+    ...render(ui, { wrapper: Wrapper, ...renderOptions })
+  }
+}

--- a/static/js/testUtils/renderWithProviders_test.js
+++ b/static/js/testUtils/renderWithProviders_test.js
@@ -1,0 +1,56 @@
+import React from "react"
+import { assert } from "chai"
+import { connect } from "react-redux"
+import configureTestStore from "redux-asserts"
+
+import rootReducer from "../reducers"
+import renderWithProviders from "./renderWithProviders"
+
+const ShowsStoreKeys = ({ keyCount }) => <div>keys:{keyCount}</div>
+
+const Connected = connect(state => ({
+  keyCount: Object.keys(state).length
+}))(ShowsStoreKeys)
+
+describe("renderWithProviders", () => {
+  let store
+
+  beforeEach(() => {
+    store = configureTestStore(rootReducer)
+  })
+
+  it("renders a connected component with the store in context", () => {
+    const { getByText } = renderWithProviders(<Connected />, { store })
+    const expected = `keys:${Object.keys(store.getState()).length}`
+    assert.isNotNull(getByText(expected))
+  })
+
+  it("echoes the store back on the result", () => {
+    const result = renderWithProviders(<Connected />, { store })
+    assert.strictEqual(result.store, store)
+  })
+
+  it("returns the standard RTL result object", () => {
+    const result = renderWithProviders(<Connected />, { store })
+    assert.isFunction(result.rerender)
+    assert.isFunction(result.unmount)
+    assert.instanceOf(result.container, window.HTMLElement)
+  })
+
+  it("throws a clear error when no store is given", () => {
+    assert.throws(
+      () => renderWithProviders(<Connected />),
+      "renderWithProviders requires a `store` option"
+    )
+  })
+
+  it("forwards unrecognised options to RTL render", () => {
+    const host = document.createElement("div")
+    document.body.appendChild(host)
+    const { container } = renderWithProviders(<Connected />, {
+      store,
+      container: host
+    })
+    assert.strictEqual(container, host)
+  })
+})

--- a/static/js/testUtils/teardown_test.js
+++ b/static/js/testUtils/teardown_test.js
@@ -1,0 +1,31 @@
+import React from "react"
+import { assert } from "chai"
+import { render } from "@testing-library/react"
+
+let unmountCount = 0
+
+class UnmountRecorder extends React.Component {
+  componentWillUnmount() {
+    unmountCount += 1
+  }
+
+  render() {
+    return <div>mounted</div>
+  }
+}
+
+describe("global teardown", () => {
+  it("mounts a component and lets the afterEach hook run", () => {
+    render(<UnmountRecorder />)
+    assert.equal(unmountCount, 0)
+  })
+
+  it("unmounted the previous test's tree before this test started", () => {
+    assert.equal(
+      unmountCount,
+      1,
+      "componentWillUnmount did not fire -- global_init.js wiped the DOM " +
+        "before RTL could unmount, so cleanup is not running"
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7229,13 +7229,6 @@ raw-body@^3.0.2:
     iconv-lite "~0.7.0"
     unpipe "~1.0.0"
 
-react-addons-shallow-compare@^15.6.0:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz#28a94b0dfee71530852c66a69053d59a1baf04cb"
-  integrity sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==
-  dependencies:
-    object-assign "^4.1.0"
-
 react-document-title@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/react-document-title/-/react-document-title-2.0.3.tgz#bbf922a0d71412fc948245e4283b2412df70f2b9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,21 +38,21 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.27.1"
-    js-tokens "^4.0.0"
-    picocolors "^1.1.1"
-
-"@babel/code-frame@^7.29.7":
-  version "7.29.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
-  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.29.7"
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
@@ -1723,10 +1723,43 @@
     "@sinonjs/commons" "^3.0.1"
     type-detect "^4.1.0"
 
+"@testing-library/dom@8.20.1", "@testing-library/dom@^8.0.0":
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.1.tgz#2e52a32e46fc88369eef7eef634ac2a192decd9f"
+  integrity sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.1.3"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@12.1.5":
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
+
+"@testing-library/user-event@14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
@@ -1765,6 +1798,11 @@
   integrity sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==
   dependencies:
     undici-types "~7.18.0"
+
+"@types/react-dom@<18.0.0":
+  version "17.0.26"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.26.tgz#fa7891ba70fd39ddbaa7e85b6ff9175bb546bc1b"
+  integrity sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==
 
 "@typescript-eslint/experimental-utils@1.13.0":
   version "1.13.0"
@@ -2168,6 +2206,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-styles@^6.1.0:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
@@ -2210,7 +2253,14 @@ argv@0.0.2:
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
   integrity sha512-dEamhpPEwRUBpLNHeuCm/v+g0anFByHahxodVO/BbAarHVBBg2MccCwf9K+o1Pof+2btdnkJelYVUWjW/VrATw==
 
-array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
+aria-query@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
+  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
+  dependencies:
+    deep-equal "^2.0.5"
+
+array-buffer-byte-length@^1.0.0, array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz#384d12a37295aec3769ab022ad323a18a51ccf8b"
   integrity sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==
@@ -3032,6 +3082,16 @@ call-bind@^1.0.2, call-bind@^1.0.7, call-bind@^1.0.8:
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.2"
 
+call-bind@^1.0.5, call-bind@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
+  integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    get-intrinsic "^1.3.0"
+    set-function-length "^1.2.2"
+
 call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
@@ -3664,6 +3724,30 @@ deep-diff@^0.3.5:
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
   integrity sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug==
 
+deep-equal@^2.0.5:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.3.tgz#af89dafb23a396c7da3e862abc0be27cf51d56e1"
+  integrity sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.5"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.2"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.2"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.1"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.13"
+
 deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
@@ -3735,6 +3819,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-helpers@^3.4.0:
   version "3.4.0"
@@ -4032,6 +4121,21 @@ es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-get-iterator@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
+  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    is-arguments "^1.1.1"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.7"
+    isarray "^2.0.5"
+    stop-iteration-iterator "^1.0.0"
 
 es-iterator-helpers@^1.2.1:
   version "1.2.1"
@@ -4871,7 +4975,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
+get-intrinsic@^1.1.3, get-intrinsic@^1.2.2, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -5401,7 +5505,15 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
+is-arguments@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
+  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
+
+is-array-buffer@^3.0.2, is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
   integrity sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==
@@ -5536,7 +5648,7 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-map@^2.0.3:
+is-map@^2.0.2, is-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
   integrity sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==
@@ -5607,7 +5719,7 @@ is-property@^1.0.0, is-property@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
   integrity sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==
 
-is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.2.1:
+is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.4, is-regex@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
   integrity sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==
@@ -5622,12 +5734,12 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-set@^2.0.3:
+is-set@^2.0.2, is-set@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.3.tgz#8ab209ea424608141372ded6e0cb200ef1d9d01d"
   integrity sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==
 
-is-shared-array-buffer@^1.0.4:
+is-shared-array-buffer@^1.0.2, is-shared-array-buffer@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz#9b67844bd9b7f246ba0708c3a93e34269c774f6f"
   integrity sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==
@@ -6173,6 +6285,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
 m3u8-parser@^7.2.0:
   version "7.2.0"
@@ -7081,6 +7198,15 @@ pretty-format@^23.0.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -7284,7 +7410,7 @@ react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.2:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -7550,7 +7676,7 @@ regenerator-transform@^0.10.0:
     babel-types "^6.19.0"
     private "^0.1.6"
 
-regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
+regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
   integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
@@ -8096,7 +8222,7 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.1.0, side-channel@^1.1.1:
+side-channel@^1.0.4, side-channel@^1.1.0, side-channel@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
   integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
@@ -8187,7 +8313,7 @@ statuses@^2.0.1, statuses@^2.0.2, statuses@~2.0.2:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
-stop-iteration-iterator@^1.1.0:
+stop-iteration-iterator@^1.0.0, stop-iteration-iterator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
   integrity sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==
@@ -9130,7 +9256,7 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
-which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
+which-boxed-primitive@^1.0.2, which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz#d76ec27df7fa165f18d5808374a5fe23c29b176e"
   integrity sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==
@@ -9160,7 +9286,7 @@ which-builtin-type@^1.2.1:
     which-collection "^1.0.2"
     which-typed-array "^1.1.16"
 
-which-collection@^1.0.2:
+which-collection@^1.0.1, which-collection@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.2.tgz#627ef76243920a107e7ce8e96191debe4b16c2a0"
   integrity sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==
@@ -9174,6 +9300,19 @@ which-module@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
   integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
+
+which-typed-array@^1.1.13:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
+  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    for-each "^0.3.5"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
 
 which-typed-array@^1.1.16, which-typed-array@^1.1.19:
   version "1.1.19"


### PR DESCRIPTION
## Related issues

- Implements **mitodl/hq#12636** — *OVS React 18: Phase E0+R0 — RTL harness and React upgrade prep*
- Part of epic **mitodl/hq#7958** — *React 18 upgrade* (sub-issue 1 of 8)

> Closing keywords don't work across repositories, so mitodl/hq#12636 needs to be closed manually
> when this merges.

---

## What

Phase E0 + R0 of the React 15 → 18 / Enzyme → RTL migration. Stands up React Testing Library
alongside Enzyme with a shared render helper and correct teardown, converts one pilot test file,
and clears the React-upgrade prerequisites that don't depend on Enzyme.

**React stays on `^15.6.1` and Enzyme stays installed.** Nothing here upgrades React.

## Why this ordering

RTL 12 and Enzyme coexist in one mocha process, so the migration can proceed file-by-file with the
suite green throughout. This was verified directly rather than assumed: RTL 12.1.5 renders, fires
events, resolves async queries, and unmounts correctly on `react@15.6.1` — despite `act` being
`undefined` on `react-dom@15`. RTL degrades gracefully instead of throwing.

That matters because it means **no unofficial Enzyme bridge adapter is needed at any point.**
Enzyme is removed while still on React 15, then React moves in later phases.

## Changes

| Commit | Change |
|---|---|
| `bcfad9a` | Remove unused `react-addons-shallow-compare` (zero imports; doesn't exist for React 16+) |
| `bf8e775` | Add `--exit` to the mocha runner (default/coverage/codecov; watch excluded) |
| `c023294` | `componentWillReceiveProps` → `componentDidUpdate` in `Dialog`/`Drawer`/`Menu` |
| `cbcdf77` | Add RTL 12.1.5 / dom 8.20.1 / user-event 14.6.1, pinned exact, + harness test |
| `e80dfb6` | Repo-wide `prettier-eslint` reformat (isolated, no behaviour change) |
| `86b1e29` | Call RTL `cleanup()` in global teardown; drop dead `#integration_test_div` branch |
| `7fd9380` | Add shared `renderWithProviders` RTL helper |
| `f8284e6` | Convert `ErrorPage_test.js` from Enzyme to RTL (pilot / reference pattern) |

New files under `static/js/testUtils/`: `renderWithProviders.js` plus `harness_test.js`,
`teardown_test.js`, `renderWithProviders_test.js`.

## Verification

- **Suite: 480 → 492 passing**, run twice with identical counts
- `npm run lint` clean; `npm run fmt:check` clean
- `NODE_ENV=production npm run build` compiles (7 pre-existing Sass warnings from `@material` 0.33)
- Enzyme test files: **32 → 31**
- No new entries in the `js_test.sh` stderr allowlist (still 7)

**The pilot conversion was mutation-checked by hand.** Two bugs were injected into `ErrorPage.js`
(corrupted title text, renamed `.message` class) and each killed all 3 tests — confirming the
converted test detects breakage rather than merely passing.

**The three lifecycle conversions were verified in a browser**, since no test covers them (they're
reached only via `.instance()`, the API being removed). Each of the drawer, Edit Collection dialog,
and per-video `more_vert` menu was opened, closed, **and reopened** — the reopen being the case
that matters, as `componentDidUpdate` doesn't fire on mount and the prop comparison inverted. All
passed, with zero console errors across a full cycle.

## Reviewer notes

- **`e80dfb6` is the noisy one.** The repo had drifted from its own formatter (last repo-wide
  format was #398; `fmt:check` isn't a CI gate), so `npm run fmt` rewrote 36 unrelated files.
  Landed as its own commit so the other seven stay reviewable. Of the 36, 25 differ only in
  whitespace; the other 11 were hand-checked as prettier normalizations (quote style, trailing
  commas, import/expression reflow). **Review it with whitespace hidden.**
- `@testing-library/react` is pinned to exactly `12.1.5` with no caret — v13+ requires React 18.
  Please don't let a caret in until React reaches 18.

## Out of scope / follow-ups

Two pre-existing environment bugs surfaced while running this. Neither is caused by these changes
and neither is fixed here:

1. **`Dockerfile-node` ships node 24.17.0 while `package.json` pins 24.16.0.** Yarn 1 hard-fails on
   the mismatch, so the `watch` container crash-loops and every bundle 404s — `docker-compose up`
   currently yields a blank app. Workaround is `YARN_IGNORE_ENGINES=1` in a local `.env`.
2. `docker-compose.yml` still carries the obsolete `version:` attribute, warned on every command.

Also noted for a future ticket: `global_init.js` appends a `<script>` tag at module load "to appease
videojs-youtube", but the `afterEach` wipes `document.body.innerHTML` — so it's gone after the first
test. Not addressed here because fixing it changes behaviour for tests this PR doesn't touch.

## Next

| Issue | Phase |
|---|---|
| mitodl/hq#12637 | Stryker mutation baseline + CI ledger |
| mitodl/hq#12638 | Convert Tier 1 + Tier 2 (17 files) |
| mitodl/hq#12639 | VideoPlayer controller extraction |
| mitodl/hq#12640 | Remaining conversions, **remove Enzyme** |
| mitodl/hq#12641 | React 16.14 |
| mitodl/hq#12642 | React 17.0.2 |
| mitodl/hq#12643 | React 18.3.1 |

Recommend landing the mutation-testing baseline (mitodl/hq#12637) before the bulk conversions in
mitodl/hq#12638 — it's the only objective check that converted tests still assert anything.
